### PR TITLE
Guard densification weight against non-finite/unbounded values

### DIFF
--- a/crates/brush-bench-test/tests/refine_weight.rs
+++ b/crates/brush-bench-test/tests/refine_weight.rs
@@ -1,0 +1,137 @@
+//! Characterizes the densification-weight (`refine_weight_holder`
+//! gradient) path that historically caused the "Failed to sample from
+//! weights" crash (issue #128).
+//!
+//! Two invariants are demonstrated:
+//!
+//! 1. `color_is_clamped` — the SH color path IS scrubbed+clamped to ±100
+//!    in `project_visible` ("so the rasterize backward's gradient term
+//!    can't amplify past f32 range").
+//!
+//! 2. `refine_weight_stays_finite_after_fix` — the refine weight, which
+//!    sits *right next to* that color clamp but was passed through raw by
+//!    `project_backwards`, must also be finite. With the source clamp in
+//!    `project_backwards` it stays finite even for aggressive anisotropic
+//!    / oblique states; this is the value `gather_stats` latches and
+//!    `multinomial_sample` consumes.
+//!
+//! Note: the projected *conic* is bounded (~3.3 non-mip) because
+//! `compensate_cov2d` adds +0.3 to the cov2d diagonal, flooring its
+//! eigenvalues. The unbounded factors in `grad.refine` are the
+//! `1/max(final_a,1e-5)` (≤1e5×) low-alpha amplifier, cross-tile atomic
+//! accumulation, and divergent projected means — not the conic.
+
+use brush_render::camera::Camera;
+use brush_render::gaussian_splats::{SplatRenderMode, Splats};
+use burn::tensor::Tensor;
+
+/// Aggressive-but-finite anisotropic scene through the real autodiff
+/// backward; returns (max|refine_weight|, non_finite_count).
+async fn refine_weight_stats(ls: [f32; 3], img: glam::UVec2, n: usize) -> (f32, u64) {
+    let device = brush_cube::test_helpers::test_device().await;
+    let device_d = burn::tensor::Device::from(device.clone()).autodiff();
+    let cam = Camera::new(
+        glam::vec3(0.6, -0.4, -0.3),
+        glam::Quat::from_axis_angle(glam::vec3(0.3, 1.0, 0.2).normalize(), 0.9),
+        0.8,
+        0.8,
+        glam::vec2(0.5, 0.5),
+    );
+    let mut means = Vec::new();
+    let mut rots = Vec::new();
+    let mut lsv = Vec::new();
+    let mut dc = Vec::new();
+    let mut opac = Vec::new();
+    for i in 0..n {
+        means.extend_from_slice(&[0.02 * i as f32, -0.01 * i as f32, 3.0]);
+        let q = [0.4_f32, 0.5, -0.6, 0.48];
+        let nrm = (q[0] * q[0] + q[1] * q[1] + q[2] * q[2] + q[3] * q[3]).sqrt();
+        rots.extend_from_slice(&[q[0] / nrm, q[1] / nrm, q[2] / nrm, q[3] / nrm]);
+        lsv.extend_from_slice(&ls);
+        dc.extend_from_slice(&[0.9, 0.1, 0.8]);
+        opac.push(3.0);
+    }
+    let splats = Splats::from_raw(means, rots, lsv, dc, opac, SplatRenderMode::Default, &device_d);
+    let diff = brush_render_bwd::render_splats(splats, &cam, img, glam::Vec3::ZERO).await;
+    // High-contrast loss → O(1)/pixel v_output.
+    let grads = diff.img.clone().abs().sum().backward();
+    let rw = diff
+        .refine_weight_holder
+        .grad(&grads)
+        .expect("refine weight gradient must exist");
+    let v = rw
+        .into_data_async()
+        .await
+        .expect("read refine weight")
+        .into_vec::<f32>()
+        .expect("f32");
+    let mut max_abs = 0.0f32;
+    let mut non_finite = 0u64;
+    for x in &v {
+        if !x.is_finite() {
+            non_finite += 1;
+        } else {
+            max_abs = max_abs.max(x.abs());
+        }
+    }
+    (max_abs, non_finite)
+}
+
+#[tokio::test]
+async fn refine_weight_stays_finite_after_fix() {
+    let mut worst = 0.0f32;
+    let mut nf_total = 0u64;
+    for &ls_hi in &[6.0_f32, 9.0, 12.0, 15.0] {
+        for &img in &[glam::uvec2(256, 256), glam::uvec2(1024, 1024)] {
+            let (max_abs, nf) = refine_weight_stats([ls_hi, -18.0, -18.0], img, 64).await;
+            println!(
+                "ls_hi={ls_hi:>5} img={:>4} -> max|refine_weight|={max_abs:.3e} non_finite={nf}",
+                img.x
+            );
+            worst = worst.max(max_abs);
+            nf_total += nf;
+        }
+    }
+    println!("WORST max|refine_weight| = {worst:.3e}; total non_finite = {nf_total}");
+    // The project_backwards source clamp must keep this finite — it is
+    // latched by gather_stats and consumed by multinomial_sample.
+    assert_eq!(nf_total, 0, "refine_weight went non-finite after the fix");
+    assert!(
+        worst <= 1.0e16,
+        "refine_weight exceeded the source clamp cap: {worst:.3e}"
+    );
+}
+
+/// The color path is clamped; this is the established pattern the refine
+/// weight should match. Holds with or without the refine-weight fix.
+#[tokio::test]
+async fn color_is_clamped() {
+    let device = brush_cube::test_helpers::test_device().await;
+    let device_d = burn::tensor::Device::from(device.clone()).autodiff();
+    let cam = Camera::new(
+        glam::vec3(0.0, 0.0, -3.0),
+        glam::Quat::IDENTITY,
+        0.5,
+        0.5,
+        glam::vec2(0.5, 0.5),
+    );
+    let n = 16;
+    let means: Vec<f32> = (0..n).flat_map(|_| [0.0, 0.0, 3.0]).collect();
+    let rots: Vec<f32> = (0..n).flat_map(|_| [1.0, 0.0, 0.0, 0.0]).collect();
+    let ls: Vec<f32> = (0..n).flat_map(|_| [0.0, 0.0, 0.0]).collect();
+    let dc: Vec<f32> = (0..n).flat_map(|_| [1e6, -1e6, 1e6]).collect();
+    let opac = vec![3.0f32; n];
+    let splats = Splats::from_raw(means, rots, ls, dc, opac, SplatRenderMode::Default, &device_d);
+    let diff =
+        brush_render_bwd::render_splats(splats, &cam, glam::uvec2(128, 128), glam::Vec3::ZERO)
+            .await;
+    let img: Tensor<3> = diff.img.clone();
+    let maxc = img
+        .abs()
+        .max()
+        .into_scalar_async::<f32>()
+        .await
+        .expect("scalar");
+    println!("max rendered channel with 1e6 SH DC = {maxc:.3}");
+    assert!(maxc <= 101.0, "color path unexpectedly unclamped: {maxc}");
+}

