### PR TITLE
Fix rerun.io URL here as well

### DIFF
--- a/crates/brush-viewer/src/panels/rerun.rs
+++ b/crates/brush-viewer/src/panels/rerun.rs
@@ -435,7 +435,7 @@ impl ViewerPanel for RerunPanel {
             ui.horizontal(|ui| {
                 ui.spacing_mut().item_spacing.x = 0.0;
                 ui.label("Stream data to ");
-                ui.hyperlink_to("Rerun.io", "rerun.io");
+                ui.hyperlink_to("Rerun.io", "https://rerun.io");
                 ui.label(" for visualization");
             });
 


### PR DESCRIPTION
The link in the in-app panel was broken (missing https://)