### PR TITLE
Disable SSIM on wasm for now

### DIFF
--- a/crates/brush-train/src/train.rs
+++ b/crates/brush-train/src/train.rs
@@ -257,7 +257,8 @@ where
 
             let loss = (pred_compare - batch.gt_images.clone()).abs().mean();
 
-            let loss = if self.config.ssim_weight > 0.0 {
+            // Disabled on WASM for now. On WebGPU + Metal this unfortunately has glitches.
+            let loss = if self.config.ssim_weight > 0.0 && !cfg!(target_family = "wasm") {
                 let gt_rgb =
                     batch
                         .gt_images

--- a/crates/brush-viewer/src/panels/scene.rs
+++ b/crates/brush-viewer/src/panels/scene.rs
@@ -200,12 +200,13 @@ Or load a dataset to train on. These are zip files with:
             #[cfg(target_family = "wasm")]
             ui.scope(|ui| {
                 ui.visuals_mut().override_text_color = Some(Color32::YELLOW);
-                ui.heading("Note: Running in browser is experimental");
+                ui.heading("Note: Running in browser is still experimental");
 
                 ui.label(
                     r#"
-In browser training is about 2x lower than the native app. For bigger training
-runs consider using the native app."#,
+In browser training is slower, and lower quality than the native app.
+
+For bigger training runs consider using the native app."#,
                 );
             });
 


### PR DESCRIPTION
SSIM on wasm causes bad glitches. I suspect it's related to https://github.com/tracel-ai/burn/pull/2435, but hard to say.

Adding a custom kernel in https://github.com/ArthurBrussee/brush/issues/15 might also solve this.