### PR TITLE
Harden parsing + fix pause livelock + wasm32 CI for 1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,34 @@ jobs:
 
   # ---------------------------------------------------------------------------
 
+  wasm-check:
+    name: Check wasm32
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          lfs: true
+
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.93.0
+          targets: wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "v2"
+          shared-key: "brush-wasm"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          cache-workspace-crates: true
+
+      # The browser build (brush-app / brush-js cdylibs) is only compiled for
+      # wasm32; the host-only jobs above never exercise it. Check it here so a
+      # wasm-only break can't ship green.
+      - name: check wasm32 (browser crates)
+        run: cargo check --locked -p brush-app -p brush-js --lib --target wasm32-unknown-unknown
+
+  # ---------------------------------------------------------------------------
+
   cargo-deny:
     strategy:
       fail-fast: false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1027,6 +1027,7 @@ dependencies = [
  "brush-process",
  "brush-render",
  "burn",
+ "console_error_panic_hook",
  "getrandom 0.3.4",
  "getrandom 0.4.2",
  "log",

--- a/apps/brush-app/src/ui/ui_process.rs
+++ b/apps/brush-app/src/ui/ui_process.rs
@@ -216,16 +216,13 @@ impl UiProcess {
                     if matches!(train_receiver.try_recv(), Ok(ControlMessage::Paused(true))) {
                         // Pause until we're explicitly unpaused. If the control channel
                         // closed (the process was reset / replaced, dropping the sender),
-                        // `recv()` returns `None` immediately and forever — treat that as
-                        // "resume" so we don't busy-spin and wedge the single-threaded
-                        // executor (a dropped sender must never livelock the message pump).
+                        // `recv()` returns `None` immediately and forever.
                         loop {
                             match train_receiver.recv().await {
                                 Some(ControlMessage::Paused(false)) | None => break,
                                 _ => {}
                             }
-                            // Yield back to the runtime so a burst of control messages
-                            // while paused can't starve the browser event loop.
+                            // Yield back to the runtime can't starve the browser event loop.
                             brush_async::yield_now().await;
                         }
                     }

--- a/apps/brush-app/src/ui/ui_process.rs
+++ b/apps/brush-app/src/ui/ui_process.rs
@@ -214,11 +214,20 @@ impl UiProcess {
                     // Check if training is paused. Don't care about other messages as pausing loading
                     // doesn't make much sense.
                     if matches!(train_receiver.try_recv(), Ok(ControlMessage::Paused(true))) {
-                        // Pause if needed.
-                        while !matches!(
-                            train_receiver.recv().await,
-                            Some(ControlMessage::Paused(false))
-                        ) {}
+                        // Pause until we're explicitly unpaused. If the control channel
+                        // closed (the process was reset / replaced, dropping the sender),
+                        // `recv()` returns `None` immediately and forever — treat that as
+                        // "resume" so we don't busy-spin and wedge the single-threaded
+                        // executor (a dropped sender must never livelock the message pump).
+                        loop {
+                            match train_receiver.recv().await {
+                                Some(ControlMessage::Paused(false)) | None => break,
+                                _ => {}
+                            }
+                            // Yield back to the runtime so a burst of control messages
+                            // while paused can't starve the browser event loop.
+                            brush_async::yield_now().await;
+                        }
                     }
 
                     // Mark egui as needing a repaint.

--- a/apps/brush-js/Cargo.toml
+++ b/apps/brush-js/Cargo.toml
@@ -29,6 +29,7 @@ web-sys = { workspace = true, features = [
     "FileSystemDirectoryHandle",
 ] }
 wasm-logger = "0.2"
+console_error_panic_hook = "0.1"
 
 # wasm_js random backend needs to be enabled explicitly.
 getrandom = { version = "0.4", features = ["wasm_js"] }

--- a/apps/brush-js/src/lib.rs
+++ b/apps/brush-js/src/lib.rs
@@ -5,7 +5,6 @@
 use brush_process::message::{ProcessMessage, TrainMessage};
 use brush_process::slot::Slot;
 use brush_process::{DataSource, ProcessStream, burn_init_device, burn_init_setup, create_process};
-use brush_render::MainBackend;
 use brush_render::gaussian_splats::Splats;
 use serde::Serialize;
 use std::pin::Pin;
@@ -229,6 +228,11 @@ impl BrushApp {
     /// (or call `app.initExisting(...)`) before starting any training.
     #[wasm_bindgen(constructor)]
     pub fn new() -> Self {
+        // Route Rust panics to console.error with a readable message+stack
+        // instead of an opaque "unreachable executed" trap. `set_once` is
+        // idempotent, so re-init (React StrictMode, hot reload) is harmless.
+        console_error_panic_hook::set_once();
+
         // Idempotent: hosts that re-init us (React StrictMode in dev, hot
         // reloads, etc.) would otherwise hit "logger already set" each time.
         static LOGGER_INIT: std::sync::Once = std::sync::Once::new();
@@ -421,13 +425,9 @@ async fn bridge_config_callback(
 /// the WebGPU backend (which is the only backend brush-js currently
 /// supports anyway).
 fn tensor_buffer_js<const D: usize>(tensor: burn::tensor::Tensor<D>) -> Option<JsValue> {
-    use brush_render::MainBackendBase;
-
-    let fusion_tensor = tensor.into_primitive().tensor();
-    let cube_tensor = fusion_tensor
-        .client
-        .clone()
-        .resolve_tensor_float::<MainBackendBase>(fusion_tensor);
+    // Drain pending fusion ops down to a concrete Wgpu buffer via the shared
+    // burn_glue helper (keeps us off burn's churning fusion internals).
+    let cube_tensor = brush_render::burn_glue::resolve_to_cube_float::<D>(tensor);
     let resource = cube_tensor.client.get_resource(cube_tensor.handle).ok()?;
     resource.resource().buffer.as_webgpu().map(|w| w.raw_js())
 }

--- a/apps/brush-js/src/lib.rs
+++ b/apps/brush-js/src/lib.rs
@@ -425,8 +425,6 @@ async fn bridge_config_callback(
 /// the WebGPU backend (which is the only backend brush-js currently
 /// supports anyway).
 fn tensor_buffer_js<const D: usize>(tensor: burn::tensor::Tensor<D>) -> Option<JsValue> {
-    // Drain pending fusion ops down to a concrete Wgpu buffer via the shared
-    // burn_glue helper (keeps us off burn's churning fusion internals).
     let cube_tensor = brush_render::burn_glue::resolve_to_cube_float::<D>(tensor);
     let resource = cube_tensor.client.get_resource(cube_tensor.handle).ok()?;
     resource.resource().buffer.as_webgpu().map(|w| w.raw_js())

--- a/crates/brush-dataset/src/config.rs
+++ b/crates/brush-dataset/src/config.rs
@@ -6,7 +6,12 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "kebab-case")]
 pub struct ModelConfig {
     /// SH degree of splats.
-    #[arg(long, help_heading = "Model Options", default_value = "3")]
+    #[arg(
+        long,
+        help_heading = "Model Options",
+        default_value = "3",
+        value_parser = clap::value_parser!(u32).range(0..=4)
+    )]
     pub sh_degree: u32,
 }
 

--- a/crates/brush-dataset/src/formats/mod.rs
+++ b/crates/brush-dataset/src/formats/mod.rs
@@ -65,6 +65,17 @@ pub async fn load_dataset(
 
     let result = dataset?;
 
+    // A dataset that parsed but has no usable training views (e.g. every image
+    // was missing or filtered out) would otherwise "load" and then crash on the
+    // first training batch. Reject it here with a typed error instead.
+    if result.dataset.train.views.is_empty() {
+        return Err(FormatError::InvalidFormat(
+            "dataset contains no usable training views (all images missing or filtered out)"
+                .to_owned(),
+        )
+        .into());
+    }
+
     // If there's an initial ply file, override the init stream with that.
     let mut ply_paths: Vec<_> = vfs.files_with_extension("ply").collect();
     ply_paths.sort();

--- a/crates/brush-dataset/src/formats/nerfstudio.rs
+++ b/crates/brush-dataset/src/formats/nerfstudio.rs
@@ -157,6 +157,13 @@ async fn read_transforms_file(
 
         // NeRF 'transform_matrix' is a camera-to-world transform
         let transform_matrix: Vec<f32> = frame.transform_matrix.iter().flatten().copied().collect();
+        if transform_matrix.len() != 16 {
+            return Err(FormatError::InvalidFormat(format!(
+                "frame '{}' has a {}-element transform_matrix, expected a 4x4 (16 elements)",
+                frame.file_path,
+                transform_matrix.len()
+            )));
+        }
         let mut transform = glam::Mat4::from_cols_slice(&transform_matrix).transpose();
         // Swap basis to match camera format and reconstrunstion ply (if included).
         transform.y_axis *= -1.0;

--- a/crates/brush-dataset/src/scene_loader.rs
+++ b/crates/brush-dataset/src/scene_loader.rs
@@ -10,25 +10,25 @@ use crate::scene::{Scene, SceneBatch, sample_to_packed_data, view_to_sample_imag
 /// Cache budget for decoded source images. 6 GB on native; less on
 /// wasm since the whole heap is bounded by browser limits.
 #[cfg(not(target_family = "wasm"))]
-const CACHE_BUDGET_MB: usize = 6 * 1024;
+const CACHE_BUDGET_BYTES: usize = 6 * 1024 * 1024 * 1024;
 #[cfg(target_family = "wasm")]
-const CACHE_BUDGET_MB: usize = 2 * 1024;
+const CACHE_BUDGET_BYTES: usize = 2 * 1024 * 1024 * 1024;
 
 /// Shared decoded-image cache. Each slot holds at most one image; once
-/// the running total passes `budget_mb`, new images bypass the cache
+/// the running total passes `budget_bytes`, new images bypass the cache
 /// and just get re-decoded on every visit.
 struct ImageCache {
     slots: Vec<Option<Arc<DynamicImage>>>,
-    used_mb: usize,
-    budget_mb: usize,
+    used_bytes: usize,
+    budget_bytes: usize,
 }
 
 impl ImageCache {
     fn new(n_views: usize) -> Self {
         Self {
             slots: vec![None; n_views],
-            used_mb: 0,
-            budget_mb: CACHE_BUDGET_MB,
+            used_bytes: 0,
+            budget_bytes: CACHE_BUDGET_BYTES,
         }
     }
 
@@ -40,10 +40,12 @@ impl ImageCache {
         if self.slots[index].is_some() {
             return;
         }
-        let size_mb = image.as_bytes().len() / (1024 * 1024);
-        if self.used_mb + size_mb < self.budget_mb {
+        // Track exact bytes: rounding to whole MB let sub-MB images slip in
+        // for free and bypass the budget entirely.
+        let size_bytes = image.as_bytes().len();
+        if self.used_bytes + size_bytes < self.budget_bytes {
             self.slots[index] = Some(image);
-            self.used_mb += size_mb;
+            self.used_bytes += size_bytes;
         }
     }
 }

--- a/crates/brush-serde/src/import.rs
+++ b/crates/brush-serde/src/import.rs
@@ -189,7 +189,9 @@ pub fn stream_splat_from_ply<T: AsyncRead + Unpin>(
         let mut file = PlyChunkedReader::new();
         read_chunk(&mut reader, file.buffer_mut()).await?;
 
-        let header = file.header().expect("Must have header");
+        let header = file
+            .header()
+            .ok_or_else(|| DeserializeError::custom("missing PLY header"))?;
         // Parse some metadata.
         let up_axis = header
             .comments
@@ -292,7 +294,9 @@ async fn parse_ply<T: AsyncRead + Unpin>(
     render_mode: Option<SplatRenderMode>,
     update: &mut TimedUpdate,
 ) -> Result<(), DeserializeError> {
-    let header = file.header().expect("Must have header");
+    let header = file
+        .header()
+        .ok_or_else(|| DeserializeError::custom("missing PLY header"))?;
     let vertex = header
         .get_element("vertex")
         .ok_or(DeserializeError::custom("Unknown format"))?;
@@ -474,7 +478,7 @@ async fn parse_compressed_ply<T: AsyncRead + Unpin>(
 
     let sh_vals = file
         .header()
-        .expect("Must have header")
+        .ok_or_else(|| DeserializeError::custom("missing PLY header"))?
         .elem_defs
         .get(2)
         .cloned();

--- a/crates/brush-train/src/train.rs
+++ b/crates/brush-train/src/train.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 use brush_dataset::scene::SceneBatch;
-use brush_loss::{ImageLossConfig, image_loss, unpack_gt_rgb};
+use brush_loss::{ImageLossConfig, image_loss};
 use brush_render::gaussian_splats::Splats;
 use brush_render::{AlphaMode, bounding_box::BoundingBox, sh::sh_coeffs_for_degree};
 use brush_render_bwd::render_splats;
@@ -174,6 +174,9 @@ impl SplatTrainer {
             };
             let loss_map = image_loss(pred_for_loss, gt_packed.clone(), cfg);
 
+            // `loss` is only reassigned by the LPIPS path below, which is
+            // compiled out on wasm — so `mut` is unused there.
+            #[cfg_attr(target_family = "wasm", allow(unused_mut))]
             let mut loss = if do_alpha_match {
                 let rgb = loss_map.clone().slice(s![.., .., 0..3]).mean();
                 let alpha = loss_map.slice(s![.., .., 3..4]).mean();
@@ -186,7 +189,7 @@ impl SplatTrainer {
             // here costs ~99 MB at 4K, only when LPIPS is enabled.
             #[cfg(not(target_family = "wasm"))]
             if let Some(lpips) = &self.lpips {
-                let gt_rgb = unpack_gt_rgb(gt_packed.clone(), composite_bg);
+                let gt_rgb = brush_loss::unpack_gt_rgb(gt_packed.clone(), composite_bg);
                 let gt_rgb_diff: Tensor<3> = Tensor::from_inner(gt_rgb);
                 loss = loss
                     + lpips.lpips(

--- a/crates/brush-vfs/src/lib.rs
+++ b/crates/brush-vfs/src/lib.rs
@@ -57,7 +57,9 @@ impl PathKey {
     }
 
     fn from_path(path: &Path) -> Self {
-        Self::from_str(path.clean().to_str().expect("Invalid path"))
+        // Lossily convert rather than panicking on non-UTF-8 filenames; the key
+        // is only used for case-insensitive lookups.
+        Self::from_str(&path.clean().to_string_lossy())
     }
 }
 

--- a/crates/colmap-reader/src/lib.rs
+++ b/crates/colmap-reader/src/lib.rs
@@ -430,7 +430,6 @@ async fn read_images_binary<R: AsyncBufRead + Unpin>(
         let point_data = if with_points {
             // `num_points2d` comes straight from the file; don't pre-allocate
             // from it or a hostile/truncated file can trigger a huge alloc.
-            // The per-element reads below bound growth to real file content.
             let mut xys = Vec::new();
             let mut point3d_ids = Vec::new();
 
@@ -568,8 +567,6 @@ async fn read_points3d_binary<R: AsyncRead + Unpin>(
         let track_length = reader.read_u64_le().await?;
 
         let points_aux = if points_aux {
-            // `track_length` is file-controlled; see the note above — grow from
-            // empty so a bogus length can't drive an unbounded allocation.
             let mut image_ids = Vec::new();
             let mut point2d_idxs = Vec::new();
 

--- a/crates/colmap-reader/src/lib.rs
+++ b/crates/colmap-reader/src/lib.rs
@@ -413,6 +413,14 @@ async fn read_images_binary<R: AsyncBufRead + Unpin>(
         let mut name_bytes = Vec::new();
         reader.read_until(b'\0', &mut name_bytes).await?;
 
+        // `read_until` only stops short of the delimiter on EOF; a truncated
+        // file leaves us without the trailing '\0', so don't slice blindly.
+        if name_bytes.last() != Some(&b'\0') {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "image name was not null-terminated (truncated images file?)",
+            ));
+        }
         let name = std::str::from_utf8(&name_bytes[..name_bytes.len() - 1])
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?
             .to_owned();
@@ -420,8 +428,11 @@ async fn read_images_binary<R: AsyncBufRead + Unpin>(
         let num_points2d = reader.read_u64_le().await?;
 
         let point_data = if with_points {
-            let mut xys = Vec::with_capacity(num_points2d as usize);
-            let mut point3d_ids = Vec::with_capacity(num_points2d as usize);
+            // `num_points2d` comes straight from the file; don't pre-allocate
+            // from it or a hostile/truncated file can trigger a huge alloc.
+            // The per-element reads below bound growth to real file content.
+            let mut xys = Vec::new();
+            let mut point3d_ids = Vec::new();
 
             for _ in 0..num_points2d {
                 xys.push(glam::Vec2::new(
@@ -557,8 +568,10 @@ async fn read_points3d_binary<R: AsyncRead + Unpin>(
         let track_length = reader.read_u64_le().await?;
 
         let points_aux = if points_aux {
-            let mut image_ids = Vec::with_capacity(track_length as usize);
-            let mut point2d_idxs = Vec::with_capacity(track_length as usize);
+            // `track_length` is file-controlled; see the note above — grow from
+            // empty so a bogus length can't drive an unbounded allocation.
+            let mut image_ids = Vec::new();
+            let mut point2d_idxs = Vec::new();
 
             for _ in 0..track_length {
                 image_ids.push(reader.read_i32_le().await?);


### PR DESCRIPTION
Few small fixes to harden some things, and fix a case where tiny images (<1 MB) could overflow the cache capacity.