### PR TITLE
Fix Android build

### DIFF
--- a/crates/brush-android/src/lib.rs
+++ b/crates/brush-android/src/lib.rs
@@ -5,14 +5,14 @@ use std::os::raw::c_void;
 use std::sync::Arc;
 
 #[allow(non_snake_case)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "system" fn JNI_OnLoad(vm: jni::JavaVM, _: *mut c_void) -> jint {
     let vm_ref = Arc::new(vm);
     rrfd::android::jni_initialize(vm_ref);
     JNI_VERSION_1_6
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 fn android_main(app: winit::platform::android::activity::AndroidApp) {
     use winit::platform::android::EventLoopBuilderExtAndroid;
 
@@ -40,7 +40,7 @@ fn android_main(app: winit::platform::android::activity::AndroidApp) {
                 wgpu_options,
                 ..Default::default()
             },
-            Box::new(|cc| Ok(Box::new(brush_app::App::new(cc, send)))),
+            Box::new(|cc| Ok(Box::new(brush_app::App::new(cc, send, None)))),
         )
         .unwrap();
     });

--- a/crates/rrfd/src/android.rs
+++ b/crates/rrfd/src/android.rs
@@ -82,7 +82,7 @@ pub(crate) async fn pick_file() -> Result<File> {
     file.context("No file selected")
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 extern "system" fn Java_com_splats_app_FilePicker_onFilePickerResult<'local>(
     _env: JNIEnv<'local>,
     _class: JClass<'local>,


### PR DESCRIPTION
- `#[no_mangle]` -> `#[unsafe(no_mangle)]`
- Add the missing `start_uri_override` parameter for `brush_app::App::new`