### PR TITLE
Improve VFS (case insensitive by default), file loading, and splat import

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,6 +879,7 @@ dependencies = [
  "brush-render",
  "brush-vfs",
  "burn",
+ "burn-cubecl",
  "clap",
  "colmap-reader",
  "glam",

--- a/crates/brush-dataset/Cargo.toml
+++ b/crates/brush-dataset/Cargo.toml
@@ -9,18 +9,21 @@ license.workspace = true
 brush-render.path = "../brush-render"
 brush-vfs.path = "../brush-vfs"
 colmap-reader.path = "../colmap-reader"
+
+burn.workspace = true
+burn-cubecl.workspace = true
+
 anyhow.workspace = true
 image.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 glam.workspace = true
-burn.workspace = true
+
 tracing.workspace = true
 web-time.workspace = true
 log.workspace = true
 ply-rs.workspace = true
 rand.workspace = true
-
 
 tokio_with_wasm.workspace = true
 tokio-stream.workspace = true

--- a/crates/brush-dataset/src/formats/colmap.rs
+++ b/crates/brush-dataset/src/formats/colmap.rs
@@ -1,7 +1,4 @@
-use std::{
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+use std::{path::PathBuf, sync::Arc};
 
 use super::DataStream;
 use crate::{
@@ -22,23 +19,6 @@ use brush_vfs::BrushVfs;
 use burn::backend::wgpu::WgpuDevice;
 use glam::Vec3;
 use std::collections::HashMap;
-
-fn find_base_path(archive: &BrushVfs, search_path: &str) -> Option<PathBuf> {
-    for path in archive.file_names() {
-        let lower_name = path.to_str().map(|s| s.to_lowercase());
-
-        if let Some(lower_name) = lower_name {
-            // Nb: This will use case sensitivity from the OS.
-            if lower_name.ends_with(search_path) {
-                return path
-                    .ancestors()
-                    .nth(Path::new(search_path).components().count())
-                    .map(|x| x.to_owned());
-            }
-        }
-    }
-    None
-}
 
 fn find_mask_and_img(vfs: &BrushVfs, paths: &[PathBuf]) -> Result<(PathBuf, Option<PathBuf>)> {
     let mut path_masks = HashMap::new();
@@ -72,9 +52,11 @@ pub(crate) async fn load_dataset(
 ) -> Option<Result<(DataStream<SplatMessage>, Dataset)>> {
     log::info!("Loading colmap dataset");
 
-    let (cam_path, img_path) = if let Some(path) = find_base_path(&vfs, "cameras.bin") {
+    let (cam_path, img_path) = if let Some(path) = vfs.files_with_filename("cameras.bin").next() {
+        let path = path.parent().expect("unreachable");
         (path.join("cameras.bin"), path.join("images.bin"))
-    } else if let Some(path) = find_base_path(&vfs, "cameras.txt") {
+    } else if let Some(path) = vfs.files_with_filename("cameras.txt").next() {
+        let path = path.parent().expect("unreachable");
         (path.join("cameras.txt"), path.join("images.txt"))
     } else {
         return None;
@@ -131,11 +113,7 @@ async fn load_dataset_inner(
 
         // Colmap only specifies an image name, not a full path. We brute force
         // search for the image in the archive.
-        let img_paths: Vec<_> = vfs
-            .file_names()
-            .filter(|p| p.ends_with(&img_info.name))
-            .collect();
-
+        let img_paths: Vec<_> = vfs.files_with_filename(&img_info.name).collect();
         let (path, mask_path) = find_mask_and_img(&vfs, &img_paths)
             .with_context(|| format!("Failed to find image {}", img_info.name))?;
 
@@ -170,13 +148,8 @@ async fn load_dataset_inner(
     let device = device.clone();
     let load_args = load_args.clone();
     let init_stream = try_fn_stream(|emitter| async move {
-        let points_path = vfs.file_names().find(|p| {
-            if let Some(path) = p.to_str().map(|p| p.to_lowercase()) {
-                path.ends_with("points3d.txt") || path.ends_with("points3d.bin")
-            } else {
-                false
-            }
-        });
+        let points_path = { vfs.files_with_filename("points3d.txt").next() }
+            .or_else(|| vfs.files_with_filename("points3d.bin").next());
 
         let Some(points_path) = points_path else {
             return Ok(());

--- a/crates/brush-dataset/src/formats/nerfstudio.rs
+++ b/crates/brush-dataset/src/formats/nerfstudio.rs
@@ -11,7 +11,7 @@ use async_fn_stream::try_fn_stream;
 use brush_render::camera::fov_to_focal;
 use brush_render::camera::{Camera, focal_to_fov};
 use brush_vfs::BrushVfs;
-use burn::prelude::Backend;
+use burn::backend::wgpu::WgpuDevice;
 use std::path::Path;
 use std::sync::Arc;
 use tokio::io::AsyncReadExt;
@@ -177,11 +177,11 @@ async fn read_transforms_file(
     Ok(results)
 }
 
-pub async fn read_dataset<B: Backend>(
+pub async fn read_dataset(
     vfs: Arc<BrushVfs>,
     load_args: &LoadDataseConfig,
-    device: &B::Device,
-) -> Option<Result<(DataStream<SplatMessage<B>>, Dataset)>> {
+    device: &WgpuDevice,
+) -> Option<Result<(DataStream<SplatMessage>, Dataset)>> {
     log::info!("Loading nerfstudio dataset");
 
     let json_files: Vec<_> = vfs
@@ -204,13 +204,13 @@ pub async fn read_dataset<B: Backend>(
     Some(read_dataset_inner(vfs, load_args, device, json_files, transforms_path).await)
 }
 
-async fn read_dataset_inner<B: Backend>(
+async fn read_dataset_inner(
     vfs: Arc<BrushVfs>,
     load_args: &LoadDataseConfig,
-    device: &<B as Backend>::Device,
+    device: &WgpuDevice,
     json_files: Vec<std::path::PathBuf>,
     transforms_path: std::path::PathBuf,
-) -> Result<(DataStream<SplatMessage<B>>, Dataset)> {
+) -> Result<(DataStream<SplatMessage>, Dataset)> {
     let mut buf = String::new();
     vfs.reader_at_path(&transforms_path)
         .await?

--- a/crates/brush-dataset/src/lib.rs
+++ b/crates/brush-dataset/src/lib.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 pub mod config;
 pub mod scene;
 pub mod scene_loader;

--- a/crates/brush-process/src/process.rs
+++ b/crates/brush-process/src/process.rs
@@ -22,13 +22,20 @@ pub fn process_stream(
         log::info!("Starting process with source {source:?}");
         let vfs = Arc::new(source.into_vfs().await?);
 
-        let paths: Vec<_> = vfs.file_names().collect();
-        log::info!("Mounted VFS with {} files", paths.len());
+        let vfs_counts = vfs.file_count();
+        let ply_count = vfs.files_with_extension("ply").count();
 
-        if paths
-            .iter()
-            .all(|p| p.extension().is_some_and(|p| p == "ply"))
-        {
+        for file in vfs.file_paths() {
+            log::info!("Processing file: {:?}", file);
+        }
+
+        log::info!(
+            "Mounted VFS with {} files. (plys: {})",
+            vfs.file_count(),
+            ply_count
+        );
+
+        if vfs_counts == ply_count {
             view_stream(vfs, device, emitter).await?;
         } else {
             train_stream(vfs, process_args, device, emitter).await?;

--- a/crates/brush-process/src/process.rs
+++ b/crates/brush-process/src/process.rs
@@ -25,10 +25,6 @@ pub fn process_stream(
         let vfs_counts = vfs.file_count();
         let ply_count = vfs.files_with_extension("ply").count();
 
-        for file in vfs.file_paths() {
-            log::info!("Processing file: {:?}", file);
-        }
-
         log::info!(
             "Mounted VFS with {} files. (plys: {})",
             vfs.file_count(),

--- a/crates/brush-process/src/train_stream.rs
+++ b/crates/brush-process/src/train_stream.rs
@@ -67,7 +67,7 @@ pub(crate) async fn train_stream(
             // If the metadata has an up axis prefer that, otherwise estimate
             // the up direction.
             up_axis: message.meta.up_axis.or(Some(estimated_up)),
-            splats: Box::new(message.splats.valid()),
+            splats: Box::new(message.splats.clone()),
             frame: 0,
             total_frames: 0,
         };
@@ -95,7 +95,8 @@ pub(crate) async fn train_stream(
         Splats::from_random_config(&config, adjusted_bounds, &mut rng, &device)
     };
 
-    let mut splats = splats.with_sh_degree(process_args.model_config.sh_degree);
+    let splats = splats.with_sh_degree(process_args.model_config.sh_degree);
+    let mut splats = splats.into_autodiff();
 
     let mut eval_scene = dataset.eval;
     let scene_extent = dataset.train.estimate_extent().unwrap_or(1.0);

--- a/crates/brush-process/src/view_stream.rs
+++ b/crates/brush-process/src/view_stream.rs
@@ -15,7 +15,7 @@ pub(crate) async fn view_stream(
 ) -> anyhow::Result<()> {
     emitter.emit(ProcessMessage::NewSource).await;
 
-    let paths: Vec<_> = vfs.file_names().collect();
+    let paths: Vec<_> = vfs.file_paths().collect();
 
     for (i, path) in paths.iter().enumerate() {
         log::info!("Loading single ply file");

--- a/crates/brush-vfs/src/data_source.rs
+++ b/crates/brush-vfs/src/data_source.rs
@@ -1,12 +1,6 @@
-use crate::{BrushVfs, PathReader, WasmNotSend};
+use crate::BrushVfs;
 use anyhow::anyhow;
-use std::{
-    io::Cursor,
-    path::{Path, PathBuf},
-    str::FromStr,
-};
-use tokio::io::AsyncReadExt;
-use tokio::io::{AsyncRead, BufReader};
+use std::{path::Path, str::FromStr};
 use tokio_stream::StreamExt;
 use tokio_util::io::StreamReader;
 
@@ -33,53 +27,16 @@ impl FromStr for DataSource {
     }
 }
 
-async fn read_at_most<R: AsyncRead + Unpin>(
-    reader: &mut R,
-    limit: usize,
-) -> std::io::Result<Vec<u8>> {
-    let mut buffer = vec![0; limit];
-    let bytes_read = reader.read(&mut buffer).await?;
-    buffer.truncate(bytes_read);
-    Ok(buffer)
-}
-
 impl DataSource {
-    async fn vfs_from_reader(
-        reader: impl AsyncRead + WasmNotSend + Unpin + 'static,
-    ) -> anyhow::Result<BrushVfs> {
-        // Small hack to peek some bytes: Read them
-        // and add them at the start again.
-        let mut data = BufReader::new(reader);
-        let peek = read_at_most(&mut data, 64).await?;
-        let reader = Cursor::new(peek.clone()).chain(data);
-
-        if peek.as_slice().starts_with(b"ply") {
-            let mut path_reader = PathReader::default();
-            path_reader.add(Path::new("input.ply"), reader);
-            Ok(BrushVfs::from_paths(path_reader))
-        } else if peek.starts_with(b"PK") {
-            BrushVfs::from_zip_reader(reader)
-                .await
-                .map_err(|e| anyhow::anyhow!(e))
-        } else if peek.starts_with(b"<!DOCTYPE html>") {
-            // TODO: Display HTML page on WASM maybe?
-            anyhow::bail!("Failed to download data.")
-        } else {
-            anyhow::bail!("only zip and ply files are supported. Unknown data type.")
-        }
-    }
-
     pub async fn into_vfs(self) -> anyhow::Result<BrushVfs> {
         match self {
             Self::PickFile => {
-                let picked = rrfd::pick_file().await.map_err(|e| anyhow!(e))?;
-                let data = picked.read().await;
-                let reader = Cursor::new(data);
-                Self::vfs_from_reader(reader).await
+                let reader = rrfd::pick_file().await.map_err(|e| anyhow!(e))?;
+                BrushVfs::from_reader(reader).await
             }
             Self::PickDirectory => {
                 let picked = rrfd::pick_directory().await.map_err(|e| anyhow!(e))?;
-                BrushVfs::from_directory(&picked).await
+                BrushVfs::from_path(&picked).await
             }
             Self::Url(url) => {
                 let mut url = url.clone();
@@ -112,9 +69,9 @@ impl DataSource {
                 let response =
                     response.map(|b| b.map_err(|_e| std::io::ErrorKind::ConnectionAborted));
                 let reader = StreamReader::new(response);
-                Self::vfs_from_reader(reader).await
+                BrushVfs::from_reader(reader).await
             }
-            Self::Path(path) => BrushVfs::from_directory(&PathBuf::from(path)).await,
+            Self::Path(path) => BrushVfs::from_path(&Path::new(&path)).await,
         }
     }
 }

--- a/crates/brush-vfs/src/data_source.rs
+++ b/crates/brush-vfs/src/data_source.rs
@@ -71,7 +71,7 @@ impl DataSource {
                 let reader = StreamReader::new(response);
                 BrushVfs::from_reader(reader).await
             }
-            Self::Path(path) => BrushVfs::from_path(&Path::new(&path)).await,
+            Self::Path(path) => BrushVfs::from_path(Path::new(&path)).await,
         }
     }
 }

--- a/crates/brush-vfs/src/lib.rs
+++ b/crates/brush-vfs/src/lib.rs
@@ -27,7 +27,7 @@ use zip::ZipArchive;
 // So, it can help to annotate futures/objects as send only on not-wasm.
 #[cfg(target_family = "wasm")]
 mod wasm_send {
-    pub trait WasmNotSend {}
+    pub trait SendNotWasm {}
     impl<T> SendNotWasm for T {}
 }
 #[cfg(not(target_family = "wasm"))]

--- a/crates/rrfd/Cargo.toml
+++ b/crates/rrfd/Cargo.toml
@@ -16,8 +16,11 @@ rfd = { version = "0.15.0", default-features = false, features = [
     "tokio",
 ] }
 
-[target.'cfg(target_os = "android")'.dependencies]
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
 tokio = { workspace = true, features = ["fs", "sync"] }
+
+[target.'cfg(target_family = "wasm")'.dependencies]
+tokio = { workspace = true, features = ["sync"] }
 
 [lints]
 workspace = true

--- a/crates/rrfd/src/lib.rs
+++ b/crates/rrfd/src/lib.rs
@@ -5,57 +5,35 @@ pub mod android;
 use anyhow::Context;
 use anyhow::Result;
 use std::path::PathBuf;
-
-pub enum FileHandle {
-    #[cfg(not(target_os = "android"))]
-    Rfd(rfd::FileHandle),
-    #[cfg(target_os = "android")]
-    Android(tokio::fs::File),
-}
-
-impl FileHandle {
-    pub async fn write(&self, data: &[u8]) -> std::io::Result<()> {
-        match self {
-            #[cfg(not(target_os = "android"))]
-            Self::Rfd(file_handle) => file_handle.write(data).await,
-            #[cfg(target_os = "android")]
-            Self::Android(_) => {
-                let _ = data;
-                unimplemented!("No saving on Android yet.")
-            }
-        }
-    }
-
-    pub async fn read(mut self) -> Vec<u8> {
-        match &mut self {
-            #[cfg(not(target_os = "android"))]
-            Self::Rfd(file_handle) => file_handle.read().await,
-            #[cfg(target_os = "android")]
-            Self::Android(file) => {
-                use tokio::io::AsyncReadExt;
-
-                let mut buf = vec![];
-                file.read_to_end(&mut buf).await.unwrap();
-                buf
-            }
-        }
-    }
-}
+use tokio::io::{AsyncRead, BufReader};
 
 /// Pick a file and return the name & bytes of the file.
-pub async fn pick_file() -> Result<FileHandle> {
+pub async fn pick_file() -> Result<impl AsyncRead + Unpin> {
     #[cfg(not(target_os = "android"))]
     {
         let file = rfd::AsyncFileDialog::new()
             .pick_file()
             .await
             .context("No file selected")?;
-        Ok(FileHandle::Rfd(file))
+
+        #[cfg(target_family = "wasm")]
+        {
+            Ok(Cursor::new(file.read().await))
+        }
+
+        #[cfg(not(target_family = "wasm"))]
+        {
+            let file = tokio::fs::File::open(file.path())
+                .await
+                .expect("Internal file picking error");
+            Ok(BufReader::new(file))
+        }
     }
 
     #[cfg(target_os = "android")]
     {
-        android::pick_file().await.map(FileHandle::Android)
+        let file = android::pick_file().await?;
+        BufReader::new(file)
     }
 }
 
@@ -79,7 +57,7 @@ pub async fn pick_directory() -> Result<PathBuf> {
 /// Saves data to a file and returns the filename the data was saved too.
 ///
 /// Nb: Does not work on Android currently.
-pub async fn save_file(default_name: &str) -> Result<FileHandle> {
+pub async fn save_file(default_name: &str, data: Vec<u8>) -> Result<()> {
     #[cfg(not(target_os = "android"))]
     {
         let file = rfd::AsyncFileDialog::new()
@@ -87,7 +65,14 @@ pub async fn save_file(default_name: &str) -> Result<FileHandle> {
             .save_file()
             .await
             .context("No file selected")?;
-        Ok(FileHandle::Rfd(file))
+
+        #[cfg(not(target_family = "wasm"))]
+        tokio::fs::write(file.path(), data).await?;
+
+        #[cfg(target_family = "wasm")]
+        file.write(data);
+
+        Ok(())
     }
 
     #[cfg(target_os = "android")]


### PR DESCRIPTION
- Edit VFS to consistently be case insenstive a la mac and windows
- Unload memory while importing splats
- Single file loading now properly is a tokio async file instead of doing a full read first.