### PR TITLE
Support RealityCapture/Postshot CSV+PLY datasets

### DIFF
--- a/apps/brush-app/src/ui/datasets.rs
+++ b/apps/brush-app/src/ui/datasets.rs
@@ -18,10 +18,10 @@ use crate::ui::{
 };
 
 const TEX_CACHE_LIMIT: usize = 16;
-/// Max edge length the preview panel keeps. Big enough that downscaling is
-/// barely visible at typical window sizes, small enough that 8K source images
-/// don't dominate `ColorImage` alloc + GPU upload.
-const PREVIEW_MAX_EDGE: u32 = 2048;
+/// Floor for the preview edge so a collapsed/tiny panel still decodes a usable
+/// image. There's no ceiling: the preview is sized to the panel (see `ui`), and
+/// `load()` never upscales past the source anyway.
+const PREVIEW_MIN_EDGE: u32 = 32;
 /// Concurrent decode actors. Sized to the cache so a full burst of distinct
 /// requests can each get their own actor instead of queuing.
 const LOAD_POOL_SIZE: usize = TEX_CACHE_LIMIT;
@@ -63,6 +63,10 @@ pub struct DatasetPanel {
     /// Pool of decode actors. Round-robin via `next_actor`.
     actors: Vec<Actor>,
     next_actor: usize,
+
+    /// Edge length (physical px) the cached previews were decoded for; tracks
+    /// the panel size so resizing reloads at a matching resolution.
+    preview_edge: u32,
 }
 
 impl Default for DatasetPanel {
@@ -80,15 +84,19 @@ impl Default for DatasetPanel {
             displayed: None,
             actors,
             next_actor: 0,
+            preview_edge: PREVIEW_MIN_EDGE,
         }
     }
 }
 
