### PR TITLE
Import for supersplat compressed ply's

### DIFF
--- a/crates/brush-dataset/src/formats/colmap.rs
+++ b/crates/brush-dataset/src/formats/colmap.rs
@@ -229,11 +229,12 @@ pub(crate) async fn load_dataset<B: Backend>(
                 let mut colors: Vec<f32> = points_data
                     .values()
                     .flat_map(|p| {
-                        [
-                            rgb_to_sh(p.rgb[0] as f32 / 255.0),
-                            rgb_to_sh(p.rgb[1] as f32 / 255.0),
-                            rgb_to_sh(p.rgb[2] as f32 / 255.0),
-                        ]
+                        let sh = rgb_to_sh(glam::vec3(
+                            p.rgb[0] as f32 / 255.0,
+                            p.rgb[1] as f32 / 255.0,
+                            p.rgb[2] as f32 / 255.0,
+                        ));
+                        [sh.x, sh.y, sh.z]
                     })
                     .collect();
 
@@ -248,7 +249,7 @@ pub(crate) async fn load_dataset<B: Backend>(
                     Splats::from_raw(&positions, None, None, Some(&colors), None, &device);
                 emitter
                     .emit(SplatMessage {
-                        meta: crate::splat_import::SplatMetadata {
+                        meta: crate::splat_import::ParseMetadata {
                             up_axis: None,
                             total_splats: init_splat.num_splats(),
                             frame_count: 1,

--- a/crates/brush-dataset/src/lib.rs
+++ b/crates/brush-dataset/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod brush_vfs;
 mod formats;
+mod parsed_gaussian;
+mod quant;
 pub mod scene_loader;
 pub mod splat_export;
 pub mod splat_import;

--- a/crates/brush-dataset/src/parsed_gaussian.rs
+++ b/crates/brush-dataset/src/parsed_gaussian.rs
@@ -1,0 +1,143 @@
+use brush_render::render::channel_to_sh;
+use glam::{Quat, Vec3};
+use ply_rs::ply::{Property, PropertyAccess};
+
+use crate::quant::{decode_quat, decode_vec_8_8_8_8, decode_vec_11_10_11};
+
+/// A gaussian as it parsed in the ply.
+///
+/// Nb that this is somewhat abused and the values are mostly what _directly_ comes out of the ply,
+/// which might need activation/de-activation/dequantization before the values are usable.
+#[derive(Default)]
+pub(crate) struct ParsedGaussian {
+    pub(crate) mean: Vec3,
+    pub(crate) log_scale: Vec3,
+    pub(crate) opacity: f32,
+    pub(crate) rotation: Quat,
+    pub(crate) sh_dc: Vec3,
+    // NB: This is in the inria format, aka [channels, coeffs]
+    // not [coeffs, channels].
+    pub(crate) sh_coeffs_rest: Vec<f32>,
+}
+
+impl PropertyAccess for ParsedGaussian {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn set_property(&mut self, key: &str, property: Property) {
+        let ascii = key.as_bytes();
+
+        match ascii {
+            // Custom parsed values.
+            b"packed_position" => {
+                // Atm not doing anything if this is not a uint (which is invalid).
+                if let Property::UInt(value) = property {
+                    // Parse to (normalized) means.
+                    self.mean = decode_vec_11_10_11(value);
+                }
+            }
+            b"packed_rotation" => {
+                // Atm not doing anything if this is not a uint (which is invalid).
+                if let Property::UInt(value) = property {
+                    // Parse to (normalized) quaternion.
+                    self.rotation = decode_quat(value);
+                }
+            }
+
+            b"packed_scale" => {
+                // Atm not doing anything if this is not a uint (which is invalid).
+                if let Property::UInt(value) = property {
+                    // Parse to (normalized) scale.
+                    self.log_scale = decode_vec_11_10_11(value);
+                }
+            }
+
+            b"packed_color" => {
+                // Atm not doing anything if this is not a uint (which is invalid).
+                if let Property::UInt(value) = property {
+                    // Parse to (normalized) color.
+                    let vec = decode_vec_8_8_8_8(value);
+                    self.sh_dc = glam::vec3(vec.x, vec.y, vec.z);
+                    self.opacity = vec.w;
+                }
+            }
+
+            _ => {
+                let value = match property {
+                    Property::Float(value) => value,
+                    Property::UChar(value) => (value as f32) / (u8::MAX as f32 - 1.0),
+                    Property::UShort(value) => (value as f32) / (u16::MAX as f32 - 1.0),
+                    _ => return,
+                };
+
+                if value.is_nan() || value.is_infinite() {
+                    log::warn!("Invalid numbers in imported splat, skipping parse.");
+                    return;
+                }
+
+                // Floating point values.
+                match ascii {
+                    b"x" => self.mean[0] = value,
+                    b"y" => self.mean[1] = value,
+                    b"z" => self.mean[2] = value,
+                    b"scale_0" => self.log_scale[0] = value,
+                    b"scale_1" => self.log_scale[1] = value,
+                    b"scale_2" => self.log_scale[2] = value,
+                    b"opacity" => self.opacity = value,
+
+                    // Rotations are saved in scalar from.
+                    b"rot_0" => self.rotation.w = value,
+                    b"rot_1" => self.rotation.x = value,
+                    b"rot_2" => self.rotation.y = value,
+                    b"rot_3" => self.rotation.z = value,
+
+                    b"f_dc_0" => self.sh_dc[0] = value,
+                    b"f_dc_1" => self.sh_dc[1] = value,
+                    b"f_dc_2" => self.sh_dc[2] = value,
+                    b"red" => self.sh_dc[0] = channel_to_sh(value),
+                    b"green" => self.sh_dc[1] = channel_to_sh(value),
+                    b"blue" => self.sh_dc[2] = channel_to_sh(value),
+                    _ if ascii.starts_with(b"f_rest_") => {
+                        if let Ok(idx) = key["f_rest_".len()..].parse::<u32>() {
+                            if idx >= self.sh_coeffs_rest.len() as u32 {
+                                self.sh_coeffs_rest.resize(idx as usize + 1, 0.0);
+                            }
+                            self.sh_coeffs_rest[idx as usize] = value;
+                        }
+                    }
+                    _ => (),
+                }
+            }
+        }
+    }
+
+    fn get_float(&self, key: &str) -> Option<f32> {
+        let ascii = key.as_bytes();
+
+        match ascii {
+            b"x" => Some(self.mean[0]),
+            b"y" => Some(self.mean[1]),
+            b"z" => Some(self.mean[2]),
+            b"scale_0" => Some(self.log_scale[0]),
+            b"scale_1" => Some(self.log_scale[1]),
+            b"scale_2" => Some(self.log_scale[2]),
+            b"opacity" => Some(self.opacity),
+            b"rot_0" => Some(self.rotation.w),
+            b"rot_1" => Some(self.rotation.x),
+            b"rot_2" => Some(self.rotation.y),
+            b"rot_3" => Some(self.rotation.z),
+            b"f_dc_0" => Some(self.sh_dc[0]),
+            b"f_dc_1" => Some(self.sh_dc[1]),
+            b"f_dc_2" => Some(self.sh_dc[2]),
+            _ if key.starts_with("f_rest_") => {
+                if let Ok(idx) = key["f_rest_".len()..].parse::<usize>() {
+                    self.sh_coeffs_rest.get(idx).copied()
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+}

--- a/crates/brush-dataset/src/quant.rs
+++ b/crates/brush-dataset/src/quant.rs
@@ -1,0 +1,69 @@
+use std::f32;
+
+/// Unpacks a value from an n-bit normalized integer representation back to a float in [0, 1]
+fn unpack_unorm(packed: u32, bits: u32) -> f32 {
+    let max_value = (1 << bits) - 1;
+    packed as f32 / max_value as f32
+}
+
+pub(crate) fn decode_vec_11_10_11(value: u32) -> glam::Vec3 {
+    let first = (value >> 21) & 0x7FF; // First 11 bits
+    let second = (value >> 11) & 0x3FF; // Next 10 bits
+    let third = value & 0x7FF; // Last 11 bits
+    glam::vec3(
+        unpack_unorm(first, 11),
+        unpack_unorm(second, 10),
+        unpack_unorm(third, 11),
+    )
+}
+
+pub(crate) fn decode_vec_8_8_8_8(value: u32) -> glam::Vec4 {
+    // Create Vec4 from a u32, each component gets 8 bits
+    // Extract each byte
+    let x = (value >> 24) & 0xFF;
+    let y = (value >> 16) & 0xFF;
+    let z = (value >> 8) & 0xFF;
+    let w = value & 0xFF;
+
+    // Normalize to 0.0-1.0 range
+    glam::vec4(
+        unpack_unorm(x, 8),
+        unpack_unorm(y, 8),
+        unpack_unorm(z, 8),
+        unpack_unorm(w, 8),
+    )
+}
+
+pub(crate) fn decode_quat(value: u32) -> glam::Quat {
+    let largest = ((value >> 30) & 0x3) as usize; // First 2 bits
+
+    let a = (value >> 20) & 0x3FF; // Next 10 bits
+    let b = (value >> 10) & 0x3FF; // Next 10 bits
+    let c = value & 0x3FF; // Last 10 bits
+
+    let norm = 0.5 * f32::consts::SQRT_2;
+
+    let a = (unpack_unorm(a, 10) - 0.5) / norm;
+    let b = (unpack_unorm(b, 10) - 0.5) / norm;
+    let c = (unpack_unorm(c, 10) - 0.5) / norm;
+
+    let vals = [a, b, c];
+
+    let mut quat = [0.0; 4];
+    quat[largest] = (1.0 - glam::vec3(a, b, c).length_squared()).sqrt();
+
+    let mut ind = 0;
+
+    #[allow(clippy::needless_range_loop)]
+    for i in 0..4 {
+        if i != largest {
+            quat[i] = vals[ind];
+            ind += 1;
+        }
+    }
+    let w = quat[0];
+    let x = quat[1];
+    let y = quat[2];
+    let z = quat[3];
+    glam::Quat::from_xyzw(x, y, z, w)
+}

--- a/crates/brush-dataset/src/splat_import.rs
+++ b/crates/brush-dataset/src/splat_import.rs
@@ -1,7 +1,7 @@
-use std::collections::HashSet;
+use std::{collections::HashSet, pin::Pin};
 
 use async_fn_stream::try_fn_stream;
-use brush_render::render::rgb_to_sh;
+use brush_render::{gaussian_splats::inverse_sigmoid, render::rgb_to_sh};
 use burn::{
     prelude::Backend,
     tensor::{Tensor, TensorData},
@@ -9,156 +9,19 @@ use burn::{
 use glam::{Quat, Vec3, Vec4};
 use ply_rs::{
     parser::Parser,
-    ply::{ElementDef, Header, Property, PropertyAccess},
+    ply::{DefaultElement, ElementDef, Encoding, Header, Property, PropertyAccess},
 };
 use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncRead, BufReader};
-use tokio_stream::Stream;
+use tokio_stream::{Stream, StreamExt};
 use tokio_with_wasm::alias as tokio_wasm;
 use tracing::trace_span;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use brush_render::gaussian_splats::Splats;
 
-pub(crate) struct GaussianData {
-    pub(crate) means: Vec3,
-    pub(crate) log_scale: Vec3,
-    pub(crate) opacity: f32,
-    pub(crate) rotation: Quat,
-    pub(crate) sh_dc: [f32; 3],
-    // NB: This is in the inria format, aka [channels, coeffs]
-    // not [coeffs, channels].
-    pub(crate) sh_coeffs_rest: Vec<f32>,
-}
+use crate::parsed_gaussian::ParsedGaussian;
 
-impl PropertyAccess for GaussianData {
-    fn new() -> Self {
-        Self {
-            means: Vec3::ZERO,
-            log_scale: Vec3::ZERO,
-            opacity: 0.0,
-            rotation: Quat::IDENTITY,
-            sh_dc: [0.0, 0.0, 0.0],
-            sh_coeffs_rest: Vec::new(),
-        }
-    }
-
-    fn set_property(&mut self, key: &str, property: Property) {
-        let ascii = key.as_bytes();
-
-        let mut value = if let Property::Float(value) = property {
-            value
-        } else if let Property::UChar(value) = property {
-            (value as f32) / (u8::MAX as f32)
-        } else if let Property::UShort(value) = property {
-            (value as f32) / (u16::MAX as f32)
-        } else {
-            return;
-        };
-
-        if value.is_nan() || value.is_infinite() {
-            log::warn!("Invalid numbers in imported splat, defaulting to 0");
-            value = 0.0;
-        }
-
-        match ascii {
-            b"x" => self.means[0] = value,
-            b"y" => self.means[1] = value,
-            b"z" => self.means[2] = value,
-            b"scale_0" => self.log_scale[0] = value,
-            b"scale_1" => self.log_scale[1] = value,
-            b"scale_2" => self.log_scale[2] = value,
-            b"opacity" => self.opacity = value,
-            b"rot_0" => self.rotation.w = value,
-            b"rot_1" => self.rotation.x = value,
-            b"rot_2" => self.rotation.y = value,
-            b"rot_3" => self.rotation.z = value,
-            b"f_dc_0" => self.sh_dc[0] = value,
-            b"f_dc_1" => self.sh_dc[1] = value,
-            b"f_dc_2" => self.sh_dc[2] = value,
-            b"red" => self.sh_dc[0] = rgb_to_sh(value),
-            b"green" => self.sh_dc[1] = rgb_to_sh(value),
-            b"blue" => self.sh_dc[2] = rgb_to_sh(value),
-            _ if key.starts_with("f_rest_") => {
-                if let Ok(idx) = key["f_rest_".len()..].parse::<u32>() {
-                    if idx >= self.sh_coeffs_rest.len() as u32 {
-                        self.sh_coeffs_rest.resize(idx as usize + 1, 0.0);
-                    }
-                    self.sh_coeffs_rest[idx as usize] = value;
-                }
-            }
-            _ => (),
-        }
-    }
-
-    fn get_float(&self, key: &str) -> Option<f32> {
-        let ascii = key.as_bytes();
-
-        match ascii {
-            b"x" => Some(self.means[0]),
-            b"y" => Some(self.means[1]),
-            b"z" => Some(self.means[2]),
-            b"scale_0" => Some(self.log_scale[0]),
-            b"scale_1" => Some(self.log_scale[1]),
-            b"scale_2" => Some(self.log_scale[2]),
-            b"opacity" => Some(self.opacity),
-            b"rot_0" => Some(self.rotation.w),
-            b"rot_1" => Some(self.rotation.x),
-            b"rot_2" => Some(self.rotation.y),
-            b"rot_3" => Some(self.rotation.z),
-            b"f_dc_0" => Some(self.sh_dc[0]),
-            b"f_dc_1" => Some(self.sh_dc[1]),
-            b"f_dc_2" => Some(self.sh_dc[2]),
-            _ if key.starts_with("f_rest_") => {
-                if let Ok(idx) = key["f_rest_".len()..].parse::<usize>() {
-                    self.sh_coeffs_rest.get(idx).copied()
-                } else {
-                    None
-                }
-            }
-            _ => None,
-        }
-    }
-}
-
-fn interleave_coeffs(sh_dc: [f32; 3], sh_rest: &[f32]) -> Vec<f32> {
-    let channels = 3;
-    let coeffs_per_channel = sh_rest.len() / channels;
-    let mut result = Vec::with_capacity(sh_rest.len() + 3);
-    result.extend(sh_dc);
-
-    for i in 0..coeffs_per_channel {
-        for j in 0..channels {
-            let index = j * coeffs_per_channel + i;
-            result.push(sh_rest[index]);
-        }
-    }
-    result
-}
-
-async fn decode_splat<T: AsyncBufRead + Unpin + 'static>(
-    reader: &mut T,
-    parser: &Parser<GaussianData>,
-    header: &Header,
-    element: &ElementDef,
-) -> tokio::io::Result<GaussianData> {
-    match header.encoding {
-        ply_rs::ply::Encoding::Ascii => {
-            let mut ascii_line = String::new();
-            reader.read_line(&mut ascii_line).await?;
-            let elem = parser.read_ascii_element(&ascii_line, element)?;
-            ascii_line.clear();
-            Ok(elem)
-        }
-        ply_rs::ply::Encoding::BinaryBigEndian => {
-            parser.read_big_endian_element(reader, element).await
-        }
-        ply_rs::ply::Encoding::BinaryLittleEndian => {
-            parser.read_little_endian_element(reader, element).await
-        }
-    }
-}
-
-pub struct SplatMetadata {
+pub struct ParseMetadata {
     pub up_axis: Option<Vec3>,
     pub total_splats: u32,
     pub frame_count: u32,
@@ -166,18 +29,55 @@ pub struct SplatMetadata {
 }
 
 pub struct SplatMessage<B: Backend> {
-    pub meta: SplatMetadata,
+    pub meta: ParseMetadata,
     pub splats: Splats<B>,
 }
 
-#[derive(Debug)]
-struct QuantMeta {
-    mean: Vec3,
-    rotation: Vec4,
-    scale: Vec3,
+enum PlyFormat {
+    Ply,
+    Brush4DCompressed,
+    SuperSplatCompressed,
 }
 
-pub fn load_splat_from_ply<T: AsyncRead + Unpin + 'static, B: Backend>(
+fn interleave_coeffs(sh_dc: Vec3, sh_rest: &[f32], result: &mut Vec<f32>) {
+    let channels = 3;
+    let coeffs_per_channel = sh_rest.len() / channels;
+    result.extend([sh_dc.x, sh_dc.y, sh_dc.z]);
+    for i in 0..coeffs_per_channel {
+        for j in 0..channels {
+            let index = j * coeffs_per_channel + i;
+            result.push(sh_rest[index]);
+        }
+    }
+}
+
+async fn parse_elem<T: AsyncBufRead + Unpin + 'static, E: PropertyAccess>(
+    reader: &mut T,
+    parser: &Parser<E>,
+    encoding: Encoding,
+    element: &ElementDef,
+) -> tokio::io::Result<E> {
+    match encoding {
+        Encoding::Ascii => {
+            let mut ascii_line = String::new();
+            reader.read_line(&mut ascii_line).await?;
+            let elem = parser.read_ascii_element(&ascii_line, element)?;
+            ascii_line.clear();
+            Ok(elem)
+        }
+        Encoding::BinaryBigEndian => parser.read_big_endian_element(reader, element).await,
+        Encoding::BinaryLittleEndian => parser.read_little_endian_element(reader, element).await,
+    }
+}
+
+/// Call this in a loop to yield every once in a while.
+async fn try_yield(i: usize) {
+    if i % 1000 == 0 {
+        tokio_wasm::task::yield_now().await;
+    }
+}
+
+pub fn load_splat_from_ply<T: AsyncRead + Send + Unpin + 'static, B: Backend>(
     reader: T,
     subsample_points: Option<u32>,
     device: B::Device,
@@ -188,10 +88,11 @@ pub fn load_splat_from_ply<T: AsyncRead + Unpin + 'static, B: Backend>(
     let _span = trace_span!("Read splats").entered();
 
     try_fn_stream(|emitter| async move {
-        let gaussian_parser = Parser::<GaussianData>::new();
+        let header = Parser::<DefaultElement>::new()
+            .read_header(&mut reader)
+            .await?;
 
-        let header = gaussian_parser.read_header(&mut reader).await?;
-
+        // Parse some metadata.
         let up_axis = header
             .comments
             .iter()
@@ -203,6 +104,348 @@ pub fn load_splat_from_ply<T: AsyncRead + Unpin + 'static, B: Backend>(
             })
             .next_back();
 
+        // Check whether there is a vertex header that has at least XYZ.
+        let has_vertex = header.elements.iter().any(|el| el.name == "vertex");
+
+        let ply_type = if has_vertex && header.elements.first().is_some_and(|el| el.name == "chunk")
+        {
+            PlyFormat::SuperSplatCompressed
+        } else if has_vertex && header.elements.iter().any(|el| el.name == "delta_vertex_") {
+            PlyFormat::Brush4DCompressed
+        } else if has_vertex {
+            PlyFormat::Ply
+        } else {
+            anyhow::bail!("Couldn't decide format of Ply file. Unknown Ply format.")
+        };
+
+        let mut stream: Pin<Box<dyn Stream<Item = _> + Send>> = match ply_type {
+            PlyFormat::Ply => {
+                Box::pin(parse_ply(reader, subsample_points, device, header, up_axis))
+            }
+            PlyFormat::Brush4DCompressed => Box::pin(parse_delta_ply(
+                reader,
+                subsample_points,
+                device,
+                header,
+                up_axis,
+            )),
+            PlyFormat::SuperSplatCompressed => Box::pin(parse_compressed_ply(
+                reader,
+                subsample_points,
+                device,
+                header,
+                up_axis,
+            )),
+        };
+        while let Some(splat) = stream.next().await {
+            emitter.emit(splat?).await;
+        }
+        Ok(())
+    })
+}
+
+fn parse_ply<T: AsyncBufRead + Send + Unpin + 'static, B: Backend>(
+    mut reader: T,
+    subsample_points: Option<u32>,
+    device: B::Device,
+    header: Header,
+    up_axis: Option<Vec3>,
+) -> impl Stream<Item = Result<SplatMessage<B>>> + 'static {
+    try_fn_stream(|emitter| async move {
+        let vertex = header.elements.first().context("No elements in header")?;
+        if vertex.name != "vertex" {
+            anyhow::bail!("First element must be 'vertex'")
+        }
+
+        let parser = Parser::<ParsedGaussian>::new();
+
+        let properties: HashSet<_> = vertex.properties.iter().map(|x| x.name.clone()).collect();
+        let mut means = Vec::with_capacity(vertex.count);
+        let mut log_scales = properties
+            .contains("scale_0")
+            .then(|| Vec::with_capacity(vertex.count));
+        let mut rotations = properties
+            .contains("rot_0")
+            .then(|| Vec::with_capacity(vertex.count));
+        let mut sh_coeffs = (properties.contains("f_dc_0") || properties.contains("red"))
+            .then(|| Vec::with_capacity(vertex.count * 24));
+        let mut opacity = properties
+            .contains("opacity")
+            .then(|| Vec::with_capacity(vertex.count));
+
+        let update_every = vertex.count.div_ceil(20);
+
+        let mut last_update = 0;
+
+        for i in 0..vertex.count {
+            try_yield(i).await;
+
+            // Doing this after first reading and parsing the points is quite wasteful, but
+            // we do need to advance the reader.
+            if let Some(subsample) = subsample_points {
+                if i % subsample as usize != 0 {
+                    continue;
+                }
+            }
+
+            let splat = parse_elem(&mut reader, &parser, header.encoding, vertex).await?;
+
+            means.push(splat.mean);
+            if let Some(scales) = &mut log_scales {
+                scales.push(splat.log_scale);
+            }
+            if let Some(rotation) = &mut rotations {
+                rotation.push(splat.rotation);
+            }
+            if let Some(opacity) = &mut opacity {
+                opacity.push(splat.opacity);
+            }
+            if let Some(sh_coeffs) = &mut sh_coeffs {
+                interleave_coeffs(splat.sh_dc, &splat.sh_coeffs_rest, sh_coeffs);
+            }
+
+            if (i - last_update) >= update_every || i == vertex.count - 1 {
+                let splats = Splats::from_raw(
+                    &means,
+                    rotations.as_deref(),
+                    log_scales.as_deref(),
+                    sh_coeffs.as_deref(),
+                    opacity.as_deref(),
+                    &device,
+                );
+                emitter
+                    .emit(SplatMessage {
+                        meta: ParseMetadata {
+                            total_splats: vertex.count as u32,
+                            up_axis,
+                            frame_count: 0,
+                            current_frame: 0,
+                        },
+                        splats,
+                    })
+                    .await;
+
+                last_update = i;
+            }
+        }
+
+        Ok(())
+    })
+}
+
+fn parse_compressed_ply<T: AsyncBufRead + Unpin + 'static, B: Backend>(
+    mut reader: T,
+    subsample_points: Option<u32>,
+    device: B::Device,
+    header: Header,
+    up_axis: Option<Vec3>,
+) -> impl Stream<Item = Result<SplatMessage<B>>> + 'static {
+    #[derive(Default)]
+    struct MinMax {
+        min: Vec3,
+        max: Vec3,
+    }
+
+    impl MinMax {
+        fn dequant(&self, raw: Vec3) -> Vec3 {
+            self.min + raw * (self.max - self.min)
+        }
+    }
+
+    #[derive(Default)]
+    struct QuantMeta {
+        mean: MinMax,
+        scale: MinMax,
+        color: MinMax,
+    }
+
+    impl PropertyAccess for QuantMeta {
+        fn new() -> Self {
+            Self::default()
+        }
+
+        fn set_property(&mut self, key: &str, property: Property) {
+            let ascii = key.as_bytes();
+            let Property::Float(val) = property else {
+                return;
+            };
+            match ascii {
+                b"min_x" => self.mean.min.x = val,
+                b"min_y" => self.mean.min.y = val,
+                b"min_z" => self.mean.min.z = val,
+
+                b"max_x" => self.mean.max.x = val,
+                b"max_y" => self.mean.max.y = val,
+                b"max_z" => self.mean.max.z = val,
+
+                b"min_scale_x" => self.scale.min.x = val,
+                b"min_scale_y" => self.scale.min.y = val,
+                b"min_scale_z" => self.scale.min.z = val,
+
+                b"max_scale_x" => self.scale.max.x = val,
+                b"max_scale_y" => self.scale.max.y = val,
+                b"max_scale_z" => self.scale.max.z = val,
+
+                b"min_r" => self.color.min.x = val,
+                b"min_g" => self.color.min.y = val,
+                b"min_b" => self.color.min.z = val,
+
+                b"max_r" => self.color.max.x = val,
+                b"max_g" => self.color.max.y = val,
+                b"max_b" => self.color.max.z = val,
+                _ => {}
+            }
+        }
+    }
+
+    try_fn_stream(|emitter| async move {
+        let quant_elem = header
+            .elements
+            .first()
+            .context("Not enough elements in header")?;
+        if quant_elem.name != "chunk" {
+            anyhow::bail!("First element should be chunk compression metadata!");
+        }
+
+        let parser = Parser::<QuantMeta>::new();
+        let mut quant_metas = vec![];
+        for i in 0..quant_elem.count {
+            try_yield(i).await;
+            let quant_meta = parse_elem(&mut reader, &parser, header.encoding, quant_elem).await?;
+            quant_metas.push(quant_meta);
+        }
+
+        let vertex = header
+            .elements
+            .get(1)
+            .context("Not enough elements in header")?;
+        if vertex.name != "vertex" {
+            anyhow::bail!("Second element should be vertex compression metadata!");
+        }
+
+        let parser = Parser::<ParsedGaussian>::new();
+        let mut means = Vec::with_capacity(vertex.count);
+        // Atm, unlike normal plys, these values aren't optional.
+        let mut log_scales = Vec::with_capacity(vertex.count);
+        let mut rotations = Vec::with_capacity(vertex.count);
+        let mut sh_coeffs = Vec::with_capacity(vertex.count);
+        let mut opacity = Vec::with_capacity(vertex.count);
+
+        let update_every = vertex.count.div_ceil(20);
+        let mut last_update = 0;
+
+        for i in 0..vertex.count {
+            // Occasionally yield.
+            if i % 500 == 0 {
+                tokio_wasm::task::yield_now().await;
+            }
+
+            // Doing this after first reading and parsing the points is quite wasteful, but
+            // we do need to advance the reader.
+            if let Some(subsample) = subsample_points {
+                if i % subsample as usize != 0 {
+                    continue;
+                }
+            }
+
+            let quant_data = quant_metas
+                .get(i / 256)
+                .context("not enough quantization data to parse ply")?;
+
+            let mut splat = parse_elem(&mut reader, &parser, header.encoding, vertex).await?;
+            splat.mean = quant_data.mean.dequant(splat.mean);
+            means.push(splat.mean);
+
+            splat.log_scale = quant_data.scale.dequant(splat.log_scale);
+            log_scales.push(splat.log_scale);
+            rotations.push(splat.rotation);
+
+            // Compressed ply specifies things in post-activated values. Convert to pre-activated values.
+            opacity.push(inverse_sigmoid(splat.opacity));
+
+            // These come in as RGB colors. Convert to base SH coeffecients.
+            splat.sh_dc = quant_data.color.dequant(splat.sh_dc);
+            splat.sh_dc = rgb_to_sh(splat.sh_dc);
+            sh_coeffs.extend([splat.sh_dc.x, splat.sh_dc.y, splat.sh_dc.z]);
+
+            // Occasionally send some updated splats.
+            if (i - last_update) >= update_every || i == vertex.count - 1 {
+                emitter
+                    .emit(SplatMessage {
+                        meta: ParseMetadata {
+                            total_splats: vertex.count as u32,
+                            up_axis,
+                            frame_count: 0,
+                            current_frame: 0,
+                        },
+                        splats: Splats::from_raw(
+                            &means,
+                            Some(&rotations),
+                            Some(&log_scales),
+                            Some(&sh_coeffs),
+                            Some(&opacity),
+                            &device,
+                        ),
+                    })
+                    .await;
+                last_update = i;
+            }
+        }
+
+        if let Some(sh_vals) = header.elements.get(2) {
+            if sh_vals.name != "sh" {
+                anyhow::bail!("Second element should be SH compression metadata!");
+            }
+
+            let mut total_coeffs = vec![];
+            for i in 0..sh_vals.count {
+                try_yield(i).await;
+
+                // Parse a splat - though nb only SH values will be used.
+                let mut splat = parse_elem(&mut reader, &parser, header.encoding, sh_vals).await?;
+                for coeff in &mut splat.sh_coeffs_rest {
+                    *coeff = 8.0 * (*coeff - 0.5);
+                }
+
+                let dc = glam::vec3(sh_coeffs[i * 3], sh_coeffs[i * 3 + 1], sh_coeffs[i * 3 + 2]);
+                interleave_coeffs(dc, &splat.sh_coeffs_rest, &mut total_coeffs);
+            }
+
+            emitter
+                .emit(SplatMessage {
+                    meta: ParseMetadata {
+                        total_splats: vertex.count as u32,
+                        up_axis,
+                        frame_count: 0,
+                        current_frame: 0,
+                    },
+                    splats: Splats::from_raw(
+                        &means,
+                        Some(&rotations),
+                        Some(&log_scales),
+                        Some(&total_coeffs),
+                        Some(&opacity),
+                        &device,
+                    ),
+                })
+                .await;
+        }
+
+        Ok(())
+    })
+}
+
+fn parse_delta_ply<T: AsyncBufRead + Unpin + 'static, B: Backend>(
+    mut reader: T,
+    subsample_points: Option<u32>,
+    device: B::Device,
+    header: Header,
+    up_axis: Option<Vec3>,
+) -> impl Stream<Item = Result<SplatMessage<B>>> + 'static {
+    try_fn_stream(|emitter| async move {
+        let parser = Parser::<ParsedGaussian>::new();
+
+        // Check for frame count.
         let frame_count = header
             .elements
             .iter()
@@ -211,6 +454,13 @@ pub fn load_splat_from_ply<T: AsyncRead + Unpin + 'static, B: Backend>(
 
         let mut final_splat = None;
         let mut frame = 0;
+
+        #[derive(Debug)]
+        struct QuantMeta {
+            mean: Vec3,
+            rotation: Vec4,
+            scale: Vec3,
+        }
 
         let mut meta_min = QuantMeta {
             mean: Vec3::ZERO,
@@ -222,20 +472,10 @@ pub fn load_splat_from_ply<T: AsyncRead + Unpin + 'static, B: Backend>(
             rotation: Vec4::ONE,
             scale: Vec3::ONE,
         };
+
         for element in &header.elements {
             let properties: HashSet<_> =
                 element.properties.iter().map(|x| x.name.clone()).collect();
-
-            let n_sh_coeffs = (3 + element
-                .properties
-                .iter()
-                .filter_map(|x| {
-                    x.name
-                        .strip_prefix("f_rest_")
-                        .and_then(|x| x.parse::<u32>().ok())
-                })
-                .max()
-                .unwrap_or(0)) as usize;
 
             let mut means = Vec::with_capacity(element.count);
             let mut log_scales = properties
@@ -245,44 +485,35 @@ pub fn load_splat_from_ply<T: AsyncRead + Unpin + 'static, B: Backend>(
                 .contains("rot_0")
                 .then(|| Vec::with_capacity(element.count));
             let mut sh_coeffs = (properties.contains("f_dc_0") || properties.contains("red"))
-                .then(|| Vec::with_capacity(element.count * n_sh_coeffs));
+                .then(|| Vec::with_capacity(element.count * 24));
             let mut opacity = properties
                 .contains("opacity")
                 .then(|| Vec::with_capacity(element.count));
 
             if element.name == "vertex" {
-                if ["x", "y", "z"].into_iter().any(|p| !properties.contains(p)) {
-                    anyhow::bail!("Invalid splat ply. Missing properties!");
-                }
-
-                let update_every = element.count.div_ceil(25);
+                let update_every = element.count.div_ceil(20);
 
                 for i in 0..element.count {
-                    // Occasionally yield.
-                    if i % 500 == 0 {
-                        tokio_wasm::task::yield_now().await;
-                    }
+                    try_yield(i).await;
 
                     // Occasionally send some updated splats.
                     if i % update_every == update_every - 1 {
-                        let splats = Splats::from_raw(
-                            &means,
-                            rotations.as_deref(),
-                            log_scales.as_deref(),
-                            sh_coeffs.as_deref(),
-                            opacity.as_deref(),
-                            &device,
-                        );
-
                         emitter
                             .emit(SplatMessage {
-                                meta: SplatMetadata {
+                                meta: ParseMetadata {
                                     total_splats: element.count as u32,
                                     up_axis,
                                     frame_count,
                                     current_frame: frame,
                                 },
-                                splats,
+                                splats: Splats::from_raw(
+                                    &means,
+                                    rotations.as_deref(),
+                                    log_scales.as_deref(),
+                                    sh_coeffs.as_deref(),
+                                    opacity.as_deref(),
+                                    &device,
+                                ),
                             })
                             .await;
                     }
@@ -295,29 +526,22 @@ pub fn load_splat_from_ply<T: AsyncRead + Unpin + 'static, B: Backend>(
                         }
                     }
 
-                    let splat =
-                        decode_splat(&mut reader, &gaussian_parser, &header, element).await?;
+                    let splat = parse_elem(&mut reader, &parser, header.encoding, element).await?;
 
-                    means.push(splat.means);
-                    if let Some(scales) = log_scales.as_mut() {
+                    means.push(splat.mean);
+                    if let Some(scales) = &mut log_scales {
                         scales.push(splat.log_scale);
                     }
-                    if let Some(rotation) = rotations.as_mut() {
-                        // Normalize rotations, bail if 0.
-                        let vec: Vec4 = splat.rotation.into();
-                        let vec = vec.try_normalize().map_or(Quat::IDENTITY, Quat::from_vec4);
-                        rotation.push(vec);
+                    if let Some(rotation) = &mut rotations {
+                        rotation.push(splat.rotation);
                     }
-                    if let Some(opacity) = opacity.as_mut() {
+                    if let Some(opacity) = &mut opacity {
                         opacity.push(splat.opacity);
                     }
-                    if let Some(sh_coeffs) = sh_coeffs.as_mut() {
-                        let sh_coeffs_interleaved =
-                            interleave_coeffs(splat.sh_dc, &splat.sh_coeffs_rest);
-                        sh_coeffs.extend(sh_coeffs_interleaved);
+                    if let Some(sh_coeffs) = &mut sh_coeffs {
+                        interleave_coeffs(splat.sh_dc, &splat.sh_coeffs_rest, sh_coeffs);
                     }
                 }
-
                 let splats = Splats::from_raw(
                     &means,
                     rotations.as_deref(),
@@ -329,7 +553,7 @@ pub fn load_splat_from_ply<T: AsyncRead + Unpin + 'static, B: Backend>(
                 final_splat = Some(splats.clone());
                 emitter
                     .emit(SplatMessage {
-                        meta: SplatMetadata {
+                        meta: ParseMetadata {
                             total_splats: element.count as u32,
                             up_axis,
                             frame_count,
@@ -339,13 +563,13 @@ pub fn load_splat_from_ply<T: AsyncRead + Unpin + 'static, B: Backend>(
                     })
                     .await;
             } else if element.name.starts_with("meta_delta_min_") {
-                let splat = decode_splat(&mut reader, &gaussian_parser, &header, element).await?;
-                meta_min.mean = splat.means;
+                let splat = parse_elem(&mut reader, &parser, header.encoding, element).await?;
+                meta_min.mean = splat.mean;
                 meta_min.rotation = splat.rotation.into();
                 meta_min.scale = splat.log_scale;
             } else if element.name.starts_with("meta_delta_max_") {
-                let splat = decode_splat(&mut reader, &gaussian_parser, &header, element).await?;
-                meta_max.mean = splat.means;
+                let splat = parse_elem(&mut reader, &parser, header.encoding, element).await?;
+                meta_max.mean = splat.mean;
                 meta_max.rotation = splat.rotation.into();
                 meta_max.scale = splat.log_scale;
             } else if element.name.starts_with("delta_vertex_") {
@@ -354,17 +578,14 @@ pub fn load_splat_from_ply<T: AsyncRead + Unpin + 'static, B: Backend>(
                 };
 
                 for i in 0..element.count {
-                    // Occasionally yield.
-                    if i % 500 == 0 {
-                        tokio_wasm::task::yield_now().await;
-                    }
+                    try_yield(i).await;
                     // The splat we decode is normed to 0-1 (if quantized), so rescale to
                     // actual values afterwards.
                     let splat_enc =
-                        decode_splat(&mut reader, &gaussian_parser, &header, element).await?;
+                        parse_elem(&mut reader, &parser, header.encoding, element).await?;
 
                     // Let's only animate transforms for now.
-                    means.push(splat_enc.means * (meta_max.mean - meta_min.mean) + meta_min.mean);
+                    means.push(splat_enc.mean * (meta_max.mean - meta_min.mean) + meta_min.mean);
 
                     if let Some(rotation) = rotations.as_mut() {
                         let val: Vec4 = splat_enc.rotation.into();
@@ -411,25 +632,22 @@ pub fn load_splat_from_ply<T: AsyncRead + Unpin + 'static, B: Backend>(
                     splats.log_scales.val()
                 };
 
-                let new_splat = Splats::from_tensor_data(
-                    means,
-                    rotations,
-                    log_scales,
-                    splats.sh_coeffs.val(),
-                    splats.raw_opacity.val(),
-                )
-                .with_normed_rotations();
-
                 // Emit newly animated splat.
                 emitter
                     .emit(SplatMessage {
-                        meta: SplatMetadata {
+                        meta: ParseMetadata {
                             total_splats: element.count as u32,
                             up_axis,
                             frame_count,
                             current_frame: frame,
                         },
-                        splats: new_splat,
+                        splats: Splats::from_tensor_data(
+                            means,
+                            rotations,
+                            log_scales,
+                            splats.sh_coeffs.val(),
+                            splats.raw_opacity.val(),
+                        ),
                     })
                     .await;
 

--- a/crates/brush-dataset/src/splat_import.rs
+++ b/crates/brush-dataset/src/splat_import.rs
@@ -77,7 +77,7 @@ async fn try_yield(i: usize) {
     }
 }
 
-pub fn load_splat_from_ply<T: AsyncRead + Send + Unpin + 'static, B: Backend>(
+pub fn load_splat_from_ply<T: AsyncRead + Unpin + 'static, B: Backend>(
     reader: T,
     subsample_points: Option<u32>,
     device: B::Device,

--- a/crates/brush-process/src/rerun_tools.rs
+++ b/crates/brush-process/src/rerun_tools.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use brush_dataset::clamp_img_to_max_size;
 use brush_render::gaussian_splats::Splats;
+use brush_render::shaders::project_visible::SH_C0;
 use brush_train::eval::EvalSample;
 use brush_train::image::view_to_sample;
 use brush_train::{image::tensor_into_image, scene::Scene, train::RefineStats};
@@ -63,7 +64,7 @@ impl VisualizeTools {
                         .sh_coeffs
                         .val()
                         .slice([0..splats.num_splats() as usize, 0..1, 0..3])
-                        * brush_render::render::SH_C0
+                        * SH_C0
                         + 0.5;
 
                 let transparency = sigmoid(splats.raw_opacity.val());

--- a/crates/brush-render/src/gaussian_splats.rs
+++ b/crates/brush-render/src/gaussian_splats.rs
@@ -88,6 +88,7 @@ impl<B: Backend> Splats<B> {
         let means_tensor = Tensor::from_data(TensorData::new(means_tensor, [n_splats, 3]), device);
 
         let rotations = if let Some(rotations) = rotations {
+            // Rasterizer expects quaternions in scalar form.
             let rotations: Vec<f32> = rotations
                 .iter()
                 .flat_map(|v| [v.w, v.x, v.y, v.z])

--- a/crates/brush-render/src/render.rs
+++ b/crates/brush-render/src/render.rs
@@ -22,9 +22,9 @@ use burn_wgpu::CubeTensor;
 use burn_wgpu::WgpuRuntime;
 
 use burn::tensor::ops::FloatTensorOps;
-use glam::{ivec2, uvec2};
+use glam::{Vec3, ivec2, uvec2};
 
-pub const SH_C0: f32 = shaders::project_visible::SH_C0;
+const SH_C0: f32 = shaders::project_visible::SH_C0;
 
 pub const fn sh_coeffs_for_degree(degree: u32) -> u32 {
     (degree + 1).pow(2)
@@ -41,8 +41,16 @@ pub fn sh_degree_from_coeffs(coeffs_per_channel: u32) -> u32 {
     }
 }
 
-pub fn rgb_to_sh(rgb: f32) -> f32 {
+pub fn channel_to_sh(rgb: f32) -> f32 {
     (rgb - 0.5) / SH_C0
+}
+
+pub fn rgb_to_sh(rgb: Vec3) -> Vec3 {
+    glam::vec3(
+        channel_to_sh(rgb.x),
+        channel_to_sh(rgb.y),
+        channel_to_sh(rgb.z),
+    )
 }
 
 pub(crate) fn calc_tile_bounds(img_size: glam::UVec2) -> glam::UVec2 {


### PR DESCRIPTION
Import SuperSplat's compressed.ply format. Split the ply importer into a few modes to not have to juggle all permutations at the same time. This also speeds up the regular importer a tiny bit, as it doesn't have to check some conditations anymore.