### PR TITLE
Improve training steps per second accuracy

### DIFF
--- a/crates/brush-ui/src/stats.rs
+++ b/crates/brush-ui/src/stats.rs
@@ -94,7 +94,11 @@ impl AppPane for StatsPanel {
                 self.num_splats = splats.num_splats();
                 let current_iter_per_s = (iter - self.last_train_step.1) as f32
                     / (*total_elapsed - self.last_train_step.0).as_secs_f32();
-                self.train_iter_per_s = 0.95 * self.train_iter_per_s + 0.05 * current_iter_per_s;
+                self.train_iter_per_s = if *iter < 16 {
+                    current_iter_per_s
+                } else {
+                    0.95 * self.train_iter_per_s + 0.05 * current_iter_per_s
+                };
                 self.last_train_step = (*total_elapsed, *iter);
             }
             ProcessMessage::EvalResult {


### PR DESCRIPTION
Originally, the steps per second displayed in, e.g., the GUI are way too low during early training iterations. This adds a warmup period of 16 iterations to fix that. As a result, the number now better reflects how much the GPU goes Brrr.