### PR TITLE
Put egui in charge of wgpu device again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -715,6 +715,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "brush-train",
+ "brush-ui",
  "brush-viewer",
  "console_error_panic_hook",
  "eframe",
@@ -840,6 +841,7 @@ dependencies = [
  "brush-render",
  "burn",
  "burn-fusion",
+ "burn-wgpu",
  "eframe",
  "egui",
  "glam",
@@ -7672,6 +7674,7 @@ dependencies = [
  "brush-train",
  "brush-ui",
  "burn",
+ "burn-wgpu",
  "eframe",
  "egui",
  "env_logger",
@@ -7679,6 +7682,7 @@ dependencies = [
  "image",
  "rand",
  "tokio",
+ "wgpu",
 ]
 
 [[package]]

--- a/crates/brush-desktop/Cargo.toml
+++ b/crates/brush-desktop/Cargo.toml
@@ -16,6 +16,7 @@ egui.workspace = true
 eframe.workspace = true
 brush-viewer.path = "../brush-viewer"
 brush-train.path = "../brush-train"
+brush-ui.path = "../brush-ui"
 log.workspace = true
 env_logger.workspace = true
 parking_lot.workspace = true

--- a/crates/brush-desktop/src/main.rs
+++ b/crates/brush-desktop/src/main.rs
@@ -54,8 +54,6 @@ fn main() {
 
         // On wasm, run as a local task.
         tokio::spawn(async {
-            let setup = create_wgpu_device().await;
-
             let web_options = eframe::WebOptions {
                 wgpu_options,
                 ..Default::default()

--- a/crates/brush-desktop/src/main.rs
+++ b/crates/brush-desktop/src/main.rs
@@ -1,11 +1,10 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
-use brush_train::create_wgpu_setup;
-
-use eframe::egui_wgpu::{WgpuConfiguration, WgpuSetup};
 use tokio_with_wasm::alias as tokio;
 
 fn main() {
+    let wgpu_options = brush_ui::create_egui_options();
+
     #[cfg(not(target_family = "wasm"))]
     {
         let runtime = tokio::runtime::Builder::new_multi_thread()
@@ -14,18 +13,6 @@ fn main() {
             .unwrap();
 
         runtime.block_on(async {
-            let setup = create_wgpu_setup().await;
-
-            let wgpu_options = WgpuConfiguration {
-                wgpu_setup: WgpuSetup::Existing {
-                    instance: setup.instance,
-                    adapter: setup.adapter,
-                    device: setup.device,
-                    queue: setup.queue,
-                },
-                ..Default::default()
-            };
-
             env_logger::init();
 
             // NB: Load carrying icon. egui at head fails when no icon is included
@@ -40,8 +27,6 @@ fn main() {
                     .with_inner_size(egui::Vec2::new(1450.0, 900.0))
                     .with_active(true)
                     .with_icon(std::sync::Arc::new(icon)),
-
-                // Need a slightly more careful wgpu init to support burn.
                 wgpu_options,
                 ..Default::default()
             };
@@ -69,18 +54,10 @@ fn main() {
 
         // On wasm, run as a local task.
         tokio::spawn(async {
-            let setup = create_wgpu_setup().await;
+            let setup = create_wgpu_device().await;
 
             let web_options = eframe::WebOptions {
-                wgpu_options: WgpuConfiguration {
-                    wgpu_setup: WgpuSetup::Existing {
-                        instance: setup.instance,
-                        adapter: setup.adapter,
-                        device: setup.device,
-                        queue: setup.queue,
-                    },
-                    ..Default::default()
-                },
+                wgpu_options,
                 ..Default::default()
             };
 

--- a/crates/brush-render/benches/render_bench.rs
+++ b/crates/brush-render/benches/render_bench.rs
@@ -33,6 +33,7 @@ fn generate_bench_data() -> anyhow::Result<()> {
     let num_points = 2usize.pow(21); //  Maxmimum number of splats to bench.
 
     let device = WgpuDevice::DefaultDevice;
+
     let means = Tensor::<DiffBack, 2>::random(
         [num_points, 3],
         burn::tensor::Distribution::Uniform(-0.5, 0.5),
@@ -178,7 +179,7 @@ fn bench_general(
                 let _ = out.0.mean().backward();
             }
             // Wait for GPU work.
-            <Wgpu as burn::prelude::Backend>::sync(&WgpuDevice::DefaultDevice);
+            <Wgpu as burn::prelude::Backend>::sync(&device);
         });
     } else {
         // Run with no autodiff graph.
@@ -189,7 +190,7 @@ fn bench_general(
                 let _ = splats.render(&camera, resolution, true);
             }
             // Wait for GPU work.
-            <Wgpu as burn::prelude::Backend>::sync(&WgpuDevice::DefaultDevice);
+            <Wgpu as burn::prelude::Backend>::sync(&device);
         });
     }
 }

--- a/crates/brush-render/src/render.rs
+++ b/crates/brush-render/src/render.rs
@@ -680,7 +680,6 @@ mod tests {
     //     let num_points = 1;
 
     //     let img_size = glam::uvec2(16, 16);
-    //     let device = WgpuDevice::BestAvailable;
 
     //     let means = Tensor::<DiffBack, 2, _>::zeros([num_points, 3], &device).require_grad();
     //     let log_scales = Tensor::ones([num_points, 3], &device).require_grad();

--- a/crates/brush-train/src/lib.rs
+++ b/crates/brush-train/src/lib.rs
@@ -1,19 +1,6 @@
-use burn_wgpu::{AutoGraphicsApi, RuntimeOptions};
-
 pub mod eval;
 pub mod ssim;
 pub mod train;
 
 pub mod image;
 pub mod scene;
-
-pub async fn create_wgpu_setup() -> burn_wgpu::WgpuSetup {
-    burn_wgpu::init_setup_async::<AutoGraphicsApi>(
-        &burn_wgpu::WgpuDevice::DefaultDevice,
-        RuntimeOptions {
-            tasks_max: 64,
-            memory_config: burn_wgpu::MemoryConfiguration::ExclusivePages,
-        },
-    )
-    .await
-}

--- a/crates/brush-ui/Cargo.toml
+++ b/crates/brush-ui/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 
 [dependencies]
 burn.workspace = true
+burn-wgpu.workspace = true
 burn-fusion.workspace = true
 brush-render.path = "../brush-render"
 glam.workspace = true

--- a/crates/brush-ui/src/lib.rs
+++ b/crates/brush-ui/src/lib.rs
@@ -1,4 +1,47 @@
+use std::sync::Arc;
+
+use burn_wgpu::{RuntimeOptions, WgpuDevice};
+use eframe::egui_wgpu::WgpuConfiguration;
+use wgpu::{Adapter, Device, Queue};
+
 pub mod burn_texture;
+
+pub fn create_wgpu_device(
+    adapter: Arc<Adapter>,
+    device: Arc<Device>,
+    queue: Arc<Queue>,
+) -> WgpuDevice {
+    let setup = burn_wgpu::WgpuSetup {
+        instance: Arc::new(wgpu::Instance::new(wgpu::InstanceDescriptor::default())), // unused... need to fix this in Burn.
+        adapter: adapter.clone(),
+        device: device.clone(),
+        queue: queue.clone(),
+    };
+
+    burn_wgpu::init_device(
+        setup,
+        RuntimeOptions {
+            tasks_max: 64,
+            memory_config: burn_wgpu::MemoryConfiguration::ExclusivePages,
+        },
+    )
+}
+
+pub fn create_egui_options() -> WgpuConfiguration {
+    WgpuConfiguration {
+        wgpu_setup: eframe::egui_wgpu::WgpuSetup::CreateNew {
+            supported_backends: wgpu::Backends::all(),
+            power_preference: wgpu::PowerPreference::HighPerformance,
+            device_descriptor: Arc::new(|adapter: &Adapter| wgpu::DeviceDescriptor {
+                label: Some("egui+burn"),
+                required_features: adapter.features(),
+                required_limits: adapter.limits(),
+                memory_hints: wgpu::MemoryHints::Performance,
+            }),
+        },
+        ..Default::default()
+    }
+}
 
 pub fn draw_checkerboard(ui: &mut egui::Ui, rect: egui::Rect) {
     let id = egui::Id::new("checkerboard");

--- a/crates/brush-viewer/src/viewer.rs
+++ b/crates/brush-viewer/src/viewer.rs
@@ -297,10 +297,13 @@ impl ViewerContext {
 
 impl Viewer {
     pub fn new(cc: &eframe::CreationContext) -> Self {
-        let state = cc.wgpu_render_state.as_ref().unwrap();
-
         // For now just assume we're running on the default
-        let device = WgpuDevice::DefaultDevice;
+        let state = cc.wgpu_render_state.as_ref().unwrap();
+        let device = brush_ui::create_wgpu_device(
+            state.adapter.clone(),
+            state.device.clone(),
+            state.queue.clone(),
+        );
 
         cfg_if::cfg_if! {
             if #[cfg(target_family = "wasm")] {

--- a/crates/train-2d/Cargo.toml
+++ b/crates/train-2d/Cargo.toml
@@ -7,11 +7,13 @@ license.workspace = true
 
 [dependencies]
 burn.workspace = true
+burn-wgpu.workspace = true
+wgpu.workspace = true
 brush-train.path = "../brush-train"
 brush-render.path = "../brush-render"
 brush-ui.path = "../brush-ui"
 
-tokio.workspace = true
+tokio = { workspace = true, features = ["sync", "rt-multi-thread", "macros"] }
 env_logger.workspace = true
 async-fn-stream.workspace = true
 rand.workspace = true


### PR DESCRIPTION
When creating a wgpu adapter, you need to specify what surfaces are supported, or otherwise the graphics API might create an adapter which can't render to a surface. Only egui has access to the surface so sadly we need to put it in charge again of device creation. This means env vars like `CUBECL_WGPU_DEFAULT_DEVICE` no longer work. WGPU_ADAPTER_NAME can do the same job though,

This might fix errors like https://github.com/ArthurBrussee/brush/issues/33, and similair issues on Android.