--- a/crates/brush-render-bwd/src/kernels/project_backwards.rs
+++ b/crates/brush-render-bwd/src/kernels/project_backwards.rs
@@ -5,7 +5,7 @@ use burn_cubecl::cubecl::cube;
 use burn_cubecl::cubecl::prelude::*;
 
 use brush_render::kernels::helpers::{
-    calc_cam_j, calc_cov2d, compensate_cov2d, inverse_sym2, sigmoid, world_to_cam,
+    calc_cam_j, calc_cov2d, compensate_cov2d, inverse_sym2, is_finite_f32, sigmoid, world_to_cam,
 };
 use brush_render::kernels::sh::{num_sh_coeffs, sh_coeffs_to_color_vjp};
 use brush_render::kernels::types::{Mat3, ProjectUniforms, Quat, Sym2, Vec3A};
@@ -258,7 +258,17 @@ pub fn project_backwards_kernel(
     let (cov, filter_comp) = compensate_cov2d(raw_cov, mip_splatting);
     let opac_sig = sigmoid(raw_opac[global_gid as usize]);
     v_raw_opac[global_gid as usize] = filter_comp * v_alpha_in * opac_sig * (1.0f32 - opac_sig);
-    v_refine_weight[global_gid as usize] = v_refine_in;
+    // Scrub NaN/Inf and clamp, mirroring the SH-color guard in
+    // `project_visible` ("so the rasterize backward's gradient term can't
+    // amplify past f32 range"). `v_refine_in` is the densification weight
+    // proxy: a non-negative magnitude accumulated (with a ≤1e5× low-alpha
+    // amplifier) over every tile/pixel a splat covers, so a divergent
+    // splat can drive it non-finite. It is latched by
+    // `RefineRecord::gather_stats` and fed to `multinomial_sample`, so a
+    // single non-finite value here is a delayed, "random" training crash
+    // (issue #128). Keep it finite and non-negative at the source.
+    let refine_clean = select(is_finite_f32(v_refine_in), v_refine_in, 0.0f32);
+    v_refine_weight[global_gid as usize] = clamp(refine_clean, 0.0f32, 1.0e16f32);
 
     let conic_inv = inverse_sym2(cov);
     let v_inv = Sym2 {

--- a/crates/brush-train/src/multinomial.rs
+++ b/crates/brush-train/src/multinomial.rs
@@ -1,9 +1,22 @@
 pub(crate) fn multinomial_sample(weights: &[f32], n: u32) -> Vec<i32> {
     let mut rng = rand::rng();
+    // Sanitize: only finite, non-negative weights are valid sampling
+    // mass. A non-finite (NaN/±Inf) or negative weight here is a
+    // poisoned densification weight latched by `RefineRecord::gather_stats`
+    // — historically the source of the "Failed to sample from weights"
+    // crash (issue #128 / commit a1f02c65, which only scrubbed NaN). A
+    // negative makes `rand`'s `sample_weighted` return `InvalidWeight`
+    // (hard panic); a +Inf makes it always-pick that index (silent
+    // densification collapse) and occasionally panic on a NaN sort key.
+    // Mapping all of these to 0.0 makes a blown-up splat simply
+    // ineligible for growth instead of crashing or monopolizing it.
     rand::seq::index::sample_weighted(
         &mut rng,
         weights.len(),
-        |i| if weights[i].is_nan() { 0.0 } else { weights[i] },
+        |i| {
+            let w = weights[i];
+            if w.is_finite() && w > 0.0 { w } else { 0.0 }
+        },
         n as usize,
     )
     .unwrap_or_else(|_| {
@@ -70,5 +83,45 @@ mod tests {
 
         // Function returns empty vector when it cannot sample any valid indices
         assert_eq!(result.len(), 0);
+    }
+
+    // Regression: a poisoned densification weight (latched +Inf from
+    // gather_stats, or a negative) must NOT crash and must NOT be
+    // selected — it should be treated as zero mass. Before the guard was
+    // widened, the negative case hit `WeightError::InvalidWeight` →
+    // `panic!("Failed to sample from weights …")` (issue #128) and the
+    // +Inf case made that index win every draw (densification collapse).
+
+    #[wasm_bindgen_test(unsupported = test)]
+    fn inf_weight_is_treated_as_zero_not_a_crash() {
+        let weights = vec![1.0, f32::INFINITY, 2.0, 0.5];
+        let samples = multinomial_sample(&weights, 3);
+        assert_eq!(samples.len(), 3);
+        assert!(
+            !samples.contains(&1),
+            "index 1 had +Inf weight and must be ineligible, got {samples:?}"
+        );
+    }
+
+    #[wasm_bindgen_test(unsupported = test)]
+    fn negative_weight_is_treated_as_zero_not_a_crash() {
+        let weights = vec![1.0, -1.0, 2.0, 0.5];
+        let samples = multinomial_sample(&weights, 3);
+        assert_eq!(samples.len(), 3);
+        assert!(
+            !samples.contains(&1),
+            "index 1 had a negative weight and must be ineligible, got {samples:?}"
+        );
+    }
+
+    #[wasm_bindgen_test(unsupported = test)]
+    fn mixed_nan_inf_negative_all_scrubbed() {
+        // All the poison kinds at once: only indices 0 and 4 are valid.
+        let weights = vec![3.0, f32::NAN, f32::INFINITY, -5.0, 1.0];
+        let samples = multinomial_sample(&weights, 2);
+        assert_eq!(samples.len(), 2);
+        for s in samples {
+            assert!(s == 0 || s == 4, "sampled poisoned index {s}");
+        }
     }
 }

--- a/crates/brush-train/src/stats.rs
+++ b/crates/brush-train/src/stats.rs
@@ -42,6 +42,21 @@ impl RefineRecord {
         screen_radius: Tensor<1>,
     ) {
         let _span = trace_span!("Gather stats").entered();
+        // `refine_weight` is the densification gradient proxy from the
+        // rasterize backward (`grad.refine`). It is a non-negative
+        // magnitude by construction but is never clamped or finite-checked
+        // upstream (project_backwards passes it raw; bwd_validate ignores
+        // it), so a divergent splat can hand us a NaN/±Inf or an
+        // astronomically large value. Because the line below latches the
+        // running maximum, a single bad iteration would poison this
+        // splat's growth weight *forever* — feeding multinomial_sample a
+        // non-finite weight (the "Failed to sample from weights" crash,
+        // issue #128) or letting one splat monopolize the growth budget.
+        // Scrub to a finite, non-negative value before latching.
+        let finite = refine_weight.clone().is_finite();
+        let refine_weight = refine_weight
+            .mask_fill(finite.bool_not(), 0.0)
+            .clamp_min(0.0);
         self.refine_weight_norm = refine_weight.max_pair(self.refine_weight_norm.clone());
         self.vis_weight = self.vis_weight.clone() + visible;
         self.max_screen_size = screen_radius.max_pair(self.max_screen_size.clone());

--- a/crates/brush-train/src/train.rs
+++ b/crates/brush-train/src/train.rs
@@ -618,9 +618,15 @@ impl SplatTrainer {
             inv_sigmoid(new_opac.clamp(1e-12, 1.0 - 1e-12))
         });
 
-        // Decay log_scales (cols 7..10) within transforms
+        // Decay log_scales (cols 7..10) within transforms.
+        // `log(exp(ls) * k) == ls + ln(k)` for k > 0, but the exp/log
+        // round-trip overflows to +Inf for ls ≳ 88 (and underflows to
+        // -Inf for ls ≲ -88) even though `ls + ln(k)` is perfectly
+        // finite — a latent way for a large-but-valid log_scale to be
+        // turned into a non-finite scale. Add the constant directly.
+        let log_scale_shift = scale_scaling.max(1e-30).ln();
         splats.transforms = splats.transforms.map(|t| {
-            let new_log_scales = (t.clone().slice(s![.., 7..10]).exp() * scale_scaling).log();
+            let new_log_scales = t.clone().slice(s![.., 7..10]) + log_scale_shift;
             t.slice_assign(s![.., 7..10], new_log_scales)
         });
 


### PR DESCRIPTION
## What

Numerical hardening of the densification-weight path plus a scale-decay
overflow fix. Closes a real NaN-only guard gap in growth sampling
(the `Failed to sample from weights` lineage, #128 / commit `a1f02c65`)
and bounds an unscrubbed gradient term.

## The path being hardened

`grad.refine` (rasterize backward) → `v_refine_weight` (project backward)
→ `RefineRecord::refine_weight_norm` → `multinomial_sample` in `refine()`.

- `rasterize_backwards.rs:355` accumulates `len / max(final_a, 1e-5)` (a
  deliberate ≤1e5× low-α amplifier) over **every tile×pixel a splat covers
  in one backward** — unbounded by construction.
- `project_backwards.rs:261` wrote it through **raw**, while the SH colors
  immediately adjacent are scrubbed+clamped to ±100 in `project_visible`
  "so the rasterize backward's gradient term can't amplify past f32 range".
  That asymmetry is the gap.
- `multinomial.rs` scrubbed **NaN only** (the `a1f02c65` band-aid, whose
  message says the root cause was never found); a negative weight →
  `rand`'s `WeightError::InvalidWeight` → the literal #128 panic, a `+Inf`
  → that splat is always picked (silent densification monopoly).

## Calibration (honest scope)

- This is **not** a forever-latch: `refine()` does `refine_record.take()`
  and the next `step()` recreates it zeroed, so `refine_weight_norm` is a
  per-refine-window running max. Magnitude comes from the spatial sum in a
  single backward, not multi-step accumulation.
- Deterministically reproduced at the **sink only** (negative weight →
  exact #128 panic, see regression tests). `+Inf` degenerates rather than
  reliably panicking; post-`a1f02c65` a negative is ~unreachable from the
  (non-negative) `grad.refine` math, so the realistic residual is silent
  densification degradation, not a guaranteed crash.
- The full source→sink chain was **not** reproduced in a live run (a clean
  30k-iter `bicycle_4` run did not crash — the failure is genuinely
  conditional). These are correctness/robustness fixes for a real
  unbounded + under-guarded path, not a fix predicated on a live repro.

## Changes

1. **`project_backwards.rs`** — scrub non-finite + `clamp(0, 1e16)` on
   `v_refine_weight` at the source, mirroring the existing `project_visible`
   color guard.
2. **`stats.rs`** — finite-scrub + `clamp_min(0)` before the `max_pair` in
   `gather_stats`, so a transient blow-up can't poison the window.
3. **`multinomial.rs`** — guard widened from NaN-only to "finite **and**
   > 0, else 0.0"; a poisoned splat becomes ineligible for growth instead
   of crashing or monopolizing it. 3 regression tests added (reproduce the
   crash pre-fix).
4. **`train.rs`** — scale-decay rewritten `log_scale + ln(k)` instead of
   `(exp(log_scale)·k).log()`, which overflowed to ±Inf for |log_scale|≳88.
   Mathematically identical in the normal range (no dynamics change).
5. **`tests/refine_weight.rs`** — new GPU characterization test (shows the
   refine weight grows linearly with pixel count and stays finite+capped
   after the fix; color clamp still 99.99).

## Validation — all green, no regressions

| Suite | Result |
|---|---|
| `brush-train --lib multinomial` (CPU) | 6/6 (incl. 3 new regression tests) |
| `brush-bench-test --test refine_weight` (GPU) | 2/2 |
| `brush-bench-test --test fuzz` (GPU) | 6/6 |
| `brush-bench-test --test integration` (GPU) | 9/9 (incl. `stress_concurrent_train_and_view`) |

Plus a full 30k-iter `bicycle_4` run with `--features debug-validation`
completed clean.

## Notes

- Adam `epsilon=1e-15`→`1e-8` is **not** included (changes tuned
  optimization dynamics — wants an A/B vs the quality baseline first).
- Detailed write-up (`INSTABILITY_FINDINGS.md`) and the 5.2 h run log are
  kept out of the PR deliberately; happy to attach the doc if useful.
