### PR TITLE
Patch burn to the shared-tensor fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,7 +250,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
  "x11rb",
 ]
 
@@ -741,7 +741,7 @@ dependencies = [
  "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1307,7 +1307,7 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 [[package]]
 name = "burn"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn#27964e0160e6f4172618ca7bc2d5d01039c7991f"
+source = "git+https://github.com/tracel-ai/burn?branch=fix%2Fshared-tensor#a39049cc3924f193cb25172f2ec0468d36196af0"
 dependencies = [
  "burn-autodiff",
  "burn-core",
@@ -1323,7 +1323,7 @@ dependencies = [
 [[package]]
 name = "burn-autodiff"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn#27964e0160e6f4172618ca7bc2d5d01039c7991f"
+source = "git+https://github.com/tracel-ai/burn?branch=fix%2Fshared-tensor#a39049cc3924f193cb25172f2ec0468d36196af0"
 dependencies = [
  "burn-backend",
  "burn-std",
@@ -1341,7 +1341,7 @@ dependencies = [
 [[package]]
 name = "burn-backend"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn#27964e0160e6f4172618ca7bc2d5d01039c7991f"
+source = "git+https://github.com/tracel-ai/burn?branch=fix%2Fshared-tensor#a39049cc3924f193cb25172f2ec0468d36196af0"
 dependencies = [
  "burn-std",
  "bytemuck",
@@ -1360,7 +1360,7 @@ dependencies = [
 [[package]]
 name = "burn-backend-extension"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn#27964e0160e6f4172618ca7bc2d5d01039c7991f"
+source = "git+https://github.com/tracel-ai/burn?branch=fix%2Fshared-tensor#a39049cc3924f193cb25172f2ec0468d36196af0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1370,7 +1370,7 @@ dependencies = [
 [[package]]
 name = "burn-core"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn#27964e0160e6f4172618ca7bc2d5d01039c7991f"
+source = "git+https://github.com/tracel-ai/burn?branch=fix%2Fshared-tensor#a39049cc3924f193cb25172f2ec0468d36196af0"
 dependencies = [
  "ahash",
  "bincode",
@@ -1403,7 +1403,7 @@ dependencies = [
 [[package]]
 name = "burn-cpu"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn#27964e0160e6f4172618ca7bc2d5d01039c7991f"
+source = "git+https://github.com/tracel-ai/burn?branch=fix%2Fshared-tensor#a39049cc3924f193cb25172f2ec0468d36196af0"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -1414,7 +1414,7 @@ dependencies = [
 [[package]]
 name = "burn-cubecl"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn#27964e0160e6f4172618ca7bc2d5d01039c7991f"
+source = "git+https://github.com/tracel-ai/burn?branch=fix%2Fshared-tensor#a39049cc3924f193cb25172f2ec0468d36196af0"
 dependencies = [
  "burn-backend",
  "burn-cubecl-fusion",
@@ -1433,7 +1433,7 @@ dependencies = [
 [[package]]
 name = "burn-cubecl-fusion"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn#27964e0160e6f4172618ca7bc2d5d01039c7991f"
+source = "git+https://github.com/tracel-ai/burn?branch=fix%2Fshared-tensor#a39049cc3924f193cb25172f2ec0468d36196af0"
 dependencies = [
  "burn-backend",
  "burn-fusion",
@@ -1450,7 +1450,7 @@ dependencies = [
 [[package]]
 name = "burn-cuda"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn#27964e0160e6f4172618ca7bc2d5d01039c7991f"
+source = "git+https://github.com/tracel-ai/burn?branch=fix%2Fshared-tensor#a39049cc3924f193cb25172f2ec0468d36196af0"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -1461,7 +1461,7 @@ dependencies = [
 [[package]]
 name = "burn-dataset"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn#27964e0160e6f4172618ca7bc2d5d01039c7991f"
+source = "git+https://github.com/tracel-ai/burn?branch=fix%2Fshared-tensor#a39049cc3924f193cb25172f2ec0468d36196af0"
 dependencies = [
  "csv",
  "derive-new",
@@ -1485,7 +1485,7 @@ dependencies = [
 [[package]]
 name = "burn-derive"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn#27964e0160e6f4172618ca7bc2d5d01039c7991f"
+source = "git+https://github.com/tracel-ai/burn?branch=fix%2Fshared-tensor#a39049cc3924f193cb25172f2ec0468d36196af0"
 dependencies = [
  "derive-new",
  "proc-macro2",
@@ -1496,7 +1496,7 @@ dependencies = [
 [[package]]
 name = "burn-dispatch"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn#27964e0160e6f4172618ca7bc2d5d01039c7991f"
+source = "git+https://github.com/tracel-ai/burn?branch=fix%2Fshared-tensor#a39049cc3924f193cb25172f2ec0468d36196af0"
 dependencies = [
  "burn-autodiff",
  "burn-backend",
@@ -1513,7 +1513,7 @@ dependencies = [
 [[package]]
 name = "burn-flex"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn#27964e0160e6f4172618ca7bc2d5d01039c7991f"
+source = "git+https://github.com/tracel-ai/burn?branch=fix%2Fshared-tensor#a39049cc3924f193cb25172f2ec0468d36196af0"
 dependencies = [
  "aligned-vec",
  "burn-backend",
@@ -1531,7 +1531,7 @@ dependencies = [
 [[package]]
 name = "burn-fusion"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn#27964e0160e6f4172618ca7bc2d5d01039c7991f"
+source = "git+https://github.com/tracel-ai/burn?branch=fix%2Fshared-tensor#a39049cc3924f193cb25172f2ec0468d36196af0"
 dependencies = [
  "burn-backend",
  "burn-ir",
@@ -1548,7 +1548,7 @@ dependencies = [
 [[package]]
 name = "burn-ir"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn#27964e0160e6f4172618ca7bc2d5d01039c7991f"
+source = "git+https://github.com/tracel-ai/burn?branch=fix%2Fshared-tensor#a39049cc3924f193cb25172f2ec0468d36196af0"
 dependencies = [
  "burn-backend",
  "hashbrown 0.16.1",
@@ -1558,7 +1558,7 @@ dependencies = [
 [[package]]
 name = "burn-ndarray"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn#27964e0160e6f4172618ca7bc2d5d01039c7991f"
+source = "git+https://github.com/tracel-ai/burn?branch=fix%2Fshared-tensor#a39049cc3924f193cb25172f2ec0468d36196af0"
 dependencies = [
  "atomic_float",
  "burn-autodiff",
@@ -1584,7 +1584,7 @@ dependencies = [
 [[package]]
 name = "burn-nn"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn#27964e0160e6f4172618ca7bc2d5d01039c7991f"
+source = "git+https://github.com/tracel-ai/burn?branch=fix%2Fshared-tensor#a39049cc3924f193cb25172f2ec0468d36196af0"
 dependencies = [
  "burn-core",
  "num-traits",
@@ -1593,7 +1593,7 @@ dependencies = [
 [[package]]
 name = "burn-optim"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn#27964e0160e6f4172618ca7bc2d5d01039c7991f"
+source = "git+https://github.com/tracel-ai/burn?branch=fix%2Fshared-tensor#a39049cc3924f193cb25172f2ec0468d36196af0"
 dependencies = [
  "burn-core",
  "derive-new",
@@ -1606,7 +1606,7 @@ dependencies = [
 [[package]]
 name = "burn-rl"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn#27964e0160e6f4172618ca7bc2d5d01039c7991f"
+source = "git+https://github.com/tracel-ai/burn?branch=fix%2Fshared-tensor#a39049cc3924f193cb25172f2ec0468d36196af0"
 dependencies = [
  "burn-core",
  "derive-new",
@@ -1617,7 +1617,7 @@ dependencies = [
 [[package]]
 name = "burn-rocm"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn#27964e0160e6f4172618ca7bc2d5d01039c7991f"
+source = "git+https://github.com/tracel-ai/burn?branch=fix%2Fshared-tensor#a39049cc3924f193cb25172f2ec0468d36196af0"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -1628,7 +1628,7 @@ dependencies = [
 [[package]]
 name = "burn-std"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn#27964e0160e6f4172618ca7bc2d5d01039c7991f"
+source = "git+https://github.com/tracel-ai/burn?branch=fix%2Fshared-tensor#a39049cc3924f193cb25172f2ec0468d36196af0"
 dependencies = [
  "bytemuck",
  "bytes",
@@ -1652,7 +1652,7 @@ dependencies = [
 [[package]]
 name = "burn-store"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn#27964e0160e6f4172618ca7bc2d5d01039c7991f"
+source = "git+https://github.com/tracel-ai/burn?branch=fix%2Fshared-tensor#a39049cc3924f193cb25172f2ec0468d36196af0"
 dependencies = [
  "burn-core",
  "byteorder",
@@ -1672,7 +1672,7 @@ dependencies = [
 [[package]]
 name = "burn-tch"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn#27964e0160e6f4172618ca7bc2d5d01039c7991f"
+source = "git+https://github.com/tracel-ai/burn?branch=fix%2Fshared-tensor#a39049cc3924f193cb25172f2ec0468d36196af0"
 dependencies = [
  "burn-backend",
  "cc",
@@ -1685,7 +1685,7 @@ dependencies = [
 [[package]]
 name = "burn-tensor"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn#27964e0160e6f4172618ca7bc2d5d01039c7991f"
+source = "git+https://github.com/tracel-ai/burn?branch=fix%2Fshared-tensor#a39049cc3924f193cb25172f2ec0468d36196af0"
 dependencies = [
  "burn-backend",
  "burn-dispatch",
@@ -1700,7 +1700,7 @@ dependencies = [
 [[package]]
 name = "burn-train"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn#27964e0160e6f4172618ca7bc2d5d01039c7991f"
+source = "git+https://github.com/tracel-ai/burn?branch=fix%2Fshared-tensor#a39049cc3924f193cb25172f2ec0468d36196af0"
 dependencies = [
  "async-channel",
  "burn-core",
@@ -1726,7 +1726,7 @@ dependencies = [
 [[package]]
 name = "burn-vision"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn#27964e0160e6f4172618ca7bc2d5d01039c7991f"
+source = "git+https://github.com/tracel-ai/burn?branch=fix%2Fshared-tensor#a39049cc3924f193cb25172f2ec0468d36196af0"
 dependencies = [
  "aligned-vec",
  "bon",
@@ -1748,7 +1748,7 @@ dependencies = [
 [[package]]
 name = "burn-wgpu"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn#27964e0160e6f4172618ca7bc2d5d01039c7991f"
+source = "git+https://github.com/tracel-ai/burn?branch=fix%2Fshared-tensor#a39049cc3924f193cb25172f2ec0468d36196af0"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -2199,7 +2199,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3354,7 +3354,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3846,7 +3846,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5255,15 +5255,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -5291,7 +5282,7 @@ dependencies = [
  "portable-atomic-util",
  "serde_core",
  "wasm-bindgen",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6178,7 +6169,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7208,7 +7199,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7342,7 +7333,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8911,7 +8902,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9777,7 +9768,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9796,7 +9787,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10494,7 +10485,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5f7c95348f20c1c913d72157b3c6dee6ea3e30b3d19502c5a7f6d3f160dacbf"
 dependencies = [
  "cc",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -11491,7 +11482,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11607,7 +11598,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -11616,16 +11607,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -11643,31 +11625,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -11686,22 +11651,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -11710,22 +11663,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -11734,22 +11675,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -11758,22 +11687,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winit"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,21 +90,22 @@ wgpu = { version = "29", default-features = false, features = ["naga-ir"] }
 
 serde-ply = "0.2.1"
 
-burn = { git = "https://github.com/tracel-ai/burn", features = [
+# Patched to burn PR #4962 (fix/shared-tensor).
+burn = { git = "https://github.com/tracel-ai/burn", branch = "fix/shared-tensor", features = [
     'webgpu',
     "metal",
     'extension',
 ] }
-burn-cubecl = { git = "https://github.com/tracel-ai/burn" }
-burn-ir = { git = "https://github.com/tracel-ai/burn" }
-burn-wgpu = { git = "https://github.com/tracel-ai/burn", features = [
+burn-cubecl = { git = "https://github.com/tracel-ai/burn", branch = "fix/shared-tensor" }
+burn-ir = { git = "https://github.com/tracel-ai/burn", branch = "fix/shared-tensor" }
+burn-wgpu = { git = "https://github.com/tracel-ai/burn", branch = "fix/shared-tensor", features = [
     "exclusive-memory-only",
 ] }
-burn-fusion = { git = "https://github.com/tracel-ai/burn" }
+burn-fusion = { git = "https://github.com/tracel-ai/burn", branch = "fix/shared-tensor" }
 # `pytorch` is only needed by lpips-convert (one-off weight conversion tool).
 # Enabled there directly so the main graph doesn't grow `zip 8` and its newer
 # crypto family (digest 0.11, hmac 0.13, ...).
-burn-store = { git = "https://github.com/tracel-ai/burn" }
+burn-store = { git = "https://github.com/tracel-ai/burn", branch = "fix/shared-tensor" }
 
 egui = { version = "0.34"  }
 eframe = { version = "0.34", default-features = false, features = [

--- a/apps/brush-app/src/ui/app.rs
+++ b/apps/brush-app/src/ui/app.rs
@@ -234,7 +234,7 @@ impl App {
         // Initialize all panels with runtime state
         for (_, tile) in tree.tiles.iter_mut() {
             if let egui_tiles::Tile::Pane(pane) = tile {
-                pane.get_mut().as_pane_mut().init(state, &context);
+                pane.get_mut().as_pane_mut().init(state);
             }
         }
 

--- a/apps/brush-app/src/ui/panels.rs
+++ b/apps/brush-app/src/ui/panels.rs
@@ -8,7 +8,7 @@ pub(crate) trait AppPane {
 
     /// Initialize runtime state after creation or deserialization.
     #[allow(unused_variables)]
-    fn init(&mut self, state: &RenderState, process: &UiProcess) {}
+    fn init(&mut self, state: &RenderState) {}
 
     /// Draw the pane's UI's content.
     fn ui(&mut self, ui: &mut egui::Ui, process: &UiProcess);

--- a/apps/brush-app/src/ui/scene.rs
+++ b/apps/brush-app/src/ui/scene.rs
@@ -803,9 +803,9 @@ impl AppPane for ScenePanel {
         }
     }
 
-    fn init(&mut self, state: &RenderState, process: &UiProcess) {
+    fn init(&mut self, state: &RenderState) {
         self.grid = Some(GridWidget::new(state));
-        self.backbuffer = Some(SplatBackbuffer::new(state, process.actor()));
+        self.backbuffer = Some(SplatBackbuffer::new(state));
         // Create the settings popup now that we have the base_path
         self.settings_popup = Some(Arc::new(Mutex::new(SettingsPopup::new())));
     }

--- a/apps/brush-app/src/ui/splat_backbuffer.rs
+++ b/apps/brush-app/src/ui/splat_backbuffer.rs
@@ -31,7 +31,7 @@ pub struct SplatBackbuffer {
 }
 
 impl SplatBackbuffer {
-    pub fn new(state: &eframe::egui_wgpu::RenderState, actor: Actor) -> Self {
+    pub fn new(state: &eframe::egui_wgpu::RenderState) -> Self {
         // Register splat backbuffer resources
         state
             .renderer
@@ -41,6 +41,14 @@ impl SplatBackbuffer {
                 &state.device,
                 state.target_format,
             ));
+
+        // The viewer renders on its own OS thread, separate from the
+        // trainer's `ui-process` actor, so training and preview render
+        // genuinely run in parallel. Sharing tensors across the two
+        // threads (the trainer's splats are rendered here) is safe since
+        // burn's shared-tensor handling (tracel-ai/burn#4962). The actor
+        // is owned by `pipe`; dropping the backbuffer shuts the thread down.
+        let actor = Actor::new("viewer");
 
         let pipe = AsyncMap::new(
             actor,

--- a/apps/brush-app/src/ui/stats.rs
+++ b/apps/brush-app/src/ui/stats.rs
@@ -82,7 +82,7 @@ impl AppPane for StatsPanel {
         "Stats".into()
     }
 
-    fn init(&mut self, state: &RenderState, _process: &UiProcess) {
+    fn init(&mut self, state: &RenderState) {
         self.adapter_info = Some(state.adapter.get_info());
     }
 

--- a/apps/brush-app/src/ui/ui_process.rs
+++ b/apps/brush-app/src/ui/ui_process.rs
@@ -316,10 +316,6 @@ impl UiProcess {
     pub fn burn_device(&self) -> WgpuDevice {
         self.read().burn_device.clone()
     }
-
-    pub(crate) fn actor(&self) -> Actor {
-        self.read().actor.clone()
-    }
 }
 
 struct UiProcessInner {

--- a/crates/brush-loss/src/lib.rs
+++ b/crates/brush-loss/src/lib.rs
@@ -37,7 +37,7 @@ use burn_cubecl::{
 };
 use burn_fusion::{
     Fusion, FusionHandle,
-    stream::{Operation, OperationStreams},
+    stream::{Operation, StreamId},
 };
 use burn_ir::{CustomOpIr, HandleContainer, OperationIr, OperationOutput, TensorIr};
 use glam::Vec3;
@@ -766,7 +766,7 @@ where
 {
     let client = inputs[0].client.clone();
     let out = TensorIr::uninit(client.create_empty_handle(), out_shape, out_dtype);
-    let stream = OperationStreams::with_inputs(&inputs);
+    let stream = StreamId::current();
     let desc = CustomOpIr::new(name, &inputs.map(|t| t.into_ir()), &[out]);
     let wrapped = ClosureOp {
         desc: desc.clone(),

--- a/crates/brush-render-bwd/src/burn_glue.rs
+++ b/crates/brush-render-bwd/src/burn_glue.rs
@@ -12,8 +12,8 @@ use brush_render::{
 };
 use burn::{
     backend::{
-        AutodiffBackend, Backend, BackendTensor, DispatchTensorKind, TensorMetadata,
-        TensorPrimitive,
+        AutodiffBackend, Backend, BackendTensor, DispatchTensor, DispatchTensorKind,
+        TensorMetadata,
         autodiff::{
             checkpoint::{base::Checkpointer, strategy::NoCheckpointing},
             grads::Gradients,
@@ -23,12 +23,12 @@ use burn::{
         wgpu::WgpuRuntime,
     },
     module::Param,
-    tensor::{DType, Shape, Tensor},
+    tensor::{DType, Shape, Tensor, kind::BridgeTensor},
 };
 use burn_cubecl::fusion::FusionCubeRuntime;
 use burn_fusion::{
     Fusion, FusionHandle,
-    stream::{Operation, OperationStreams},
+    stream::{Operation, StreamId},
 };
 use burn_ir::{CustomOpIr, HandleContainer, OperationIr, OperationOutput, TensorIr};
 use glam::Vec3;
@@ -180,13 +180,13 @@ pub struct SplatOutputDiff {
 /// at `None`. Without that field set, ops on the resulting tensor hit
 /// `unreachable!("Should only be called with autodiff.")`.
 pub fn lift_to_autodiff<const D: usize>(t: Tensor<D>) -> Tensor<D> {
-    let dispatch = t.into_primitive().tensor();
+    let dispatch: DispatchTensor = t.into_primitive().into();
     match dispatch.kind {
         DispatchTensorKind::Wgpu(BackendTensor::Float(inner)) => {
             wrap_ad_wgpu_float(<AutodiffMain as AutodiffBackend>::from_inner(inner))
         }
         // Already autodiff — no-op.
-        DispatchTensorKind::Autodiff(_) => Tensor::from_primitive(TensorPrimitive::Float(dispatch)),
+        DispatchTensorKind::Autodiff(_) => Tensor::from_primitive(BridgeTensor::Float(dispatch)),
         _ => panic!("expected Wgpu tensor to lift to autodiff"),
     }
 }
@@ -370,7 +370,7 @@ impl SplatBwdOps<Self> for Fusion<MainBackendBase> {
                 Shape::new([num_visible, 10]),
                 DType::F32,
             );
-            let stream = OperationStreams::with_inputs(&input_tensors);
+            let stream = StreamId::current();
             let desc = CustomOpIr::new(
                 "rasterize_bwd",
                 &input_tensors.map(|t| t.into_ir()),
@@ -465,7 +465,7 @@ impl SplatBwdOps<Self> for Fusion<MainBackendBase> {
                 DType::F32,
             );
 
-            let stream = OperationStreams::with_inputs(&input_tensors);
+            let stream = StreamId::current();
             let desc = CustomOpIr::new(
                 "project_bwd",
                 &input_tensors.map(|t| t.into_ir()),

--- a/crates/brush-render/src/burn_glue.rs
+++ b/crates/brush-render/src/burn_glue.rs
@@ -2,15 +2,16 @@
 
 use burn::backend::{
     Autodiff, BackendTensor, CheckpointingStrategy, DispatchTensor, DispatchTensorKind,
-    TensorMetadata, TensorPrimitive,
+    TensorMetadata,
     tensor::{FloatTensor, IntTensor},
 };
+use burn::tensor::kind::BridgeTensor;
 use burn::tensor::{DType, Int, Tensor};
 use burn_cubecl::fusion::FusionCubeRuntime;
 use burn_cubecl::tensor::CubeTensor;
 use burn_fusion::{
     Fusion, FusionHandle,
-    stream::{Operation, OperationStreams},
+    stream::{Operation, StreamId},
 };
 use burn_ir::{CustomOpIr, HandleContainer, OperationIr, OperationOutput, TensorIr};
 use burn_wgpu::WgpuRuntime;
@@ -40,7 +41,8 @@ pub type AutodiffMain = Autodiff<MainBackend>;
 /// Extract the inner fusion-Wgpu float tensor from a non-autodiff
 /// `Tensor<D>`.
 pub fn unwrap_wgpu_float<const D: usize>(t: Tensor<D>) -> FloatTensor<MainBackend> {
-    match t.into_primitive().tensor().kind {
+    let dispatch: DispatchTensor = t.into_primitive().into();
+    match dispatch.kind {
         DispatchTensorKind::Wgpu(bt) => bt.float(),
         other => panic!(
             "expected Wgpu tensor, got: {:?}",
@@ -52,7 +54,8 @@ pub fn unwrap_wgpu_float<const D: usize>(t: Tensor<D>) -> FloatTensor<MainBacken
 /// Extract the inner fusion-Wgpu int tensor from a non-autodiff
 /// `Tensor<D, Int>`.
 pub fn unwrap_wgpu_int<const D: usize>(t: Tensor<D, Int>) -> IntTensor<MainBackend> {
-    match t.into_primitive().kind {
+    let dispatch: DispatchTensor = t.into_primitive().into();
+    match dispatch.kind {
         DispatchTensorKind::Wgpu(bt) => bt.int(),
         other => panic!(
             "expected Wgpu int tensor, got: {:?}",
@@ -64,7 +67,7 @@ pub fn unwrap_wgpu_int<const D: usize>(t: Tensor<D, Int>) -> IntTensor<MainBacke
 /// Inverse of [`unwrap_wgpu_float`]: wraps a fusion-Wgpu float tensor as a
 /// user-facing `Tensor<D>`.
 pub fn wrap_wgpu_float<const D: usize>(t: FloatTensor<MainBackend>) -> Tensor<D> {
-    Tensor::from_primitive(TensorPrimitive::Float(DispatchTensor {
+    Tensor::from_primitive(BridgeTensor::Float(DispatchTensor {
         kind: DispatchTensorKind::Wgpu(BackendTensor::Float(t)),
         checkpointing: None,
     }))
@@ -72,16 +75,16 @@ pub fn wrap_wgpu_float<const D: usize>(t: FloatTensor<MainBackend>) -> Tensor<D>
 
 /// Like [`wrap_wgpu_float`] for an int tensor.
 pub fn wrap_wgpu_int<const D: usize>(t: IntTensor<MainBackend>) -> Tensor<D, Int> {
-    Tensor::from_primitive(DispatchTensor {
+    Tensor::from_primitive(BridgeTensor::Int(DispatchTensor {
         kind: DispatchTensorKind::Wgpu(BackendTensor::Int(t)),
         checkpointing: None,
-    })
+    }))
 }
 
 /// Extract the inner `AutodiffTensor<MainBackend>` from a `Tensor<D>` on an
 /// autodiff-enabled Wgpu device. Panics on any other shape.
 pub fn unwrap_ad_wgpu_float<const D: usize>(t: Tensor<D>) -> FloatTensor<AutodiffMain> {
-    let prim = t.into_primitive().tensor();
+    let prim: DispatchTensor = t.into_primitive().into();
     match prim.kind {
         DispatchTensorKind::Autodiff(inner) => match *inner {
             DispatchTensorKind::Wgpu(BackendTensor::Autodiff(t)) => t,
@@ -100,7 +103,8 @@ pub fn unwrap_ad_wgpu_float<const D: usize>(t: Tensor<D>) -> FloatTensor<Autodif
 /// Extract the inner Wgpu `IntTensor` regardless of whether the tensor is
 /// wrapped in an autodiff device — ints are never autodiff-tracked.
 pub fn unwrap_ad_wgpu_int<const D: usize>(t: Tensor<D, Int>) -> IntTensor<MainBackend> {
-    let kind = match t.into_primitive().kind {
+    let dispatch: DispatchTensor = t.into_primitive().into();
+    let kind = match dispatch.kind {
         DispatchTensorKind::Autodiff(inner) => *inner,
         other => other,
     };
@@ -116,7 +120,7 @@ pub fn unwrap_ad_wgpu_int<const D: usize>(t: Tensor<D, Int>) -> IntTensor<MainBa
 /// Inverse of [`unwrap_ad_wgpu_float`]: wraps an autodiff tensor as a
 /// user-facing `Tensor<D>` on the autodiff device.
 pub fn wrap_ad_wgpu_float<const D: usize>(t: FloatTensor<AutodiffMain>) -> Tensor<D> {
-    Tensor::from_primitive(TensorPrimitive::Float(DispatchTensor {
+    Tensor::from_primitive(BridgeTensor::Float(DispatchTensor {
         kind: DispatchTensorKind::Autodiff(Box::new(DispatchTensorKind::Wgpu(
             BackendTensor::Autodiff(t),
         ))),
@@ -136,12 +140,12 @@ pub fn wrap_ad_wgpu_float<const D: usize>(t: FloatTensor<AutodiffMain>) -> Tenso
 /// it's combined with a tensor whose checkpointing is `None`. Using this
 /// helper instead of bare `.inner()` avoids the trap.
 pub fn detach_autodiff<const D: usize>(t: Tensor<D>) -> Tensor<D> {
-    let dispatch = t.into_primitive().tensor();
+    let dispatch: DispatchTensor = t.into_primitive().into();
     let kind = match dispatch.kind {
         DispatchTensorKind::Autodiff(inner) => *inner,
         other => other,
     };
-    Tensor::from_primitive(TensorPrimitive::Float(DispatchTensor {
+    Tensor::from_primitive(BridgeTensor::Float(DispatchTensor {
         kind,
         checkpointing: None,
     }))
@@ -149,15 +153,15 @@ pub fn detach_autodiff<const D: usize>(t: Tensor<D>) -> Tensor<D> {
 
 /// Like [`detach_autodiff`] for `Tensor<D, Int>`.
 pub fn detach_autodiff_int<const D: usize>(t: Tensor<D, Int>) -> Tensor<D, Int> {
-    let dispatch = t.into_primitive();
+    let dispatch: DispatchTensor = t.into_primitive().into();
     let kind = match dispatch.kind {
         DispatchTensorKind::Autodiff(inner) => *inner,
         other => other,
     };
-    Tensor::from_primitive(DispatchTensor {
+    Tensor::from_primitive(BridgeTensor::Int(DispatchTensor {
         kind,
         checkpointing: None,
-    })
+    }))
 }
 
 /// Resolve a `Tensor<D>` on a Wgpu device down to the underlying
@@ -294,7 +298,7 @@ impl SplatOps<Self> for Fusion<MainBackendBase> {
             DType::U32,
         );
 
-        let stream = OperationStreams::default();
+        let stream = StreamId::current();
         let desc = CustomOpIr::new(
             "render_bind",
             &[],


### PR DESCRIPTION
Points the burn git deps at [tracel-ai/burn#4962](https://github.com/tracel-ai/burn/pull/4962) (`fix/shared-tensor`), adapts brush's burn glue to its reworked dispatch/shared-tensor layer, and uses the now-safe cross-thread tensor sharing to give the viewer its own render thread.