-/// Decode + `ColorImage` build + GPU upload for a single preview view. The
-/// max-resolution cap lives on the loaded `LoadImage` so the JPEG IDCT fast
-/// path in `decode_with_cap` can pick a fractional decode size directly.
-async fn load_preview(view: SceneView, ctx: egui::Context) -> Option<TexHandle> {
-    let preview_load = view.image.clone().with_max_resolution(PREVIEW_MAX_EDGE);
+async fn load_preview(view: SceneView, ctx: egui::Context, preview_edge: u32) -> Option<TexHandle> {
+    // The preview texture is capped to the panel size for GPU/memory reasons,
+    // but report the resolution training actually uses (read from the header,
+    // no full decode) so the panel doesn't claim a misleadingly small size.
+    let (tw, th) = view.image.output_dimensions().await.ok()?;
+    let train_size = [tw as usize, th as usize];
+
+    let preview_load = view.image.clone().with_max_resolution(preview_edge);
     let image = preview_load.load().await.ok()?;
 
     brush_async::yield_now().await;
@@ -111,6 +119,7 @@ async fn load_preview(view: SceneView, ctx: egui::Context) -> Option<TexHandle> 
     Some(TexHandle {
         handle: egui_handle,
         has_alpha,
+        train_size,
     })
 }
 
@@ -153,9 +162,10 @@ impl DatasetPanel {
         let actor = &self.actors[self.next_actor];
         self.next_actor = (self.next_actor + 1) % self.actors.len();
         let view_for_task = view.clone();
+        let preview_edge = self.preview_edge;
         actor
             .run(move || async move {
-                if let Some(tex) = load_preview(view_for_task, ctx.clone()).await {
+                if let Some(tex) = load_preview(view_for_task, ctx.clone(), preview_edge).await {
                     let _ = tx.send(tex);
                     ctx.request_repaint();
                 }
@@ -209,9 +219,7 @@ impl AppPane for DatasetPanel {
         job.append(
             &format!(
                 "  |  {}x{} {}",
-                tex.handle.size()[0],
-                tex.handle.size()[1],
-                mask_info
+                tex.train_size[0], tex.train_size[1], mask_info
             ),
             0.0,
             egui::TextFormat {
@@ -275,6 +283,17 @@ impl AppPane for DatasetPanel {
 
         let target_view = pick_scene.views[*nearest].clone();
         self.current_view_index = Some(*nearest);
+
+        // Size previews to the panel in physical pixels, so we neither waste
+        // memory on oversized textures nor visibly downscale on large/hi-DPI
+        // windows.
+        let needed = ((ui.available_size().max_elem() * ui.ctx().pixels_per_point()).ceil() as u32)
+            .max(PREVIEW_MIN_EDGE);
+        let (lo, hi) = (needed.min(self.preview_edge), needed.max(self.preview_edge));
+        if hi * 10 > lo * 11 {
+            self.preview_edge = needed;
+            self.cache.clear();
+        }
 
         // Cache hit (Ready) → swap display. Pending/Miss → ensure a load is in
         // flight; spawn_load no-ops if an entry already exists.

--- a/apps/brush-app/src/ui/ui_process.rs
+++ b/apps/brush-app/src/ui/ui_process.rs
@@ -40,6 +40,8 @@ pub enum BackgroundStyle {
 pub struct TexHandle {
     pub handle: TextureHandle,
     pub has_alpha: bool,
+    /// Resolution the image trains at (preview texture is capped lower).
+    pub train_size: [usize; 2],
 }
 
 impl UiProcess {

--- a/crates/brush-dataset/src/formats/colmap.rs
+++ b/crates/brush-dataset/src/formats/colmap.rs
@@ -8,7 +8,7 @@ use super::{DatasetLoadResult, FormatError};
 use crate::{
     Dataset,
     config::LoadDataseConfig,
-    formats::find_mask_path,
+    formats::{find_image_by_name, find_mask_path, split_eval_every},
     scene::{LoadImage, SceneView},
 };
 use brush_render::kernels::camera_model::CameraModel;
@@ -25,18 +25,6 @@ use brush_render::{
 use brush_serde::{ParseMetadata, SplatData, SplatMessage};
 use brush_vfs::BrushVfs;
 use colmap_reader::{ColmapCamera, ColmapCameraModel};
-use itertools::Itertools;
-
-fn find_img<'a>(vfs: &'a BrushVfs, name: &str) -> Option<&'a Path> {
-    // Colmap only specifies an image name, not a full path. We brute force
-    // search for the image in the archive.
-    //
-    // Make sure this path doesn't start with a '/' as the files_ending_in expects
-    // things in that format (like a "filename with slashes").
-    vfs.files_ending_in(name)
-        .filter(|p| !p.iter().any(|f| f == "masks")) // Skip anything that is a mask.
-        .min()
-}
 
 /// COLMAP can emit several independent sparse reconstructions (`sparse/0`,
 /// `sparse/1`, ...) when the image graph is disconnected. They share no
@@ -198,7 +186,7 @@ async fn load_dataset_inner(
             let center_uv =
                 center / glam::vec2(colmap_camera.width as f32, colmap_camera.height as f32);
 
-            let Some(path) = find_img(&vfs, &img_info.name) else {
+            let Some(path) = find_image_by_name(&vfs, &img_info.name) else {
                 warnings.push(format!("Skipped '{}': image file not found", img_info.name));
                 continue;
             };
@@ -232,15 +220,7 @@ async fn load_dataset_inner(
             views.push(SceneView { camera, image });
         }
 
-        let (train_views, eval_views) = views.into_iter().enumerate().partition_map(|(i, v)| {
-            if let Some(split) = load_args.eval_split_every
-                && i % split == 0
-            {
-                itertools::Either::Right(v)
-            } else {
-                itertools::Either::Left(v)
-            }
-        });
+        let (train_views, eval_views) = split_eval_every(views, load_args.eval_split_every);
 
         Result::<_, FormatError>::Ok((Dataset::from_views(train_views, eval_views), warnings))
     });

--- a/crates/brush-dataset/src/formats/mod.rs
+++ b/crates/brush-dataset/src/formats/mod.rs
@@ -1,12 +1,14 @@
-use crate::{Dataset, config::LoadDataseConfig};
+use crate::{Dataset, config::LoadDataseConfig, scene::SceneView};
 use brush_serde::{DeserializeError, SplatMessage, load_splat_from_ply};
 
 use brush_vfs::BrushVfs;
 use image::ImageError;
+use itertools::{Either, Itertools};
 use std::{path::Path, sync::Arc};
 
 pub mod colmap;
 pub mod nerfstudio;
+pub mod realitycapture;
 
 use thiserror::Error;
 
@@ -45,7 +47,9 @@ pub enum DatasetError {
     #[error("Failed to load initial point cloud: {0}")]
     InitialPointCloudError(#[from] DeserializeError),
 
-    #[error("Format not recognized: only colmap and nerfstudio json are supported")]
+    #[error(
+        "Format not recognized: only colmap, nerfstudio json and RealityCapture csv are supported"
+    )]
     FormatNotSupported,
 }
 
@@ -57,6 +61,10 @@ pub async fn load_dataset(
 
     if dataset.is_none() {
         dataset = nerfstudio::read_dataset(vfs.clone(), load_args).await;
+    }
+
+    if dataset.is_none() {
+        dataset = realitycapture::read_dataset(vfs.clone(), load_args).await;
     }
 
     let Some(dataset) = dataset else {
@@ -100,6 +108,42 @@ pub async fn load_dataset(
         init_splat,
         dataset: result.dataset,
         warnings: result.warnings,
+    })
+}
+
+/// Resolve a bare image name (as stored by colmap / `RealityCapture`, which only
+/// record a filename) to a path in the VFS by brute-force suffix search. Masks
+/// are skipped so an image never resolves to its own mask.
+fn find_image_by_name<'a>(vfs: &'a BrushVfs, name: &str) -> Option<&'a Path> {
+    vfs.files_ending_in(name)
+        .filter(|p| !p.iter().any(|f| f == "masks"))
+        .min()
+}
+
+/// Convert an OpenGL/Blender camera-to-world matrix (the nerfstudio
+/// `transform_matrix` convention: +X right, +Y up, +Z back) into brush's
+/// camera pose (+X right, +Y down, +Z forward).
+fn opengl_c2w_to_pose(mut c2w: glam::Mat4) -> (glam::Vec3, glam::Quat) {
+    c2w.y_axis *= -1.0;
+    c2w.z_axis *= -1.0;
+    let (_, rotation, translation) = c2w.to_scale_rotation_translation();
+    (translation, rotation)
+}
+
+/// Split views into (train, eval) by selecting every `eval_split_every`-th view
+/// for eval. With `None`, every view is a train view.
+fn split_eval_every(
+    views: Vec<SceneView>,
+    eval_split_every: Option<usize>,
+) -> (Vec<SceneView>, Vec<SceneView>) {
+    views.into_iter().enumerate().partition_map(|(i, v)| {
+        if let Some(split) = eval_split_every
+            && i % split == 0
+        {
+            Either::Right(v)
+        } else {
+            Either::Left(v)
+        }
     })
 }
 

--- a/crates/brush-dataset/src/formats/nerfstudio.rs
+++ b/crates/brush-dataset/src/formats/nerfstudio.rs
@@ -1,5 +1,4 @@
-use super::find_mask_path;
-use super::{DatasetLoadResult, FormatError};
+use super::{DatasetLoadResult, FormatError, find_mask_path, opengl_c2w_to_pose};
 use crate::{
     Dataset,
     config::LoadDataseConfig,
@@ -164,11 +163,8 @@ async fn read_transforms_file(
                 transform_matrix.len()
             )));
         }
-        let mut transform = glam::Mat4::from_cols_slice(&transform_matrix).transpose();
-        // Swap basis to match camera format and reconstrunstion ply (if included).
-        transform.y_axis *= -1.0;
-        transform.z_axis *= -1.0;
-        let (_, rotation, translation) = transform.to_scale_rotation_translation();
+        let transform = glam::Mat4::from_cols_slice(&transform_matrix).transpose();
+        let (translation, rotation) = opengl_c2w_to_pose(transform);
 
         let mut path = transforms_path
             .parent()

--- a/crates/brush-dataset/src/formats/nerfstudio.rs
+++ b/crates/brush-dataset/src/formats/nerfstudio.rs
@@ -14,7 +14,6 @@ use brush_render::kernels::camera_model::kannala_brandt_4::KannalaBrandt4Params;
 use brush_render::kernels::camera_model::radial_tangential_8::RadialTangential8Params;
 use brush_serde::load_splat_from_ply;
 use brush_vfs::BrushVfs;
-use image::GenericImageView;
 use std::path::Path;
 use std::sync::Arc;
 use tokio::io::AsyncReadExt;
@@ -195,11 +194,11 @@ async fn read_transforms_file(
 
         let w = frame.w.or(scene.w);
         let h = frame.h.or(scene.h);
-        // If we have some missing format, just get it from the image.
-        // This does require loading the image which is not great...
+        // If the json omits the size, read it from the image header (cheap, no
+        // full decode).
         let (w, h) = match (w, h) {
             (Some(w), Some(h)) => (w as u32, h as u32),
-            _ => image.load().await?.dimensions(),
+            _ => image.dimensions().await?,
         };
 
         let camera_model = resolve_camera_model(

--- a/crates/brush-dataset/src/formats/realitycapture.rs
+++ b/crates/brush-dataset/src/formats/realitycapture.rs
@@ -24,9 +24,10 @@ use tokio::io::AsyncReadExt;
 /// `x,y,alt` is the camera position and `heading,pitch,roll` its orientation
 /// (degrees). `f`, `px` and `py` are in 35mm-film units (36mm reference): `f`
 /// is the focal length and `px,py` the principal point offset from the image
-/// center. All three scale by the larger image dimension to reach pixels. `k*`
-/// and `t*` are Brown radial/tangential distortion coeffs. The accompanying
-/// sparse point cloud is a separate `.ply`, handled by the generic loader.
+/// center. All three scale by the larger image dimension to reach pixels.
+/// `k1..k4` are Brown polynomial radial coeffs (r^2, r^4, r^6, r^8) and `t1,t2`
+/// the tangential coeffs; brush has no r^8 term, so brown4's `k4` is dropped
+/// (brown3 approximation) with a warning.
 ///
 /// The column set is a user-customizable template, so optional columns may be
 /// absent: distortion (`k*`/`t*`) defaults to none (pinhole) and the principal
@@ -98,6 +99,7 @@ async fn read_dataset_inner(
 
     let mut views = Vec::new();
     let mut warnings = Vec::new();
+    let mut warned_brown4 = false;
 
     for line in lines
         .step_by(load_args.subsample_frames.unwrap_or(1) as usize)
@@ -109,6 +111,17 @@ async fn read_dataset_inner(
         let Some(name) = col(&fields, &header, "name").map(str::trim) else {
             continue;
         };
+
+        // brush's distortion model has no 4th-order (r^8) radial term, so the
+        // brown4 `k4` coefficient can't be represented; fall back to the brown3
+        // approximation and flag it once.
+        if !warned_brown4 && col_f64(&fields, &header, "k4") != 0.0 {
+            warnings.push(
+                "RealityCapture brown4 radial term (k4) isn't supported; approximating with brown3"
+                    .to_owned(),
+            );
+            warned_brown4 = true;
+        }
 
         let Some(image_path) = find_image_by_name(&vfs, name).map(Path::to_path_buf) else {
             warnings.push(format!("Skipped '{name}': image file not found"));
@@ -162,7 +175,6 @@ fn row_to_camera(fields: &[&str], header: &HashMap<String, usize>, w: u32, h: u3
         col_f64(fields, header, "k1"),
         col_f64(fields, header, "k2"),
         col_f64(fields, header, "k3"),
-        col_f64(fields, header, "k4"),
         col_f64(fields, header, "t1"),
         col_f64(fields, header, "t2"),
     );
@@ -190,15 +202,19 @@ fn row_to_camera(fields: &[&str], header: &HashMap<String, usize>, w: u32, h: u3
     Camera::new(position, rotation, fov_x, fov_y, center_uv, camera_model)
 }
 
-fn build_camera_model(k1: f64, k2: f64, k3: f64, k4: f64, t1: f64, t2: f64) -> CameraModel {
-    if [k1, k2, k3, k4, t1, t2].iter().all(|v| *v == 0.0) {
+/// `RealityCapture`'s brown3+tangential model maps onto `RadialTangential8`:
+/// `k1,k2,k3` are the polynomial radial terms (the numerator, with the rational
+/// denominator left at zero) and `t1,t2` the Brown-Conrady tangential terms.
+/// The brown4 `k4` (an r^8 term) has no slot here and is handled by the caller.
+fn build_camera_model(k1: f64, k2: f64, k3: f64, t1: f64, t2: f64) -> CameraModel {
+    if [k1, k2, k3, t1, t2].iter().all(|v| *v == 0.0) {
         return Pinhole;
     }
     RadialTangential8(RadialTangential8Params {
         k1: k1 as f32,
         k2: k2 as f32,
         k3: k3 as f32,
-        k4: k4 as f32,
+        k4: 0.0,
         k5: 0.0,
         k6: 0.0,
         p1: t1 as f32,
@@ -265,15 +281,18 @@ mod tests {
     #[wasm_bindgen_test(unsupported = test)]
     fn test_build_camera_model() {
         assert!(matches!(
-            build_camera_model(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+            build_camera_model(0.0, 0.0, 0.0, 0.0, 0.0),
             Pinhole
         ));
-        let RadialTangential8(p) = build_camera_model(1.0, 2.0, 3.0, 4.0, 5.0, 6.0) else {
+        // brown3 radial (k1,k2,k3) -> numerator; tangential (t1,t2) -> p1,p2;
+        // the rational denominator (k4,k5,k6) stays zero so it's a pure
+        // polynomial.
+        let RadialTangential8(p) = build_camera_model(1.0, 2.0, 3.0, 4.0, 5.0) else {
             panic!("expected RadialTangential8");
         };
         assert_eq!(
-            (p.k1, p.k2, p.k3, p.k4, p.p1, p.p2),
-            (1.0, 2.0, 3.0, 4.0, 5.0, 6.0)
+            (p.k1, p.k2, p.k3, p.k4, p.k5, p.k6, p.p1, p.p2),
+            (1.0, 2.0, 3.0, 0.0, 0.0, 0.0, 4.0, 5.0)
         );
     }
 }

--- a/crates/brush-dataset/src/formats/realitycapture.rs
+++ b/crates/brush-dataset/src/formats/realitycapture.rs
@@ -12,7 +12,6 @@ use brush_render::kernels::camera_model::CameraModel;
 use brush_render::kernels::camera_model::CameraModel::{Pinhole, RadialTangential8};
 use brush_render::kernels::camera_model::radial_tangential_8::RadialTangential8Params;
 use brush_vfs::BrushVfs;
-use image::GenericImageView;
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
@@ -126,9 +125,9 @@ async fn read_dataset_inner(
         );
 
         // The csv carries no image dimensions; intrinsics are resolution
-        // independent once expressed as fov + normalized center, so reading the
-        // (possibly downscaled) image just to get its aspect is fine.
-        let (w, h) = image.load().await?.dimensions();
+        // independent once expressed as fov + normalized center, so a
+        // header-only dimension read (no full decode) is enough.
+        let (w, h) = image.dimensions().await?;
 
         let camera = row_to_camera(&fields, &header, w, h);
         if !camera.is_valid() {

--- a/crates/brush-dataset/src/formats/realitycapture.rs
+++ b/crates/brush-dataset/src/formats/realitycapture.rs
@@ -1,0 +1,280 @@
+use super::{
+    DatasetLoadResult, FormatError, find_image_by_name, find_mask_path, opengl_c2w_to_pose,
+    split_eval_every,
+};
+use crate::{
+    Dataset,
+    config::LoadDataseConfig,
+    scene::{LoadImage, SceneView},
+};
+use brush_render::camera::{Camera, focal_to_fov};
+use brush_render::kernels::camera_model::CameraModel;
+use brush_render::kernels::camera_model::CameraModel::{Pinhole, RadialTangential8};
+use brush_render::kernels::camera_model::radial_tangential_8::RadialTangential8Params;
+use brush_vfs::BrushVfs;
+use image::GenericImageView;
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+use tokio::io::AsyncReadExt;
+
+/// `RealityCapture` / `RealityScan` "Internal/External camera parameters" CSV —
+/// the flat per-image format Postshot ingests. One row per image, e.g.:
+/// `#name,x,y,alt,heading,pitch,roll,f,px,py,k1,k2,k3,k4,t1,t2`.
+///
+/// `x,y,alt` is the camera position and `heading,pitch,roll` its orientation
+/// (degrees). `f`, `px` and `py` are in 35mm-film units (36mm reference): `f`
+/// is the focal length and `px,py` the principal point offset from the image
+/// center. All three scale by the larger image dimension to reach pixels. `k*`
+/// and `t*` are Brown radial/tangential distortion coeffs. The accompanying
+/// sparse point cloud is a separate `.ply`, handled by the generic loader.
+///
+/// The column set is a user-customizable template, so optional columns may be
+/// absent: distortion (`k*`/`t*`) defaults to none (pinhole) and the principal
+/// point (`px`/`py`) to the image center. Only the pose and focal columns below
+/// are required — they also serve as the format's detection signature.
+const REQUIRED_COLUMNS: &[&str] = &["name", "x", "y", "alt", "heading", "pitch", "roll", "f"];
+
+/// Map header names (lowercased, leading `#` stripped) to their column index.
+fn parse_header(line: &str) -> Option<HashMap<String, usize>> {
+    let cols: HashMap<String, usize> = line
+        .split(',')
+        .enumerate()
+        .map(|(i, name)| (name.trim().trim_start_matches('#').to_lowercase(), i))
+        .collect();
+    REQUIRED_COLUMNS
+        .iter()
+        .all(|c| cols.contains_key(*c))
+        .then_some(cols)
+}
+
+fn col<'a>(fields: &'a [&'a str], header: &HashMap<String, usize>, name: &str) -> Option<&'a str> {
+    // Copied to go from a ref-ref t
+    header.get(name).and_then(|&i| fields.get(i)).copied()
+}
+
+fn col_f64(fields: &[&str], header: &HashMap<String, usize>, name: &str) -> f64 {
+    col(fields, header, name)
+        .and_then(|s| s.trim().parse::<f64>().ok())
+        .unwrap_or(0.0)
+}
+
+pub async fn read_dataset(
+    vfs: Arc<BrushVfs>,
+    load_args: &LoadDataseConfig,
+) -> Option<Result<DatasetLoadResult, FormatError>> {
+    let csv_paths: Vec<_> = vfs.files_with_extension("csv").collect();
+
+    // Find a csv whose header looks like the RealityCapture camera format.
+    for path in csv_paths {
+        let Ok(mut reader) = vfs.reader_at_path(&path).await else {
+            continue;
+        };
+        let mut buf = String::new();
+        if reader.read_to_string(&mut buf).await.is_err() {
+            continue;
+        }
+        let Some(first_line) = buf.lines().find(|l| !l.trim().is_empty()) else {
+            continue;
+        };
+        if parse_header(first_line).is_some() {
+            log::info!("Loading RealityCapture dataset from {path:?}");
+            return Some(read_dataset_inner(vfs, load_args, buf).await);
+        }
+    }
+
+    None
+}
+
+async fn read_dataset_inner(
+    vfs: Arc<BrushVfs>,
+    load_args: &LoadDataseConfig,
+    contents: String,
+) -> Result<DatasetLoadResult, FormatError> {
+    let mut lines = contents.lines().filter(|l| !l.trim().is_empty());
+    let header = lines
+        .next()
+        .and_then(parse_header)
+        .ok_or_else(|| FormatError::InvalidFormat("RealityCapture csv has no header".to_owned()))?;
+
+    let mut views = Vec::new();
+    let mut warnings = Vec::new();
+
+    for line in lines
+        .step_by(load_args.subsample_frames.unwrap_or(1) as usize)
+        .take(load_args.max_frames.unwrap_or(usize::MAX))
+    {
+        brush_async::yield_now().await;
+
+        let fields: Vec<&str> = line.split(',').collect();
+        let Some(name) = col(&fields, &header, "name").map(str::trim) else {
+            continue;
+        };
+
+        let Some(image_path) = find_image_by_name(&vfs, name).map(Path::to_path_buf) else {
+            warnings.push(format!("Skipped '{name}': image file not found"));
+            continue;
+        };
+
+        let mask_path = find_mask_path(&vfs, &image_path).map(Path::to_path_buf);
+        let image = LoadImage::new(
+            vfs.clone(),
+            image_path,
+            mask_path,
+            load_args.max_resolution,
+            load_args.alpha_mode,
+        );
+
+        // The csv carries no image dimensions; intrinsics are resolution
+        // independent once expressed as fov + normalized center, so reading the
+        // (possibly downscaled) image just to get its aspect is fine.
+        let (w, h) = image.load().await?.dimensions();
+
+        let camera = row_to_camera(&fields, &header, w, h);
+        if !camera.is_valid() {
+            warnings.push(format!(
+                "Skipped '{name}': camera contains nan or inf values"
+            ));
+            continue;
+        }
+
+        views.push(SceneView { camera, image });
+    }
+
+    let (train_views, eval_views) = split_eval_every(views, load_args.eval_split_every);
+
+    Ok(DatasetLoadResult {
+        init_splat: None,
+        dataset: Dataset::from_views(train_views, eval_views),
+        warnings,
+    })
+}
+
+/// Build a brush [`Camera`] from one csv row and the image dimensions.
+fn row_to_camera(fields: &[&str], header: &HashMap<String, usize>, w: u32, h: u32) -> Camera {
+    let scale = w.max(h) as f64;
+
+    let focal = col_f64(fields, header, "f") * scale / 36.0;
+    let cx = col_f64(fields, header, "px") * scale + w as f64 / 2.0;
+    let cy = col_f64(fields, header, "py") * scale + h as f64 / 2.0;
+    let center_uv = glam::vec2((cx / w as f64) as f32, (cy / h as f64) as f32);
+
+    let camera_model = build_camera_model(
+        col_f64(fields, header, "k1"),
+        col_f64(fields, header, "k2"),
+        col_f64(fields, header, "k3"),
+        col_f64(fields, header, "k4"),
+        col_f64(fields, header, "t1"),
+        col_f64(fields, header, "t2"),
+    );
+    let fov_x = focal_to_fov(focal, w, &camera_model);
+    let fov_y = focal_to_fov(focal, h, &camera_model);
+
+    let heading = col_f64(fields, header, "heading") as f32;
+    let pitch = col_f64(fields, header, "pitch") as f32;
+    let roll = col_f64(fields, header, "roll") as f32;
+
+    // RealityCapture orientation: yaw(-heading) about Z, then pitch about X,
+    // then roll about Y, yielding a camera-to-world rotation in the OpenGL
+    // basis (matches nerfstudio's RealityCapture importer).
+    let rotation = glam::Quat::from_rotation_z(-heading.to_radians())
+        * glam::Quat::from_rotation_x(pitch.to_radians())
+        * glam::Quat::from_rotation_y(roll.to_radians());
+    let position = glam::vec3(
+        col_f64(fields, header, "x") as f32,
+        col_f64(fields, header, "y") as f32,
+        col_f64(fields, header, "alt") as f32,
+    );
+    let c2w = glam::Mat4::from_rotation_translation(rotation, position);
+    let (position, rotation) = opengl_c2w_to_pose(c2w);
+
+    Camera::new(position, rotation, fov_x, fov_y, center_uv, camera_model)
+}
+
+fn build_camera_model(k1: f64, k2: f64, k3: f64, k4: f64, t1: f64, t2: f64) -> CameraModel {
+    if [k1, k2, k3, k4, t1, t2].iter().all(|v| *v == 0.0) {
+        return Pinhole;
+    }
+    RadialTangential8(RadialTangential8Params {
+        k1: k1 as f32,
+        k2: k2 as f32,
+        k3: k3 as f32,
+        k4: k4 as f32,
+        k5: 0.0,
+        k6: 0.0,
+        p1: t1 as f32,
+        p2: t2 as f32,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+    const HEADER: &str = "#name,x,y,alt,heading,pitch,roll,f,px,py,k1,k2,k3,k4,t1,t2";
+    // First data row of the Postshot sample (schliemann.csv).
+    const ROW: &str = "frame_00001.jpeg,44.5876747664166,138.823621534044,6.821916401534405,170.3483067926429,85.18637269312288,-22.74995074830745,14.2390682243052,-9.482184385774318e-004,-2.446553068050568e-004,3.114799768048152e-003,4.026391718074555e-003,-1.795976992379612e-003,0,0,0";
+
+    #[wasm_bindgen_test(unsupported = test)]
+    fn test_parse_header() {
+        let header = parse_header(HEADER).expect("header should parse");
+        assert_eq!(header["name"], 0);
+        assert_eq!(header["alt"], 3);
+        assert_eq!(header["t2"], 15);
+        // A csv that isn't the RealityCapture camera format is rejected.
+        assert!(parse_header("a,b,c").is_none());
+    }
+
+    #[wasm_bindgen_test(unsupported = test)]
+    fn test_row_to_camera() {
+        let header = parse_header(HEADER).expect("header should parse");
+        let fields: Vec<&str> = ROW.split(',').collect();
+        let cam = row_to_camera(&fields, &header, 3840, 2880);
+
+        assert!(cam.is_valid());
+
+        // x,y,alt map straight to the world position (the basis swap only
+        // reorients the camera, it doesn't move it).
+        assert!((cam.position - glam::vec3(44.587_674, 138.823_62, 6.821_916)).length() < 1e-3);
+
+        // Near-zero px/py keep the principal point at the image center.
+        assert!((cam.center_uv - glam::vec2(0.5, 0.5)).length() < 1e-2);
+
+        // f=14.24 (35mm equiv) on a 4:3 frame is a wide lens; fov_x > fov_y > 0.
+        assert!(cam.fov_x > cam.fov_y && cam.fov_y > 0.0);
+        assert!((1.0..2.0).contains(&cam.fov_x));
+
+        // Non-zero radial coeffs select the distortion model.
+        assert!(matches!(cam.camera_model, RadialTangential8(_)));
+    }
+
+    #[wasm_bindgen_test(unsupported = test)]
+    fn test_minimal_header_no_distortion() {
+        // A customized template can drop the optional principal-point and
+        // distortion columns; the camera is then a centered pinhole.
+        let header = parse_header("#name,x,y,alt,heading,pitch,roll,f")
+            .expect("minimal header should parse");
+        let fields: Vec<&str> = "img.png,1,2,3,10,20,30,20.0".split(',').collect();
+        let cam = row_to_camera(&fields, &header, 1920, 1080);
+        assert!(cam.is_valid());
+        assert!(matches!(cam.camera_model, Pinhole));
+        assert!((cam.center_uv - glam::vec2(0.5, 0.5)).length() < 1e-6);
+        assert!((cam.position - glam::vec3(1.0, 2.0, 3.0)).length() < 1e-3);
+    }
+
+    #[wasm_bindgen_test(unsupported = test)]
+    fn test_build_camera_model() {
+        assert!(matches!(
+            build_camera_model(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+            Pinhole
+        ));
+        let RadialTangential8(p) = build_camera_model(1.0, 2.0, 3.0, 4.0, 5.0, 6.0) else {
+            panic!("expected RadialTangential8");
+        };
+        assert_eq!(
+            (p.k1, p.k2, p.k3, p.k4, p.p1, p.p2),
+            (1.0, 2.0, 3.0, 4.0, 5.0, 6.0)
+        );
+    }
+}

--- a/crates/brush-dataset/src/load_image.rs
+++ b/crates/brush-dataset/src/load_image.rs
@@ -110,6 +110,21 @@ impl LoadImage {
         }
     }
 
+    /// Read just the image dimensions from the file header, without decoding
+    /// the pixels. Much cheaper than `load()` when only the size is needed
+    /// (e.g. formats that carry intrinsics but not image dimensions).
+    pub async fn dimensions(&self) -> image::ImageResult<(u32, u32)> {
+        let mut img_bytes = vec![];
+        self.vfs
+            .reader_at_path(&self.path)
+            .await?
+            .read_to_end(&mut img_bytes)
+            .await?;
+        image::ImageReader::new(Cursor::new(&img_bytes))
+            .with_guessed_format()?
+            .into_dimensions()
+    }
+
     pub fn alpha_mode(&self) -> AlphaMode {
         self.alpha_mode
     }

--- a/crates/brush-dataset/src/load_image.rs
+++ b/crates/brush-dataset/src/load_image.rs
@@ -98,15 +98,37 @@ impl LoadImage {
             img = masked_img.into();
         }
 
-        let max = self.max_resolution;
-        let cap = max as f32 / img.width().max(img.height()).max(max) as f32;
-        let scale = (cap * self.scale).min(1.0);
+        let scale = self.output_scale(img.width(), img.height());
         if scale < 1.0 {
             let new_w = (img.width() as f32 * scale).max(1.0) as u32;
             let new_h = (img.height() as f32 * scale).max(1.0) as u32;
             Ok(img.resize_exact(new_w, new_h, image::imageops::FilterType::Lanczos3))
         } else {
             Ok(img)
+        }
+    }
+
+    /// Factor `load()` applies to a source of size `w`x`h`: the long edge is
+    /// capped to `max_resolution` and multiplied by `scale`.
+    fn output_scale(&self, w: u32, h: u32) -> f32 {
+        let max = self.max_resolution;
+        let cap = max as f32 / w.max(h).max(max) as f32;
+        (cap * self.scale).min(1.0)
+    }
+
+    /// Dimensions `load()` would return, computed from the header without
+    /// decoding pixels. Useful for displaying the real training resolution
+    /// without paying for a full decode.
+    pub async fn output_dimensions(&self) -> image::ImageResult<(u32, u32)> {
+        let (w, h) = self.dimensions().await?;
+        let scale = self.output_scale(w, h);
+        if scale < 1.0 {
+            Ok((
+                (w as f32 * scale).max(1.0) as u32,
+                (h as f32 * scale).max(1.0) as u32,
+            ))
+        } else {
+            Ok((w, h))
         }
     }
 

--- a/crates/brush-dataset/src/load_image.rs
+++ b/crates/brush-dataset/src/load_image.rs
@@ -2,7 +2,7 @@ use brush_render::AlphaMode;
 use brush_vfs::BrushVfs;
 use image::{DynamicImage, GenericImageView, ImageBuffer};
 use std::{
-    io::Cursor,
+    io::{self, Cursor},
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -113,16 +113,28 @@ impl LoadImage {
     /// Read just the image dimensions from the file header, without decoding
     /// the pixels. Much cheaper than `load()` when only the size is needed
     /// (e.g. formats that carry intrinsics but not image dimensions).
+    ///
+    /// Reads the file in chunks and stops as soon as the header parses, so for
+    /// typical formats only the first chunk is fetched rather than the whole
+    /// (potentially many-MB) file. A truncated prefix only ever fails to parse
+    /// (the dimension fields are reported once fully present), so a partial
+    /// buffer can't yield wrong dimensions.
     pub async fn dimensions(&self) -> image::ImageResult<(u32, u32)> {
-        let mut img_bytes = vec![];
-        self.vfs
-            .reader_at_path(&self.path)
-            .await?
-            .read_to_end(&mut img_bytes)
-            .await?;
-        image::ImageReader::new(Cursor::new(&img_bytes))
-            .with_guessed_format()?
-            .into_dimensions()
+        let mut reader = self.vfs.reader_at_path(&self.path).await?;
+        let dims = brush_vfs::read_until_parsed(&mut reader, 64 * 1024, |bytes| {
+            image::ImageReader::new(Cursor::new(bytes))
+                .with_guessed_format()
+                .ok()
+                .and_then(|r| r.into_dimensions().ok())
+        })
+        .await?;
+        dims.ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("could not determine image dimensions for {:?}", self.path),
+            )
+            .into()
+        })
     }
 
     pub fn alpha_mode(&self) -> AlphaMode {

--- a/crates/brush-render/src/camera.rs
+++ b/crates/brush-render/src/camera.rs
@@ -212,6 +212,11 @@ pub fn calculate_jacobian_clamp_limits(
     let img_w = img_size.x as f32;
     let img_h = img_size.y as f32;
 
+    // The clamp bounds the normalized coord x/z that feeds the projection, so
+    // the EWA covariance Jacobian isn't evaluated where the perspective
+    // projection blows up near the field-of-view edge. The pinhole margin
+    // `1.15 * img - c` equals the canonical 3DGS limit `1.3 * tan(fov/2)`
+    // (graphdeco-inria/diff-gaussian-rasterization, `computeCov2D`).
     match camera_model {
         Pinhole => {
             lim_pos_x = (1.15 * img_w - cx) / fx;
@@ -219,14 +224,24 @@ pub fn calculate_jacobian_clamp_limits(
             lim_neg_x = (-0.15 * img_w - cx) / fx;
             lim_neg_y = (-0.15 * img_h - cy) / fy;
         }
-        RadialTangential8(_) => {
-            // TODO: this works for small distortions,
-            // the more sophisticated version would require to invert the RT8 model
-            lim_pos_x = (1.3 * img_w - cx) / fx;
-            lim_pos_y = (1.3 * img_h - cy) / fy;
-            lim_neg_x = (-0.3 * img_w - cx) / fx;
-            lim_neg_y = (-0.3 * img_h - cy) / fy;
+        RadialTangential8(p) => {
+            // The clamp bounds x/z, the *undistorted* coord that `project_rt8`
+            // feeds the distortion. A pixel maps to the distorted coord
+            // `(px - c) / f`; invert the radial model to get the undistorted
+            // bound. With the same image margin as pinhole this collapses to the
+            // pinhole limit for a near-pinhole lens (so a tiny distortion no
+            // longer loosens the clamp and lets wide-fov splats blow up) while
+            // widening it for real barrel distortion.
+            let undistort =
+                |edge: f32| (rt8_undistort_radius((edge as f64).abs(), &p) as f32) * edge.signum();
+            lim_pos_x = undistort((1.15 * img_w - cx) / fx);
+            lim_pos_y = undistort((1.15 * img_h - cy) / fy);
+            lim_neg_x = undistort((-0.15 * img_w - cx) / fx);
+            lim_neg_y = undistort((-0.15 * img_h - cy) / fy);
         }
+        // Fisheye models project the full hemisphere without the perspective
+        // singularity, so their Jacobians aren't clamped (their kernels ignore
+        // these limits); leave them at zero.
         KannalaBrandt4(_) | ThinPrismFisheye(_) => {}
     }
 

--- a/crates/brush-vfs/src/lib.rs
+++ b/crates/brush-vfs/src/lib.rs
@@ -70,6 +70,32 @@ async fn read_at_most<R: AsyncRead + Unpin>(reader: &mut R, limit: usize) -> io:
     Ok(buffer)
 }
 
+/// Read from `reader` in chunks of `chunk_size`, calling `parse` on everything
+/// read so far after each chunk. Returns the first `Some` value `parse` yields,
+/// without consuming the rest of the reader; returns `None` if the reader hits
+/// EOF before `parse` succeeds.
+pub async fn read_until_parsed<R, T>(
+    reader: &mut R,
+    chunk_size: usize,
+    mut parse: impl FnMut(&[u8]) -> Option<T>,
+) -> io::Result<Option<T>>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut buf = vec![];
+    let mut chunk = vec![0u8; chunk_size];
+    loop {
+        let n = reader.read(&mut chunk).await?;
+        buf.extend_from_slice(&chunk[..n]);
+        if let Some(value) = parse(&buf) {
+            return Ok(Some(value));
+        }
+        if n == 0 {
+            return Ok(None);
+        }
+    }
+}
+
 enum VfsContainer {
     /// Raw data stored in memory (from zip files)
     InMemory {


### PR DESCRIPTION
Adds support for the RealityCapture / RealityScan "Internal/External camera parameters" flat CSV (the format Postshot ingests), plus fixes found while testing it on a real dataset. Closes #477.

Import (brush-dataset):
- New realitycapture.rs loader, tried after colmap and nerfstudio. Each row carries camera position, heading/pitch/roll, a 35mm-equivalent focal + principal point, and Brown distortion coefficients; the intrinsics and pose convention match nerfstudio's RealityCapture importer, and the sparse .ply is picked up by the existing init path.
- Optional columns are handled: distortion (k/t) absent or all-zero maps to pinhole, an absent principal point defaults to image center. brown4's r^8 term (k4) has no representation in the rt8 model and is dropped with a warning. Georeferenced variants (omega/phi/kappa, lat/lon) are unsupported and fall through to the normal error.

Image loading:
- LoadImage::dimensions() reads only the file header instead of decoding the whole image, via a new brush_vfs::read_until_parsed that reads in chunks and stops once the header parses. The nerfstudio size fallback uses it too. Removes a long stall before training on formats that carry intrinsics but not image dimensions.

Dataset panel:
- Preview texture is sized to the panel in physical pixels (DPI-aware) instead of a fixed 2048 cap, reloading only when the panel changes size by more than ~10%.
- The panel reports the real training resolution (LoadImage::output_dimensions) rather than the downscaled preview size.