### PR TITLE
Fix rendering of splats trained with Mip splatting

### DIFF
--- a/crates/brush-serde/src/import.rs
+++ b/crates/brush-serde/src/import.rs
@@ -214,7 +214,7 @@ pub fn stream_splat_from_ply<T: AsyncRead + Unpin>(
             .filter_map(|c| {
                 match c
                     .to_lowercase()
-                    .strip_prefix("SplatRenderMode: ")
+                    .strip_prefix("splatrendermode: ")
                     .map(|s| s.trim())
                 {
                     Some("mip") => Some(SplatRenderMode::Mip),


### PR DESCRIPTION
Fixes a typo that caused PLYs trained with Mip splatting to be rendered incorrectly (issue #466).