### PR TITLE
bench: use autodiff device for backward/training benches

### DIFF
--- a/crates/brush-bench-test/src/benches.rs
+++ b/crates/brush-bench-test/src/benches.rs
@@ -256,7 +256,7 @@ mod backward_rendering {
 
     #[divan::bench(args = [1_000_000, 2_000_000, 5_000_000])]
     fn render_grad_1080p(bencher: divan::Bencher, splat_count: usize) {
-        let device: Device = WgpuDevice::default().into();
+        let device = Device::from(WgpuDevice::default()).autodiff();
         bencher.bench_local(move || {
             block_on(async {
                 run_backward_render(&device, splat_count, (1920, 1080), ITERS_PER_SYNC).await;
@@ -267,7 +267,7 @@ mod backward_rendering {
 
     #[divan::bench(args = RESOLUTIONS)]
     fn render_grad_2m_splats(bencher: divan::Bencher, (width, height): (u32, u32)) {
-        let device: Device = WgpuDevice::default().into();
+        let device = Device::from(WgpuDevice::default()).autodiff();
         bencher.bench_local(move || {
             block_on(async {
                 run_backward_render(&device, 2_000_000, (width, height), ITERS_PER_SYNC).await;
@@ -289,7 +289,7 @@ mod training {
 
     #[divan::bench(args = SPLAT_COUNTS)]
     fn train_steps(splat_count: usize) {
-        let device: Device = WgpuDevice::default().into();
+        let device = Device::from(WgpuDevice::default()).autodiff();
         block_on(async {
             run_training_steps(&device, splat_count, (1920, 1080), ITERS_PER_SYNC).await;
             device.sync().expect("Failed to sync");


### PR DESCRIPTION
## Summary
- `render_grad_1080p`, `render_grad_2m_splats`, and `train_steps` all route through `brush_render_bwd::render_splats`, which asserts `device.is_autodiff()` and panics otherwise.
- Their device was built with a plain `WgpuDevice::default().into()`, so every backward/training bench panicked at runtime.
- Construct the device via `Device::from(WgpuDevice::default()).autodiff()` (matching the test setup).