### PR TITLE
Fix args.txt round-trip for Vec args

### DIFF
--- a/crates/brush-process/src/args_file.rs
+++ b/crates/brush-process/src/args_file.rs
@@ -85,8 +85,21 @@ pub fn config_to_args(config: &TrainStreamConfig) -> Vec<String> {
                 Value::Number(n) => {
                     args.push(format!("{arg_name} {n}"));
                 }
+                Value::Array(items) => {
+                    // Multi-value clap args (e.g. `num_args = 3`) need each element
+                    // as its own whitespace-separated token, since downstream parsing
+                    // splits on whitespace.
+                    let joined = items
+                        .iter()
+                        .map(|v| match v {
+                            Value::String(s) => s.clone(),
+                            other => other.to_string(),
+                        })
+                        .collect::<Vec<_>>()
+                        .join(" ");
+                    args.push(format!("{arg_name} {joined}"));
+                }
                 _ => {
-                    // For other types, use the JSON representation
                     args.push(format!("{arg_name} {value}"));
                 }
             }
@@ -147,6 +160,14 @@ mod tests {
         );
         assert!(args_str.contains("--sh-degree 2"), "Missing sh-degree");
         assert!(args_str.contains("--max-frames 10"), "Missing max-frames");
+    }
+
+    #[wasm_bindgen_test(unsupported = test)]
+    fn test_config_to_args_vec_round_trip() {
+        let mut config = TrainStreamConfig::default();
+        config.train_config.background_color = vec![1.0, 0.5, 0.25];
+        let merged = merge_configs(&config, &TrainStreamConfig::default());
+        assert_eq!(merged.train_config.background_color, vec![1.0, 0.5, 0.25]);
     }
 
     #[wasm_bindgen_test(unsupported = test)]


### PR DESCRIPTION
## Summary

`config_to_args` had no case for `Value::Array`, so it fell through to the generic formatter and emitted `--background-color [1.0,0.5,0.25]` (with literal brackets). Clap can't parse that, which broke two user-visible paths:

- **Settings popup → Save** wrote an unparseable `args.txt`. Next load, `load_config_from_vfs` silently dropped it (`try_parse_from(...).ok()`).
- **`merge_configs`** re-serialized initial + CLI configs, failed to re-parse, and fell back to `cli_config.clone()` — silently discarding every value from `args.txt`.

Fix: handle `Value::Array` by space-joining elements so each becomes its own token after `split_whitespace`.