### PR TITLE
Trim training config and fix settings slider ranges

### DIFF
--- a/apps/brush-app/src/ui/settings_popup.rs
+++ b/apps/brush-app/src/ui/settings_popup.rs
@@ -141,7 +141,7 @@ pub(crate) fn draw_settings(ui: &mut Ui, args: &mut TrainStreamConfig, enabled: 
         slider(
             ui,
             &mut tc.growth_grad_threshold,
-            0.0001..=0.001,
+            1e-4..=1e-2,
             "Growth threshold",
             true,
             enabled,
@@ -149,7 +149,7 @@ pub(crate) fn draw_settings(ui: &mut Ui, args: &mut TrainStreamConfig, enabled: 
         slider(
             ui,
             &mut tc.growth_select_fraction,
-            0.01..=0.2,
+            0.0..=1.0,
             "Growth selection fraction",
             false,
             enabled,
@@ -159,6 +159,14 @@ pub(crate) fn draw_settings(ui: &mut Ui, args: &mut TrainStreamConfig, enabled: 
             &mut tc.growth_stop_iter,
             5000..=20000,
             "Growth stop iteration",
+            false,
+            enabled,
+        );
+        slider(
+            ui,
+            &mut tc.split_at_screen_size,
+            0.0..=1.0,
+            "Split at screen size (0 disables)",
             false,
             enabled,
         );

--- a/crates/brush-train/src/config.rs
+++ b/crates/brush-train/src/config.rs
@@ -87,10 +87,6 @@ pub struct TrainConfig {
     #[arg(long, help_heading = "Training options", default_value = "0.002")]
     pub scale_decay: f32,
 
-    /// How long to apply aux losses and augementations for (1 being the full training duration).
-    #[arg(long, help_heading = "Training options", default_value = "0.8")]
-    pub aux_loss_time: f32,
-
     /// Weight of l1 loss on alpha if input view has transparency.
     #[arg(long, help_heading = "Refine options", default_value = "0.1")]
     pub match_alpha_weight: f32,
@@ -128,11 +124,6 @@ pub struct TrainConfig {
     /// Percentage to scale source images at each LOD level (1-100).
     #[arg(long, help_heading = "LOD options", default_value = "50")]
     pub lod_image_scale: u32,
-
-    /// Reduce optimizer memory by storing a scalar second moment per Gaussian
-    /// instead of per-element. Cuts optimizer state memory roughly in half.
-    #[arg(long, help_heading = "Training options", default_value = "false")]
-    pub reduce_second_moment: bool,
 
     /// Scene scale used for random splat initialization.
     /// When no init is provided, splats are randomly placed

--- a/crates/brush-train/src/train.rs
+++ b/crates/brush-train/src/train.rs
@@ -245,7 +245,7 @@ impl SplatTrainer {
                     AdaptorRecord::from_state(AdamState {
                         momentum: None,
                         scaling: Some(sh_lr_scales),
-                        reduce_moment_2: self.config.reduce_second_moment,
+                        reduce_moment_2: true,
                     }),
                 )]))
             });


### PR DESCRIPTION
- Remove unused `aux_loss_time` field (dead code — defined with a doc comment but never read anywhere in `crates/` or `apps/`).
- Remove `reduce_second_moment` field and hardcode `reduce_moment_2: true` in the optimizer setup, so the ~half optimizer-state memory reduction is always on.
- Settings UI: add a slider for `split_at_screen_size`; fix `growth_grad_threshold` (`1e-4..=1e-2`) and `growth_select_fraction` (`0.0..=1.0`) ranges so their defaults (0.0025 / 0.25) fall inside the slider range instead of pegged past the max.
