### PR TITLE
Fix blocked docker build using noninteractive mode, run brush as non root

### DIFF
--- a/extras/Dockerfile
+++ b/extras/Dockerfile
@@ -1,18 +1,17 @@
 # Simple docker file to run Brush. Note that as Brush has very few dependencies, you should be able to run
 # it on any system already.
 #
-# This image is for easier server deployements. Nb: This dockerfile explicatly installs nvidia drivers,
+# This image is for easier server deployments. Nb: This dockerfile explicitly installs nvidia drivers,
 # I haven't tested this on non nvidia GPUs. Alternatively, you should be able
 # to run with host drivers.
-FROM rust:1.86 as builder
-ADD https://github.com/ArthurBrussee/brush/ .
+FROM rust:1.86 AS builder
 RUN git clone https://github.com/ArthurBrussee/brush
 RUN cargo build --release --manifest-path ./brush/Cargo.toml
 
 FROM ubuntu:22.04
 
 # Install dependencies.
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get install -y \
     build-essential \
     cmake \
     libvulkan1 \
@@ -26,9 +25,10 @@ RUN mkdir /workdir
 COPY --from=builder ./brush/target/release/brush_app /workdir
 WORKDIR /workdir
 
-# Below command creates home dir for 1000 UID user if it is not present.
-RUN if ! id 1000; then useradd -m -u 1000 clouduser; fi
+# Below command creates home dir for 1000 UID user
+RUN useradd -m -u 1000 clouduser
 RUN chown -R 1000:root /workdir && chmod -R 775 /workdir
 
 # Launch training.
+USER clouduser
 ENTRYPOINT ["./brush_app"]


### PR DESCRIPTION
I just saw you pushed an example Dockerfile in the repo so I was reviewing it.
You actually run the brush_app command as root here, you forgot an important `USER clouduser`.
The 1000 user doesn't exist in the ubuntu:22.04 image so the check is unnecessary, you can always create it.
The apt-get install was blocking on a select a keyboard config for me, I added `DEBIAN_FRONTEND="noninteractive"` to fix it.
The git clone failed because of the ADD command that already creates the brush directory, I just removed that.

For it to build I had to replace nvidia-driver-570 by nvidia-driver-535 same as I have on my ubuntu host otherwise it says it can't find that package, I didn't commit that change.

Even with all the changes, when I run with
```
cd extras
docker build -t brush .
docker run --rm -v ~/:/tmp brush --export-path /tmp/gaussiansplats/penguin_export/ /tmp/gaussiansplats/penguin/
```
I get 
```
error: XDG_RUNTIME_DIR not set in the environment.
error: XDG_RUNTIME_DIR not set in the environment.
error: XDG_RUNTIME_DIR not set in the environment.
error: XDG_RUNTIME_DIR not set in the environment.
   🖌️ █▓ Dataset loaded
✅ evaluating every 1000 steps
ℹ️ Done loading                                                                                                                                                              
thread 'main' panicked at /usr/local/cargo/git/checkouts/cubecl-058c47895211d464/eaf4b4b/crates/cubecl-runtime/src/memory_management/memory_manage.rs:307:32:
No pool handles allocation of size 268431360
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
do you use specific docker run parameters to start it?