### PR TITLE
Prevent zero interval configs from crashing training

### DIFF
--- a/crates/brush-process/src/config.rs
+++ b/crates/brush-process/src/config.rs
@@ -11,13 +11,23 @@ pub struct ProcessConfig {
     #[arg(long, help_heading = "Process options", default_value = "0")]
     pub start_iter: u32,
     /// Eval every this many steps.
-    #[arg(long, help_heading = "Process options", default_value = "1000")]
+    #[arg(
+        long,
+        help_heading = "Process options",
+        default_value = "1000",
+        value_parser = clap::value_parser!(u32).range(1..)
+    )]
     pub eval_every: u32,
     /// Save the rendered eval images to disk. Uses export-path for the file location.
     #[arg(long, help_heading = "Process options", default_value = "false")]
     pub eval_save_to_disk: bool,
     /// Export every this many steps.
-    #[arg(long, help_heading = "Process options", default_value = "5000")]
+    #[arg(
+        long,
+        help_heading = "Process options",
+        default_value = "5000",
+        value_parser = clap::value_parser!(u32).range(1..)
+    )]
     pub export_every: u32,
     /// Location to put exported files. Supports {dataset} interpolation for the dataset
     /// folder name. Path is relative to the dataset's parent directory (or CWD if unavailable).

--- a/crates/brush-rerun/src/lib.rs
+++ b/crates/brush-rerun/src/lib.rs
@@ -14,10 +14,19 @@ pub struct RerunConfig {
     #[arg(long, help_heading = "Rerun options", default_value = "false")]
     pub rerun_enabled: bool,
     /// How often to log basic training statistics.
-    #[arg(long, help_heading = "Rerun options", default_value = "50")]
+    #[arg(
+        long,
+        help_heading = "Rerun options",
+        default_value = "50",
+        value_parser = clap::value_parser!(u32).range(1..)
+    )]
     pub rerun_log_train_stats_every: u32,
     /// How often to log out the full splat point cloud to rerun (warning: heavy).
-    #[arg(long, help_heading = "Rerun options")]
+    #[arg(
+        long,
+        help_heading = "Rerun options",
+        value_parser = clap::value_parser!(u32).range(1..)
+    )]
     pub rerun_log_splats_every: Option<u32>,
     /// The maximum size of images from the dataset logged to rerun.
     #[arg(long, help_heading = "Rerun options", default_value = "512")]

--- a/crates/brush-train/src/config.rs
+++ b/crates/brush-train/src/config.rs
@@ -50,7 +50,12 @@ pub struct TrainConfig {
 
     /// Frequency of 'refinement' where gaussians are replaced and densified. This should
     /// roughly be the number of images it takes to properly "cover" your scene.
-    #[arg(long, help_heading = "Refine options", default_value = "200")]
+    #[arg(
+        long,
+        help_heading = "Refine options",
+        default_value = "200",
+        value_parser = clap::value_parser!(u32).range(1..)
+    )]
     pub refine_every: u32,
 
     /// Threshold to control splat growth. Lower means faster growth.


### PR DESCRIPTION
Adds CLI validation (`u32 >= 1`) for interval fields used by training/eval/export/rerun triggers:

- `refine_every`
- `eval_every`
- `export_every`
- `rerun_log_train_stats_every`
- `rerun_log_splats_every` (when set)

This is validation-only (no training logic changes).  
Ran `cargo fmt` and `cargo check -p brush-process -p brush-train -p brush-rerun`.