### PR TITLE
Reduce degenerate splats: covariance-aware split, screen-size kill, area regularizer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1158,6 +1158,7 @@ dependencies = [
  "clap",
  "glam",
  "image",
+ "log",
  "rerun",
  "serde",
  "tokio",

--- a/apps/brush-app/src/ui/settings_popup.rs
+++ b/apps/brush-app/src/ui/settings_popup.rs
@@ -156,9 +156,9 @@ pub(crate) fn draw_settings(ui: &mut Ui, args: &mut TrainStreamConfig, enabled: 
         );
         slider(
             ui,
-            &mut tc.split_at_screen_size,
+            &mut tc.kill_at_screen_size,
             0.0..=1.0,
-            "Split at screen size (0 disables)",
+            "Kill at screen size (0 disables)",
             false,
             enabled,
         );

--- a/crates/brush-bench-test/src/benches.rs
+++ b/crates/brush-bench-test/src/benches.rs
@@ -188,6 +188,7 @@ pub async fn run_backward_render(
             &camera,
             glam::uvec2(resolution.0, resolution.1),
             Vec3::ZERO,
+            0.0,
         )
         .await;
         let _ = diff_out.img.mean().backward();

--- a/crates/brush-bench-test/tests/finite_diff.rs
+++ b/crates/brush-bench-test/tests/finite_diff.rs
@@ -101,13 +101,16 @@ async fn render_value(
     device: &burn::tensor::Device,
 ) -> f32 {
     let splats = build_splats(scene, device);
-    let diff = {
-        let splats = splats;
-        let cam: &Camera = cam;
-        let background = Vec3::ZERO;
-        async move { render_splats_with_pass(splats, cam, img_size, background, PASS).await }
-    }
-    .await;
+    let diff =
+        {
+            let splats = splats;
+            let cam: &Camera = cam;
+            let background = Vec3::ZERO;
+            async move {
+                render_splats_with_pass(splats, cam, img_size, background, PASS, 0.0, 0.0).await
+            }
+        }
+        .await;
     diff.img
         .mean()
         .into_scalar_async::<f32>()
@@ -122,13 +125,16 @@ async fn analytical_grads(
     device: &burn::tensor::Device,
 ) -> (Splats, Gradients) {
     let splats = build_splats(scene, device);
-    let diff = {
-        let splats = splats.clone();
-        let cam: &Camera = cam;
-        let background = Vec3::ZERO;
-        async move { render_splats_with_pass(splats, cam, img_size, background, PASS).await }
-    }
-    .await;
+    let diff =
+        {
+            let splats = splats.clone();
+            let cam: &Camera = cam;
+            let background = Vec3::ZERO;
+            async move {
+                render_splats_with_pass(splats, cam, img_size, background, PASS, 0.0, 0.0).await
+            }
+        }
+        .await;
     let grads = diff.img.mean().backward();
     (splats, grads)
 }
@@ -381,7 +387,7 @@ async fn finite_diff_broad_mip_mode() {
             SplatRenderMode::Mip,
             device,
         );
-        let diff = render_splats_with_pass(splats, cam, img_size, Vec3::ZERO, PASS).await;
+        let diff = render_splats_with_pass(splats, cam, img_size, Vec3::ZERO, PASS, 0.0, 0.0).await;
         diff.img
             .mean()
             .into_scalar_async::<f32>()
@@ -404,7 +410,9 @@ async fn finite_diff_broad_mip_mode() {
             SplatRenderMode::Mip,
             device,
         );
-        let diff = render_splats_with_pass(splats.clone(), cam, img_size, Vec3::ZERO, PASS).await;
+        let diff =
+            render_splats_with_pass(splats.clone(), cam, img_size, Vec3::ZERO, PASS, 0.0, 0.0)
+                .await;
         let g = diff.img.mean().backward();
         (splats, g)
     }
@@ -486,7 +494,7 @@ async fn finite_diff_weighted_loss() {
         device: &burn::tensor::Device,
     ) -> f32 {
         let splats = build_splats(scene, device);
-        let diff = render_splats_with_pass(splats, cam, img_size, Vec3::ZERO, PASS).await;
+        let diff = render_splats_with_pass(splats, cam, img_size, Vec3::ZERO, PASS, 0.0, 0.0).await;
         (diff.img * weights)
             .sum()
             .into_scalar_async::<f32>()
@@ -502,7 +510,9 @@ async fn finite_diff_weighted_loss() {
         device: &burn::tensor::Device,
     ) -> (Splats, Gradients) {
         let splats = build_splats(scene, device);
-        let diff = render_splats_with_pass(splats.clone(), cam, img_size, Vec3::ZERO, PASS).await;
+        let diff =
+            render_splats_with_pass(splats.clone(), cam, img_size, Vec3::ZERO, PASS, 0.0, 0.0)
+                .await;
         let loss = (diff.img * weights).sum();
         (splats, loss.backward())
     }

--- a/crates/brush-bench-test/tests/finite_diff.rs
+++ b/crates/brush-bench-test/tests/finite_diff.rs
@@ -101,16 +101,13 @@ async fn render_value(
     device: &burn::tensor::Device,
 ) -> f32 {
     let splats = build_splats(scene, device);
-    let diff =
-        {
-            let splats = splats;
-            let cam: &Camera = cam;
-            let background = Vec3::ZERO;
-            async move {
-                render_splats_with_pass(splats, cam, img_size, background, PASS, 0.0, 0.0).await
-            }
-        }
-        .await;
+    let diff = {
+        let splats = splats;
+        let cam: &Camera = cam;
+        let background = Vec3::ZERO;
+        async move { render_splats_with_pass(splats, cam, img_size, background, PASS, 0.0).await }
+    }
+    .await;
     diff.img
         .mean()
         .into_scalar_async::<f32>()
@@ -125,16 +122,13 @@ async fn analytical_grads(
     device: &burn::tensor::Device,
 ) -> (Splats, Gradients) {
     let splats = build_splats(scene, device);
-    let diff =
-        {
-            let splats = splats.clone();
-            let cam: &Camera = cam;
-            let background = Vec3::ZERO;
-            async move {
-                render_splats_with_pass(splats, cam, img_size, background, PASS, 0.0, 0.0).await
-            }
-        }
-        .await;
+    let diff = {
+        let splats = splats.clone();
+        let cam: &Camera = cam;
+        let background = Vec3::ZERO;
+        async move { render_splats_with_pass(splats, cam, img_size, background, PASS, 0.0).await }
+    }
+    .await;
     let grads = diff.img.mean().backward();
     (splats, grads)
 }
@@ -387,7 +381,7 @@ async fn finite_diff_broad_mip_mode() {
             SplatRenderMode::Mip,
             device,
         );
-        let diff = render_splats_with_pass(splats, cam, img_size, Vec3::ZERO, PASS, 0.0, 0.0).await;
+        let diff = render_splats_with_pass(splats, cam, img_size, Vec3::ZERO, PASS, 0.0).await;
         diff.img
             .mean()
             .into_scalar_async::<f32>()
@@ -411,8 +405,7 @@ async fn finite_diff_broad_mip_mode() {
             device,
         );
         let diff =
-            render_splats_with_pass(splats.clone(), cam, img_size, Vec3::ZERO, PASS, 0.0, 0.0)
-                .await;
+            render_splats_with_pass(splats.clone(), cam, img_size, Vec3::ZERO, PASS, 0.0).await;
         let g = diff.img.mean().backward();
         (splats, g)
     }
@@ -494,7 +487,7 @@ async fn finite_diff_weighted_loss() {
         device: &burn::tensor::Device,
     ) -> f32 {
         let splats = build_splats(scene, device);
-        let diff = render_splats_with_pass(splats, cam, img_size, Vec3::ZERO, PASS, 0.0, 0.0).await;
+        let diff = render_splats_with_pass(splats, cam, img_size, Vec3::ZERO, PASS, 0.0).await;
         (diff.img * weights)
             .sum()
             .into_scalar_async::<f32>()
@@ -511,8 +504,7 @@ async fn finite_diff_weighted_loss() {
     ) -> (Splats, Gradients) {
         let splats = build_splats(scene, device);
         let diff =
-            render_splats_with_pass(splats.clone(), cam, img_size, Vec3::ZERO, PASS, 0.0, 0.0)
-                .await;
+            render_splats_with_pass(splats.clone(), cam, img_size, Vec3::ZERO, PASS, 0.0).await;
         let loss = (diff.img * weights).sum();
         (splats, loss.backward())
     }

--- a/crates/brush-bench-test/tests/fuzz.rs
+++ b/crates/brush-bench-test/tests/fuzz.rs
@@ -505,8 +505,15 @@ async fn fuzz_bwd_random_scenes_gradients_are_finite() {
 
         let device_d = burn::tensor::Device::from(device.clone()).autodiff();
         let splats = Splats::from_raw(means, rots, ls, dc, opac, mode, &device_d);
-        let diff =
-            brush_render_bwd::render_splats(splats.clone(), &cam, img_size, glam::Vec3::ZERO).await;
+        let diff = brush_render_bwd::render_splats(
+            splats.clone(),
+            &cam,
+            img_size,
+            glam::Vec3::ZERO,
+            0.0,
+            0.0,
+        )
+        .await;
         splats.bwd_validate(diff.img.mean()).await;
     }
 }
@@ -541,9 +548,15 @@ async fn fuzz_bwd_extreme_inputs_stay_finite() {
                 SplatRenderMode::Default,
                 &device_d,
             );
-            let diff =
-                brush_render_bwd::render_splats(splats.clone(), &cam, img_size, glam::Vec3::ZERO)
-                    .await;
+            let diff = brush_render_bwd::render_splats(
+                splats.clone(),
+                &cam,
+                img_size,
+                glam::Vec3::ZERO,
+                0.0,
+                0.0,
+            )
+            .await;
             splats.bwd_validate(diff.img.mean()).await;
         }
     }

--- a/crates/brush-bench-test/tests/fuzz.rs
+++ b/crates/brush-bench-test/tests/fuzz.rs
@@ -505,15 +505,9 @@ async fn fuzz_bwd_random_scenes_gradients_are_finite() {
 
         let device_d = burn::tensor::Device::from(device.clone()).autodiff();
         let splats = Splats::from_raw(means, rots, ls, dc, opac, mode, &device_d);
-        let diff = brush_render_bwd::render_splats(
-            splats.clone(),
-            &cam,
-            img_size,
-            glam::Vec3::ZERO,
-            0.0,
-            0.0,
-        )
-        .await;
+        let diff =
+            brush_render_bwd::render_splats(splats.clone(), &cam, img_size, glam::Vec3::ZERO, 0.0)
+                .await;
         splats.bwd_validate(diff.img.mean()).await;
     }
 }
@@ -553,7 +547,6 @@ async fn fuzz_bwd_extreme_inputs_stay_finite() {
                 &cam,
                 img_size,
                 glam::Vec3::ZERO,
-                0.0,
                 0.0,
             )
             .await;

--- a/crates/brush-bench-test/tests/integration.rs
+++ b/crates/brush-bench-test/tests/integration.rs
@@ -170,7 +170,7 @@ async fn test_forward_rendering() {
         Pinhole,
     );
     let img_size = glam::uvec2(64, 64);
-    let result = render_splats(splats, &camera, img_size, Vec3::ZERO, 0.0, 0.0).await;
+    let result = render_splats(splats, &camera, img_size, Vec3::ZERO, 0.0).await;
     assert!(result.num_visible > 0, "no splats rendered");
     let data = result
         .img
@@ -307,7 +307,7 @@ async fn test_gradient_validation() {
     let img_size = glam::uvec2(64, 64);
 
     // Clone splats since render_splats takes ownership and we need splats for gradient validation
-    let result = render_splats(splats.clone(), &camera, img_size, Vec3::ZERO, 0.0, 0.0).await;
+    let result = render_splats(splats.clone(), &camera, img_size, Vec3::ZERO, 0.0).await;
     splats.bwd_validate(result.img.mean()).await;
 }
 

--- a/crates/brush-bench-test/tests/integration.rs
+++ b/crates/brush-bench-test/tests/integration.rs
@@ -170,7 +170,7 @@ async fn test_forward_rendering() {
         Pinhole,
     );
     let img_size = glam::uvec2(64, 64);
-    let result = render_splats(splats, &camera, img_size, Vec3::ZERO).await;
+    let result = render_splats(splats, &camera, img_size, Vec3::ZERO, 0.0, 0.0).await;
     assert!(result.num_visible > 0, "no splats rendered");
     let data = result
         .img
@@ -307,7 +307,7 @@ async fn test_gradient_validation() {
     let img_size = glam::uvec2(64, 64);
 
     // Clone splats since render_splats takes ownership and we need splats for gradient validation
-    let result = render_splats(splats.clone(), &camera, img_size, Vec3::ZERO).await;
+    let result = render_splats(splats.clone(), &camera, img_size, Vec3::ZERO, 0.0, 0.0).await;
     splats.bwd_validate(result.img.mean()).await;
 }
 

--- a/crates/brush-process/src/train_stream.rs
+++ b/crates/brush-process/src/train_stream.rs
@@ -173,7 +173,18 @@ pub(crate) async fn train_stream(
     let mut train_duration = Duration::from_secs(0);
     let mut dataloader = SceneLoader::new(&dataset.train, 42);
     let bounds = get_splat_bounds(init_splats.clone(), BOUND_PERCENTILE).await;
+
+    // Per-train-view (world center, focal-px at native res) for the
+    // Mip-Splatting 3D filter (always on).
+    let mut view_cams: Vec<(glam::Vec3, f32)> = Vec::with_capacity(dataset.train.views.len());
+    for view in dataset.train.views.iter() {
+        let (w, h) = view.image.dimensions().await.unwrap_or((1, 1));
+        let focal = view.camera.focal(glam::uvec2(w, h)).x;
+        view_cams.push((view.camera.position, focal));
+    }
+
     let mut trainer = SplatTrainer::new(&train_stream_config.train_config, &device, bounds);
+    trainer.set_view_cams(view_cams.clone());
 
     // Get the dataset name from the base path (if available) for interpolation.
     let dataset_name = vfs
@@ -264,6 +275,7 @@ pub(crate) async fn train_stream(
 
             let bounds = get_splat_bounds(splats.clone(), BOUND_PERCENTILE).await;
             trainer = SplatTrainer::new(&train_stream_config.train_config, &device, bounds);
+            trainer.set_view_cams(view_cams.clone());
 
             log::info!(
                 "LOD {current_lod}/{lod_levels}: Training for {lod_refine_steps} steps (image scale {:.0}%)",

--- a/crates/brush-process/src/train_stream.rs
+++ b/crates/brush-process/src/train_stream.rs
@@ -412,6 +412,16 @@ pub(crate) async fn train_stream(
                     .log_refine_stats(iter, &refine, refine_dur)
                     .unwrap();
             }
+
+            // Sample splat distribution shape (anisotropy, opacity, scale)
+            // every 1000 iters. Read-back is non-trivial, so don't run it
+            // every refine.
+            if iter % 1000 == 0 || is_last_step {
+                visualize
+                    .log_splat_distribution_stats(iter, splats.clone())
+                    .await
+                    .unwrap();
+            }
         }
 
         if refine.num_added > 0 {

--- a/crates/brush-process/src/train_stream.rs
+++ b/crates/brush-process/src/train_stream.rs
@@ -413,10 +413,9 @@ pub(crate) async fn train_stream(
                     .unwrap();
             }
 
-            // Sample splat distribution shape (anisotropy, opacity, scale)
-            // every 1000 iters. Read-back is non-trivial, so don't run it
-            // every refine.
-            if iter % 1000 == 0 || is_last_step {
+            // Distribution stats need a GPU read-back, so sample them on a
+            // coarser cadence than the per-refine stats.
+            if iter.is_multiple_of(rerun_config.rerun_log_distribution_every) || is_last_step {
                 visualize
                     .log_splat_distribution_stats(iter, splats.clone())
                     .await

--- a/crates/brush-render-bwd/src/burn_glue.rs
+++ b/crates/brush-render-bwd/src/burn_glue.rs
@@ -83,6 +83,8 @@ pub trait SplatBwdOps<B: Backend>: SplatOps<B> {
         project_uniforms: ProjectUniforms,
         render_mode: SplatRenderMode,
         v_combined: FloatTensor<B>,
+        screen_area_penalty: f32,
+        screen_area_threshold: f32,
     ) -> SplatGrads<B>;
 }
 
@@ -105,6 +107,8 @@ struct GaussianBackwardState<B: Backend> {
     pass: brush_render::gaussian_splats::RasterPass,
     background: Vec3,
     img_size: glam::UVec2,
+    screen_area_penalty: f32,
+    screen_area_threshold: f32,
 }
 
 #[derive(Debug)]
@@ -155,6 +159,8 @@ impl<B: Backend + SplatBwdOps<B>> Backward<B, NUM_BWD_ARGS> for RenderBackwards 
             state.project_uniforms,
             state.render_mode,
             rasterize_grads.v_combined,
+            state.screen_area_penalty,
+            state.screen_area_threshold,
         );
 
         if let Some(node) = transforms_parent {
@@ -231,6 +237,8 @@ pub async fn render_splats(
     camera: &Camera,
     img_size: glam::UVec2,
     background: Vec3,
+    screen_area_penalty: f32,
+    screen_area_threshold: f32,
 ) -> SplatOutputDiff {
     render_splats_with_pass(
         splats,
@@ -238,6 +246,8 @@ pub async fn render_splats(
         img_size,
         background,
         brush_render::gaussian_splats::RasterPass::Backward,
+        screen_area_penalty,
+        screen_area_threshold,
     )
     .await
 }
@@ -252,6 +262,8 @@ pub async fn render_splats_with_pass(
     img_size: glam::UVec2,
     background: Vec3,
     pass: brush_render::gaussian_splats::RasterPass,
+    screen_area_penalty: f32,
+    screen_area_threshold: f32,
 ) -> SplatOutputDiff {
     splats.clone().validate_values().await;
 
@@ -326,6 +338,8 @@ pub async fn render_splats_with_pass(
                 global_from_compact_gid: output.global_from_compact_gid,
                 background,
                 img_size,
+                screen_area_penalty,
+                screen_area_threshold,
             };
             prep.finish(state, output.out_img)
         }
@@ -447,7 +461,15 @@ impl SplatBwdOps<Self> for Fusion<MainBackendBase> {
         project_uniforms: ProjectUniforms,
         render_mode: SplatRenderMode,
         v_combined: FloatTensor<Self>,
+        screen_area_penalty: f32,
+        screen_area_threshold: f32,
     ) -> SplatGrads<Self> {
+        // The screen-area regulariser only acts in the backward kernel, so we
+        // stamp the values onto the uniforms here rather than in the forward.
+        let mut project_uniforms = project_uniforms;
+        project_uniforms.screen_area_penalty = screen_area_penalty;
+        project_uniforms.screen_area_threshold = screen_area_threshold;
+
         #[derive(Debug)]
         struct CustomOp {
             desc: CustomOpIr,
@@ -480,6 +502,9 @@ impl SplatBwdOps<Self> for Fusion<MainBackendBase> {
                     self.project_uniforms,
                     self.render_mode,
                     h.get_float_tensor::<MainBackendBase>(v_combined_in),
+                    // Already stamped onto the uniforms by the outer project_bwd.
+                    self.project_uniforms.screen_area_penalty,
+                    self.project_uniforms.screen_area_threshold,
                 );
 
                 h.register_float_tensor::<MainBackendBase>(&v_transforms.id, grads.v_transforms);

--- a/crates/brush-render-bwd/src/burn_glue.rs
+++ b/crates/brush-render-bwd/src/burn_glue.rs
@@ -7,7 +7,7 @@ use brush_render::burn_glue::{
 use brush_render::{
     SplatOps,
     camera::Camera,
-    gaussian_splats::{SplatRenderMode, Splats},
+    gaussian_splats::{SplatRenderMode, Splats, fold_min_scale},
     sh::sh_coeffs_for_degree,
     shaders::helpers::ProjectUniforms,
 };
@@ -212,6 +212,7 @@ pub fn lift_to_autodiff<const D: usize>(t: Tensor<D>) -> Tensor<D> {
 /// instead of `splats.train()` until upstream burn-dispatch fixes `from_inner`.
 pub fn lift_splats_to_autodiff(splats: Splats) -> Splats {
     let mip = splats.render_mip;
+    let min_scale = splats.min_scale.clone();
     let (transforms_id, transforms, _) = splats.transforms.consume();
     let (sh_coeffs_id, sh_coeffs, _) = splats.sh_coeffs.consume();
     let (raw_opacity_id, raw_opacity, _) = splats.raw_opacities.consume();
@@ -223,6 +224,11 @@ pub fn lift_splats_to_autodiff(splats: Splats) -> Splats {
             lift_to_autodiff(raw_opacity).require_grad(),
         ),
         render_mip: mip,
+        // Keep the frozen floor on the inner backend. `#[module(skip)]` fields
+        // aren't converted by `.valid()`, so lifting it here would leave an
+        // autodiff `f` on an inner module after eval-strip and mix backends in
+        // `scales()`/`opacities()`. The bwd render lifts a temporary copy.
+        min_scale,
     }
 }
 
@@ -269,9 +275,21 @@ pub async fn render_splats_with_pass(
 
     let refine_weight_holder = Tensor::<1>::zeros([1], &device).require_grad();
 
-    let transforms_ad = unwrap_ad_wgpu_float(splats.transforms.val());
+    // Fold the 3D-filter floor into scales/opacity for the render. `min_scale`
+    // lives on the inner backend, so lift a temporary copy to keep the fold on
+    // the autodiff graph alongside the param values.
+    let (transforms_val, raw_opac_val) = match &splats.min_scale {
+        Some(f) => fold_min_scale(
+            splats.transforms.val(),
+            splats.raw_opacities.val(),
+            lift_to_autodiff(f.clone()),
+        ),
+        None => (splats.transforms.val(), splats.raw_opacities.val()),
+    };
+
+    let transforms_ad = unwrap_ad_wgpu_float(transforms_val);
     let sh_coeffs_ad = unwrap_ad_wgpu_float(splats.sh_coeffs.val());
-    let raw_opac_ad = unwrap_ad_wgpu_float(splats.raw_opacities.val());
+    let raw_opac_ad = unwrap_ad_wgpu_float(raw_opac_val);
     let refine_weight_ad = unwrap_ad_wgpu_float(refine_weight_holder.clone());
 
     let prep_nodes = RenderBackwards

--- a/crates/brush-render-bwd/src/burn_glue.rs
+++ b/crates/brush-render-bwd/src/burn_glue.rs
@@ -84,7 +84,6 @@ pub trait SplatBwdOps<B: Backend>: SplatOps<B> {
         render_mode: SplatRenderMode,
         v_combined: FloatTensor<B>,
         screen_area_penalty: f32,
-        screen_area_threshold: f32,
     ) -> SplatGrads<B>;
 }
 
@@ -108,7 +107,6 @@ struct GaussianBackwardState<B: Backend> {
     background: Vec3,
     img_size: glam::UVec2,
     screen_area_penalty: f32,
-    screen_area_threshold: f32,
 }
 
 #[derive(Debug)]
@@ -160,7 +158,6 @@ impl<B: Backend + SplatBwdOps<B>> Backward<B, NUM_BWD_ARGS> for RenderBackwards 
             state.render_mode,
             rasterize_grads.v_combined,
             state.screen_area_penalty,
-            state.screen_area_threshold,
         );
 
         if let Some(node) = transforms_parent {
@@ -238,7 +235,6 @@ pub async fn render_splats(
     img_size: glam::UVec2,
     background: Vec3,
     screen_area_penalty: f32,
-    screen_area_threshold: f32,
 ) -> SplatOutputDiff {
     render_splats_with_pass(
         splats,
@@ -247,7 +243,6 @@ pub async fn render_splats(
         background,
         brush_render::gaussian_splats::RasterPass::Backward,
         screen_area_penalty,
-        screen_area_threshold,
     )
     .await
 }
@@ -263,7 +258,6 @@ pub async fn render_splats_with_pass(
     background: Vec3,
     pass: brush_render::gaussian_splats::RasterPass,
     screen_area_penalty: f32,
-    screen_area_threshold: f32,
 ) -> SplatOutputDiff {
     splats.clone().validate_values().await;
 
@@ -339,7 +333,6 @@ pub async fn render_splats_with_pass(
                 background,
                 img_size,
                 screen_area_penalty,
-                screen_area_threshold,
             };
             prep.finish(state, output.out_img)
         }
@@ -462,13 +455,11 @@ impl SplatBwdOps<Self> for Fusion<MainBackendBase> {
         render_mode: SplatRenderMode,
         v_combined: FloatTensor<Self>,
         screen_area_penalty: f32,
-        screen_area_threshold: f32,
     ) -> SplatGrads<Self> {
         // The screen-area regulariser only acts in the backward kernel, so we
-        // stamp the values onto the uniforms here rather than in the forward.
+        // stamp the weight onto the uniforms here rather than in the forward.
         let mut project_uniforms = project_uniforms;
         project_uniforms.screen_area_penalty = screen_area_penalty;
-        project_uniforms.screen_area_threshold = screen_area_threshold;
 
         #[derive(Debug)]
         struct CustomOp {
@@ -504,7 +495,6 @@ impl SplatBwdOps<Self> for Fusion<MainBackendBase> {
                     h.get_float_tensor::<MainBackendBase>(v_combined_in),
                     // Already stamped onto the uniforms by the outer project_bwd.
                     self.project_uniforms.screen_area_penalty,
-                    self.project_uniforms.screen_area_threshold,
                 );
 
                 h.register_float_tensor::<MainBackendBase>(&v_transforms.id, grads.v_transforms);

--- a/crates/brush-render-bwd/src/kernels/project_backwards.rs
+++ b/crates/brush-render-bwd/src/kernels/project_backwards.rs
@@ -193,7 +193,34 @@ pub fn project_backwards_kernel(
         c01: v_conics_y * 0.5f32,
         c11: v_conics_z,
     };
-    let v_cov2d = inverse2x2_vjp(conic_inv, v_inv);
+    let v_cov2d_image = inverse2x2_vjp(conic_inv, v_inv);
+
+    // Differentiable per-splat screen-area regulariser. The 1σ ellipse area
+    // in pixels is π·sqrt(det(cov)); as a fraction of the image it's
+    //   area_frac = π · sqrt(det) / (W · H)
+    // The in-kernel loss contribution is `weight · max(0, area_frac - τ)^2`
+    // normalised by num_visible. Gradient flows analytically into v_cov2d via
+    //   d(sqrt(det))/d(cov.c00) = cov.c11 / (2·sqrt(det))
+    //   d(sqrt(det))/d(cov.c01) = -cov.c01 / sqrt(det)
+    //   d(sqrt(det))/d(cov.c11) = cov.c00 / (2·sqrt(det))
+    // When weight=0, dloss_darea=0 → contribution is 0 (branch-free).
+    let det = cov.c00 * cov.c11 - cov.c01 * cov.c01;
+    let sqrt_det = f32::sqrt(f32::max(det, 1.0e-20f32));
+    let pi = 3.14159274f32;
+    let img_w_f = u.img_w as f32;
+    let img_h_f = u.img_h as f32;
+    let area_frac = pi * sqrt_det / (img_w_f * img_h_f);
+    let excess = f32::max(0.0f32, area_frac - u.screen_area_threshold);
+    let dloss_darea =
+        2.0f32 * u.screen_area_penalty * excess / f32::max(u.num_visible as f32, 1.0f32);
+    let inv_imghw = 1.0f32 / (img_w_f * img_h_f);
+    let half_pi_over_sqrtdet = pi * 0.5f32 / sqrt_det * inv_imghw;
+    let pi_over_sqrtdet = pi / sqrt_det * inv_imghw;
+    let v_cov2d = Sym2 {
+        c00: v_cov2d_image.c00 + dloss_darea * cov.c11 * half_pi_over_sqrtdet,
+        c01: v_cov2d_image.c01 + dloss_darea * (-cov.c01) * pi_over_sqrtdet,
+        c11: v_cov2d_image.c11 + dloss_darea * cov.c00 * half_pi_over_sqrtdet,
+    };
 
     // covar = M * M^T (symmetric).
     let covar = m.outer_product_self();

--- a/crates/brush-render-bwd/src/kernels/project_backwards.rs
+++ b/crates/brush-render-bwd/src/kernels/project_backwards.rs
@@ -196,23 +196,18 @@ pub fn project_backwards_kernel(
     let v_cov2d_image = inverse2x2_vjp(conic_inv, v_inv);
 
     // Differentiable per-splat screen-area regulariser. The 1σ ellipse area
-    // in pixels is π·sqrt(det(cov)); as a fraction of the image it's
-    //   area_frac = π · sqrt(det) / (W · H)
-    // The in-kernel loss contribution is `weight · max(0, area_frac - τ)^2`
-    // normalised by num_visible. Gradient flows analytically into v_cov2d via
-    //   d(sqrt(det))/d(cov.c00) = cov.c11 / (2·sqrt(det))
-    //   d(sqrt(det))/d(cov.c01) = -cov.c01 / sqrt(det)
-    //   d(sqrt(det))/d(cov.c11) = cov.c00 / (2·sqrt(det))
-    // When weight=0, dloss_darea=0 → contribution is 0 (branch-free).
+    // as a fraction of the image is `area_frac = π·sqrt(det(cov)) / (W·H)`, and
+    // the loss contribution is `weight · area_frac² / num_visible`. The gradient
+    // flows analytically into v_cov2d through `d(sqrt(det))/d(cov.*)`. With
+    // weight=0 the contribution is 0 (branch-free).
     let det = cov.c00 * cov.c11 - cov.c01 * cov.c01;
     let sqrt_det = f32::sqrt(f32::max(det, 1.0e-20f32));
-    let pi = 3.14159274f32;
+    let pi = core::f32::consts::PI;
     let img_w_f = u.img_w as f32;
     let img_h_f = u.img_h as f32;
     let area_frac = pi * sqrt_det / (img_w_f * img_h_f);
-    let excess = f32::max(0.0f32, area_frac - u.screen_area_threshold);
     let dloss_darea =
-        2.0f32 * u.screen_area_penalty * excess / f32::max(u.num_visible as f32, 1.0f32);
+        2.0f32 * u.screen_area_penalty * area_frac / f32::max(u.num_visible as f32, 1.0f32);
     let inv_imghw = 1.0f32 / (img_w_f * img_h_f);
     let half_pi_over_sqrtdet = pi * 0.5f32 / sqrt_det * inv_imghw;
     let pi_over_sqrtdet = pi / sqrt_det * inv_imghw;

--- a/crates/brush-render-bwd/src/render_bwd.rs
+++ b/crates/brush-render-bwd/src/render_bwd.rs
@@ -111,8 +111,16 @@ impl SplatBwdOps<Self> for MainBackendBase {
         project_uniforms: ProjectUniforms,
         render_mode: SplatRenderMode,
         v_combined: FloatTensor<Self>,
+        screen_area_penalty: f32,
+        screen_area_threshold: f32,
     ) -> SplatGrads<Self> {
         let _span = tracing::trace_span!("project_bwd").entered();
+
+        // The screen-area regulariser only acts in this backward kernel, so we
+        // stamp the values onto the uniforms here rather than in the forward.
+        let mut project_uniforms = project_uniforms;
+        project_uniforms.screen_area_penalty = screen_area_penalty;
+        project_uniforms.screen_area_threshold = screen_area_threshold;
 
         let transforms = into_contiguous(transforms);
         let sh_coeffs = into_contiguous(sh_coeffs);

--- a/crates/brush-render-bwd/src/render_bwd.rs
+++ b/crates/brush-render-bwd/src/render_bwd.rs
@@ -112,15 +112,13 @@ impl SplatBwdOps<Self> for MainBackendBase {
         render_mode: SplatRenderMode,
         v_combined: FloatTensor<Self>,
         screen_area_penalty: f32,
-        screen_area_threshold: f32,
     ) -> SplatGrads<Self> {
         let _span = tracing::trace_span!("project_bwd").entered();
 
         // The screen-area regulariser only acts in this backward kernel, so we
-        // stamp the values onto the uniforms here rather than in the forward.
+        // stamp the weight onto the uniforms here rather than in the forward.
         let mut project_uniforms = project_uniforms;
         project_uniforms.screen_area_penalty = screen_area_penalty;
-        project_uniforms.screen_area_threshold = screen_area_threshold;
 
         let transforms = into_contiguous(transforms);
         let sh_coeffs = into_contiguous(sh_coeffs);

--- a/crates/brush-render/src/gaussian_splats.rs
+++ b/crates/brush-render/src/gaussian_splats.rs
@@ -66,10 +66,46 @@ pub struct Splats {
     pub raw_opacities: Param<Tensor<1>>,
     #[module(skip)]
     pub render_mip: bool,
+    /// Optional per-splat world-space scale floor (Mip-Splatting's 3D filter).
+    /// Frozen, camera-derived, never optimized and never exported — a pure
+    /// training-time pressure. When set, the render path inflates each splat's
+    /// covariance to `sqrt(scale² + f²)` and energy-compensates opacity. `[N]`.
+    #[module(skip)]
+    pub min_scale: Option<Tensor<1>>,
 }
 
 pub fn inverse_sigmoid(x: f32) -> f32 {
     (x / (1.0 - x)).ln()
+}
+
+/// Mip-Splatting 3D smoothing filter: fold a per-splat world-space scale floor
+/// `f` `[N]` into the packed `transforms` `[N,10]` and `raw_opac` `[N]`. Scales
+/// become `sqrt(s² + f²)` and opacity is energy-compensated by `sqrt(det1/det2)`
+/// over the three world axes. Differentiable w.r.t. the learned scale/opacity;
+/// `f` is treated as a constant. This is the single source of truth for the
+/// floor — used by both render paths and by [`Splats::bake_min_scale`].
+pub fn fold_min_scale(
+    transforms: Tensor<2>,
+    raw_opac: Tensor<1>,
+    f: Tensor<1>,
+) -> (Tensor<2>, Tensor<1>) {
+    let n = transforms.dims()[0] as i32;
+    let log_scales = transforms.clone().slice(s![.., 7..10]); // [N,3]
+    let s2 = log_scales.mul_scalar(2.0).exp(); // s² = exp(2·log) [N,3]
+    let f2 = f.clone().mul(f).reshape([n, 1]); // [N,1]
+    let s2f = s2.clone().add(f2); // s² + f² [N,3]
+
+    let new_log = s2f.clone().log().mul_scalar(0.5); // log(sqrt(s²+f²)) [N,3]
+    let transforms = transforms.slice_assign(s![.., 7..10], new_log);
+
+    let det = |t: Tensor<2>| {
+        t.clone().slice(s![.., 0..1]) * t.clone().slice(s![.., 1..2]) * t.slice(s![.., 2..3])
+    };
+    let coef = (det(s2).div(det(s2f))).sqrt().reshape([n]); // sqrt(det1/det2) [N]
+    let opac = sigmoid(raw_opac).mul(coef).clamp(1e-6, 1.0 - 1e-6);
+    let raw_opac = opac.clone().div(opac.neg().add_scalar(1.0)).log(); // logit
+
+    (transforms, raw_opac)
 }
 
 impl Splats {
@@ -143,7 +179,16 @@ impl Splats {
             sh_coeffs: Param::initialized(ParamId::new(), sh_coeffs.detach().require_grad()),
             raw_opacities: Param::initialized(ParamId::new(), raw_opacity.detach().require_grad()),
             render_mip: mode == SplatRenderMode::Mip,
+            min_scale: None,
         }
+    }
+
+    /// Attach a per-splat world-space scale floor (see [`Splats::min_scale`]).
+    /// `f` must be `[num_splats]`. Training-only; cleared by refine and never
+    /// serialized.
+    pub fn with_min_scale(mut self, f: Tensor<1>) -> Self {
+        self.min_scale = Some(f);
+        self
     }
 
     /// Get means (positions) — slice of transforms columns 0..3.
@@ -161,12 +206,50 @@ impl Splats {
         self.transforms.val().slice(s![.., 7..10])
     }
 
+    /// Post-activation opacity, with the 3D-filter energy compensation folded
+    /// in when a `min_scale` floor is set (see [`fold_min_scale`]). This is the
+    /// splat's *real* opacity — callers (export, refine decisions, viewer)
+    /// should use it rather than reaching for `raw_opacities`.
     pub fn opacities(&self) -> Tensor<1> {
-        sigmoid(self.raw_opacities.val())
+        match &self.min_scale {
+            Some(f) => {
+                let (_, raw_opac) =
+                    fold_min_scale(self.transforms.val(), self.raw_opacities.val(), f.clone());
+                sigmoid(raw_opac)
+            }
+            None => sigmoid(self.raw_opacities.val()),
+        }
     }
 
+    /// World-space scales, with the 3D-filter floor folded in when `min_scale`
+    /// is set: `sqrt(scale² + f²)`. This is the splat's *real* size — the floor
+    /// is part of the splat's definition, so renders/exports use this, not the
+    /// raw `log_scales`.
     pub fn scales(&self) -> Tensor<2> {
-        self.log_scales().exp()
+        match &self.min_scale {
+            Some(f) => {
+                let (transforms, _) =
+                    fold_min_scale(self.transforms.val(), self.raw_opacities.val(), f.clone());
+                transforms.slice(s![.., 7..10]).exp()
+            }
+            None => self.log_scales().exp(),
+        }
+    }
+
+    /// Permanently fold the `min_scale` floor into the raw scale/opacity params
+    /// and clear it, yielding a plain canonical splat that renders identically.
+    /// Used at ply export so the floor is written as ordinary derived scales —
+    /// never as a separate field.
+    pub fn bake_min_scale(mut self) -> Self {
+        if let Some(f) = self.min_scale.take() {
+            let (transforms, raw_opac) =
+                fold_min_scale(self.transforms.val(), self.raw_opacities.val(), f);
+            self.transforms =
+                Param::initialized(self.transforms.id, transforms.detach().require_grad());
+            self.raw_opacities =
+                Param::initialized(self.raw_opacities.id, raw_opac.detach().require_grad());
+        }
+        self
     }
 
     pub fn num_splats(&self) -> u32 {
@@ -288,14 +371,23 @@ pub async fn render_splats(
     splats.clone().validate_values().await;
 
     let sh_coeffs = splats.sh_coeffs.into_value();
-    let raw_opacities = splats.raw_opacities.into_value();
+
+    // Fold the 3D-filter floor into scales/opacity first (the floor is part of
+    // the splat's definition, so eval/viewer render with it just like training).
+    let (transforms, raw_opacities) = match &splats.min_scale {
+        Some(f) => fold_min_scale(
+            splats.transforms.val(),
+            splats.raw_opacities.val(),
+            f.clone(),
+        ),
+        None => (splats.transforms.val(), splats.raw_opacities.val()),
+    };
 
     let transforms = if let Some(scale) = splat_scale {
-        let t = splats.transforms.into_value();
-        let adjusted = t.clone().slice(s![.., 7..10]) + scale.ln();
-        t.slice_assign(s![.., 7..10], adjusted)
+        let adjusted = transforms.clone().slice(s![.., 7..10]) + scale.ln();
+        transforms.slice_assign(s![.., 7..10], adjusted)
     } else {
-        splats.transforms.into_value()
+        transforms
     };
 
     let render_mode = if splats.render_mip {

--- a/crates/brush-render/src/kernels/types.rs
+++ b/crates/brush-render/src/kernels/types.rs
@@ -78,6 +78,8 @@ pub struct ProjectUniforms {
     pub sh_degree: u32,
     pub total_splats: u32,
     pub num_visible: u32,
+    pub screen_area_penalty: f32,
+    pub screen_area_threshold: f32,
 }
 
 #[cube]

--- a/crates/brush-render/src/kernels/types.rs
+++ b/crates/brush-render/src/kernels/types.rs
@@ -79,7 +79,6 @@ pub struct ProjectUniforms {
     pub total_splats: u32,
     pub num_visible: u32,
     pub screen_area_penalty: f32,
-    pub screen_area_threshold: f32,
 }
 
 #[cube]

--- a/crates/brush-render/src/lib.rs
+++ b/crates/brush-render/src/lib.rs
@@ -31,30 +31,6 @@ pub mod get_tile_offset;
 pub mod render;
 pub mod validation;
 
-/// Global config for the in-kernel screen-area regulariser. Set once by the
-/// training driver before the train loop starts; read inside the rasterizer
-/// host code when constructing `ProjectUniforms`. The values flow into the
-/// backward kernel which uses them to add an area-loss gradient contribution
-/// to v_cov2d. Zero penalty = disabled (the kernel branch short-circuits).
-use std::sync::atomic::{AtomicU32, Ordering};
-static SCREEN_AREA_PENALTY_BITS: AtomicU32 = AtomicU32::new(0);
-static SCREEN_AREA_THRESHOLD_BITS: AtomicU32 = AtomicU32::new(0);
-
-/// Set the screen-area penalty weight + threshold. Call before training.
-pub fn set_screen_area_penalty(weight: f32, threshold: f32) {
-    SCREEN_AREA_PENALTY_BITS.store(weight.to_bits(), Ordering::Relaxed);
-    SCREEN_AREA_THRESHOLD_BITS.store(threshold.to_bits(), Ordering::Relaxed);
-}
-
-/// Read the current screen-area penalty config. Used by the rasterizer host
-/// code to populate `ProjectUniforms`.
-pub fn screen_area_penalty_config() -> (f32, f32) {
-    (
-        f32::from_bits(SCREEN_AREA_PENALTY_BITS.load(Ordering::Relaxed)),
-        f32::from_bits(SCREEN_AREA_THRESHOLD_BITS.load(Ordering::Relaxed)),
-    )
-}
-
 /// `DispatchTensorKind` variant for the active wgpu backend. burn-dispatch
 /// uses different variant names per backend; brush only ever runs on the
 /// `WebGpu` variant, so this macro hides the variant name from match arms.

--- a/crates/brush-render/src/lib.rs
+++ b/crates/brush-render/src/lib.rs
@@ -31,6 +31,30 @@ pub mod get_tile_offset;
 pub mod render;
 pub mod validation;
 
+/// Global config for the in-kernel screen-area regulariser. Set once by the
+/// training driver before the train loop starts; read inside the rasterizer
+/// host code when constructing `ProjectUniforms`. The values flow into the
+/// backward kernel which uses them to add an area-loss gradient contribution
+/// to v_cov2d. Zero penalty = disabled (the kernel branch short-circuits).
+use std::sync::atomic::{AtomicU32, Ordering};
+static SCREEN_AREA_PENALTY_BITS: AtomicU32 = AtomicU32::new(0);
+static SCREEN_AREA_THRESHOLD_BITS: AtomicU32 = AtomicU32::new(0);
+
+/// Set the screen-area penalty weight + threshold. Call before training.
+pub fn set_screen_area_penalty(weight: f32, threshold: f32) {
+    SCREEN_AREA_PENALTY_BITS.store(weight.to_bits(), Ordering::Relaxed);
+    SCREEN_AREA_THRESHOLD_BITS.store(threshold.to_bits(), Ordering::Relaxed);
+}
+
+/// Read the current screen-area penalty config. Used by the rasterizer host
+/// code to populate `ProjectUniforms`.
+pub fn screen_area_penalty_config() -> (f32, f32) {
+    (
+        f32::from_bits(SCREEN_AREA_PENALTY_BITS.load(Ordering::Relaxed)),
+        f32::from_bits(SCREEN_AREA_THRESHOLD_BITS.load(Ordering::Relaxed)),
+    )
+}
+
 /// `DispatchTensorKind` variant for the active wgpu backend. burn-dispatch
 /// uses different variant names per backend; brush only ever runs on the
 /// `WebGpu` variant, so this macro hides the variant name from match arms.

--- a/crates/brush-render/src/render.rs
+++ b/crates/brush-render/src/render.rs
@@ -81,11 +81,8 @@ impl SplatOps<Self> for MainBackendBase {
             sh_degree,
             total_splats,
             num_visible: 0, // num_visible — not yet known.
-            // Screen-area regulariser is a backward-only concern; the forward
-            // leaves these at 0 and `project_bwd` overwrites them with the
-            // values threaded down from the training config.
+            // Backward-only; the forward leaves it 0 and `project_bwd` sets it.
             screen_area_penalty: 0.0,
-            screen_area_threshold: 0.0,
             jacobian_clamp_limits: calculate_jacobian_clamp_limits(
                 img_size,
                 pinhole_params,

--- a/crates/brush-render/src/render.rs
+++ b/crates/brush-render/src/render.rs
@@ -70,6 +70,7 @@ impl SplatOps<Self> for MainBackendBase {
             ((camera.fov_x as f32).hypot(camera.fov_y as f32) * 1.05).min(2.0 * PI - 1e-6) * 0.5;
         let pinhole_params = camera.build_pinhole_params(img_size);
 
+        let (screen_area_penalty, screen_area_threshold) = crate::screen_area_penalty_config();
         let mut project_uniforms = shaders::helpers::ProjectUniforms {
             viewmat: glam::Mat4::from(camera.world_to_local()).to_cols_array_2d(),
             camera_model: camera.camera_model,
@@ -81,6 +82,8 @@ impl SplatOps<Self> for MainBackendBase {
             sh_degree,
             total_splats,
             num_visible: 0, // num_visible — not yet known.
+            screen_area_penalty,
+            screen_area_threshold,
             jacobian_clamp_limits: calculate_jacobian_clamp_limits(
                 img_size,
                 pinhole_params,

--- a/crates/brush-render/src/render.rs
+++ b/crates/brush-render/src/render.rs
@@ -70,7 +70,6 @@ impl SplatOps<Self> for MainBackendBase {
             ((camera.fov_x as f32).hypot(camera.fov_y as f32) * 1.05).min(2.0 * PI - 1e-6) * 0.5;
         let pinhole_params = camera.build_pinhole_params(img_size);
 
-        let (screen_area_penalty, screen_area_threshold) = crate::screen_area_penalty_config();
         let mut project_uniforms = shaders::helpers::ProjectUniforms {
             viewmat: glam::Mat4::from(camera.world_to_local()).to_cols_array_2d(),
             camera_model: camera.camera_model,
@@ -82,8 +81,11 @@ impl SplatOps<Self> for MainBackendBase {
             sh_degree,
             total_splats,
             num_visible: 0, // num_visible — not yet known.
-            screen_area_penalty,
-            screen_area_threshold,
+            // Screen-area regulariser is a backward-only concern; the forward
+            // leaves these at 0 and `project_bwd` overwrites them with the
+            // values threaded down from the training config.
+            screen_area_penalty: 0.0,
+            screen_area_threshold: 0.0,
             jacobian_clamp_limits: calculate_jacobian_clamp_limits(
                 img_size,
                 pinhole_params,

--- a/crates/brush-render/src/shaders.rs
+++ b/crates/brush-render/src/shaders.rs
@@ -26,6 +26,10 @@ pub mod helpers {
         pub sh_degree: u32,
         pub total_splats: u32,
         pub num_visible: u32,
+        /// Weight on the in-kernel screen-area regulariser. 0 disables.
+        pub screen_area_penalty: f32,
+        /// Threshold for the screen-area regulariser (fraction of image).
+        pub screen_area_threshold: f32,
 
         // precomputed limits used for clamping the projection Jacobian
         pub jacobian_clamp_limits: JacobianClampLimits,
@@ -61,6 +65,8 @@ pub mod helpers {
                 self.sh_degree,
                 self.total_splats,
                 self.num_visible,
+                self.screen_area_penalty,
+                self.screen_area_threshold,
             )
         }
     }

--- a/crates/brush-render/src/shaders.rs
+++ b/crates/brush-render/src/shaders.rs
@@ -28,8 +28,6 @@ pub mod helpers {
         pub num_visible: u32,
         /// Weight on the in-kernel screen-area regulariser. 0 disables.
         pub screen_area_penalty: f32,
-        /// Threshold for the screen-area regulariser (fraction of image).
-        pub screen_area_threshold: f32,
 
         // precomputed limits used for clamping the projection Jacobian
         pub jacobian_clamp_limits: JacobianClampLimits,
@@ -66,7 +64,6 @@ pub mod helpers {
                 self.total_splats,
                 self.num_visible,
                 self.screen_area_penalty,
-                self.screen_area_threshold,
             )
         }
     }

--- a/crates/brush-rerun/Cargo.toml
+++ b/crates/brush-rerun/Cargo.toml
@@ -23,6 +23,7 @@ tokio.workspace = true
 rerun.workspace = true
 glam.workspace = true
 image.workspace = true
+log.workspace = true
 
 [lints]
 workspace = true

--- a/crates/brush-rerun/src/lib.rs
+++ b/crates/brush-rerun/src/lib.rs
@@ -28,6 +28,14 @@ pub struct RerunConfig {
         value_parser = clap::value_parser!(u32).range(1..)
     )]
     pub rerun_log_splats_every: Option<u32>,
+    /// How often to log the splat scale/opacity/anisotropy distribution stats.
+    #[arg(
+        long,
+        help_heading = "Rerun options",
+        default_value = "1000",
+        value_parser = clap::value_parser!(u32).range(1..)
+    )]
+    pub rerun_log_distribution_every: u32,
     /// The maximum size of images from the dataset logged to rerun.
     #[arg(long, help_heading = "Rerun options", default_value = "512")]
     pub rerun_max_img_size: u32,

--- a/crates/brush-rerun/src/visualize_tools.rs
+++ b/crates/brush-rerun/src/visualize_tools.rs
@@ -435,9 +435,9 @@ mod visualize_tools_impl {
         /// opacity, and anisotropy percentiles + degenerate-tail counts.
         ///
         /// Anisotropy is reported as two factors derived from the sorted scales
-        /// (s_max >= s_med >= s_min):
-        /// - spindle = s_max / s_med ("needle-likeness", higher = worse)
-        /// - flatness = s_med / s_min ("pancake-likeness", high = 2D surface, usually ok)
+        /// (`s_max` >= `s_med` >= `s_min)`:
+        /// - spindle = `s_max` / `s_med` ("needle-likeness", higher = worse)
+        /// - flatness = `s_med` / `s_min` ("pancake-likeness", high = 2D surface, usually ok)
         pub async fn log_splat_distribution_stats(&self, iter: u32, splats: Splats) -> Result<()> {
             let scales_data = splats
                 .scales()

--- a/crates/brush-rerun/src/visualize_tools.rs
+++ b/crates/brush-rerun/src/visualize_tools.rs
@@ -30,6 +30,45 @@ mod visualize_tools_impl {
 
     use super::VisualizeTools;
 
+    struct Percentiles {
+        p01: f64,
+        p25: f64,
+        p50: f64,
+        p75: f64,
+        p95: f64,
+        p99: f64,
+        max: f64,
+    }
+
+    fn percentiles(values: &[f32]) -> Percentiles {
+        let mut sorted: Vec<f32> = values.iter().copied().filter(|v| v.is_finite()).collect();
+        if sorted.is_empty() {
+            return Percentiles {
+                p01: 0.0,
+                p25: 0.0,
+                p50: 0.0,
+                p75: 0.0,
+                p95: 0.0,
+                p99: 0.0,
+                max: 0.0,
+            };
+        }
+        sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        let pct = |p: f32| -> f64 {
+            let idx = ((p * (sorted.len() as f32 - 1.0)).round() as usize).min(sorted.len() - 1);
+            sorted[idx] as f64
+        };
+        Percentiles {
+            p01: pct(0.01),
+            p25: pct(0.25),
+            p50: pct(0.50),
+            p75: pct(0.75),
+            p95: pct(0.95),
+            p99: pct(0.99),
+            max: pct(1.00),
+        }
+    }
+
     fn resize_to_max(img: image::RgbImage, max_size: u32) -> image::RgbImage {
         let (w, h) = img.dimensions();
         let longest = w.max(h);
@@ -392,6 +431,160 @@ mod visualize_tools_impl {
             Ok(())
         }
 
+        /// Log distributional shape stats for the current splat config: scale,
+        /// opacity, and anisotropy percentiles + degenerate-tail counts.
+        ///
+        /// Anisotropy is reported as two factors derived from the sorted scales
+        /// (s_max >= s_med >= s_min):
+        /// - spindle = s_max / s_med ("needle-likeness", higher = worse)
+        /// - flatness = s_med / s_min ("pancake-likeness", high = 2D surface, usually ok)
+        pub async fn log_splat_distribution_stats(&self, iter: u32, splats: Splats) -> Result<()> {
+            let scales_data = splats
+                .scales()
+                .into_data_async()
+                .await?
+                .into_vec::<f32>()
+                .expect("scales");
+            let opac_data = splats
+                .opacities()
+                .into_data_async()
+                .await?
+                .into_vec::<f32>()
+                .expect("opacities");
+
+            let n = opac_data.len();
+            if n == 0 {
+                return Ok(());
+            }
+            let mut max_scales = Vec::with_capacity(n);
+            let mut min_scales = Vec::with_capacity(n);
+            let mut spindle = Vec::with_capacity(n);
+            let mut flatness = Vec::with_capacity(n);
+            for chunk in scales_data.chunks(3) {
+                let mut s = [chunk[0], chunk[1], chunk[2]];
+                s.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+                let smin = s[0].max(1e-30);
+                let smed = s[1].max(1e-30);
+                let smax = s[2].max(1e-30);
+                max_scales.push(smax);
+                min_scales.push(smin);
+                spindle.push(smax / smed);
+                flatness.push(smed / smin);
+            }
+
+            let log10 = |v: &[f32]| -> Vec<f32> { v.iter().map(|x| x.log10()).collect() };
+            let max_log = log10(&max_scales);
+            let min_log = log10(&min_scales);
+
+            let n_total = n as f64;
+            let frac = |p: usize| (p as f64) / n_total;
+
+            let n_spindle_gt_3 = spindle.iter().filter(|x| **x > 3.0).count();
+            let n_spindle_gt_5 = spindle.iter().filter(|x| **x > 5.0).count();
+            let n_spindle_gt_10 = spindle.iter().filter(|x| **x > 10.0).count();
+            let n_opac_lt_05 = opac_data.iter().filter(|x| **x < 0.05).count();
+            let n_opac_lt_20 = opac_data.iter().filter(|x| **x < 0.20).count();
+
+            let spindle_pct = percentiles(&spindle);
+            let scale_max_pct = percentiles(&max_log);
+            let opac_pct = percentiles(&opac_data);
+
+            log::info!(
+                concat!(
+                    "splat_dist iter={iter} n={n} ",
+                    "spindle p50={sp50:.2} p95={sp95:.2} p99={sp99:.2} max={spmax:.2} ",
+                    "frac_gt_3={fr3:.4} frac_gt_5={fr5:.4} frac_gt_10={fr10:.4} ",
+                    "scale_max_log10 p50={smp50:.2} p99={smp99:.2} max={smmax:.2} ",
+                    "opac p50={op50:.2} p25={op25:.2} p01={op01:.2} ",
+                    "frac_opac_lt_05={fol05:.4} frac_opac_lt_20={fol20:.4}"
+                ),
+                iter = iter,
+                n = n,
+                sp50 = spindle_pct.p50,
+                sp95 = spindle_pct.p95,
+                sp99 = spindle_pct.p99,
+                spmax = spindle_pct.max,
+                fr3 = frac(n_spindle_gt_3),
+                fr5 = frac(n_spindle_gt_5),
+                fr10 = frac(n_spindle_gt_10),
+                smp50 = scale_max_pct.p50,
+                smp99 = scale_max_pct.p99,
+                smmax = scale_max_pct.max,
+                op50 = opac_pct.p50,
+                op25 = opac_pct.p25,
+                op01 = opac_pct.p01,
+                fol05 = frac(n_opac_lt_05),
+                fol20 = frac(n_opac_lt_20),
+            );
+
+            if !self.rec.is_enabled() {
+                return Ok(());
+            }
+            self.rec.set_time_sequence("iterations", iter);
+
+            self.log_percentiles("splat_dist/scale_max_log10", &max_log)?;
+            self.log_percentiles("splat_dist/scale_min_log10", &min_log)?;
+            self.log_percentiles("splat_dist/opacity", &opac_data)?;
+            self.log_percentiles("splat_dist/spindle", &spindle)?;
+            self.log_percentiles("splat_dist/flatness", &flatness)?;
+
+            self.rec.log(
+                "splat_dist/frac_spindle_gt_3",
+                &rerun::Scalars::new(vec![frac(n_spindle_gt_3)]),
+            )?;
+            self.rec.log(
+                "splat_dist/frac_spindle_gt_5",
+                &rerun::Scalars::new(vec![frac(n_spindle_gt_5)]),
+            )?;
+            self.rec.log(
+                "splat_dist/frac_spindle_gt_10",
+                &rerun::Scalars::new(vec![frac(n_spindle_gt_10)]),
+            )?;
+            self.rec.log(
+                "splat_dist/frac_opac_lt_05",
+                &rerun::Scalars::new(vec![frac(n_opac_lt_05)]),
+            )?;
+            self.rec.log(
+                "splat_dist/frac_opac_lt_20",
+                &rerun::Scalars::new(vec![frac(n_opac_lt_20)]),
+            )?;
+
+            Ok(())
+        }
+
+        fn log_percentiles(&self, path_prefix: &str, values: &[f32]) -> Result<()> {
+            let p = percentiles(values);
+            self.rec.log(
+                format!("{path_prefix}/p01"),
+                &rerun::Scalars::new(vec![p.p01]),
+            )?;
+            self.rec.log(
+                format!("{path_prefix}/p25"),
+                &rerun::Scalars::new(vec![p.p25]),
+            )?;
+            self.rec.log(
+                format!("{path_prefix}/p50"),
+                &rerun::Scalars::new(vec![p.p50]),
+            )?;
+            self.rec.log(
+                format!("{path_prefix}/p75"),
+                &rerun::Scalars::new(vec![p.p75]),
+            )?;
+            self.rec.log(
+                format!("{path_prefix}/p95"),
+                &rerun::Scalars::new(vec![p.p95]),
+            )?;
+            self.rec.log(
+                format!("{path_prefix}/p99"),
+                &rerun::Scalars::new(vec![p.p99]),
+            )?;
+            self.rec.log(
+                format!("{path_prefix}/max"),
+                &rerun::Scalars::new(vec![p.max]),
+            )?;
+            Ok(())
+        }
+
         pub fn is_enabled(&self) -> bool {
             self.rec.is_enabled()
         }
@@ -551,6 +744,15 @@ mod visualize_tools_impl {
         #[allow(unused_variables)]
         #[allow(clippy::unnecessary_wraps, clippy::unused_self)]
         pub fn log_splat_stats(&self, _iter: u32, _num_splats: u32) -> Result<()> {
+            Ok(())
+        }
+
+        #[allow(unused_variables)]
+        pub async fn log_splat_distribution_stats(
+            &self,
+            _iter: u32,
+            _splats: Splats,
+        ) -> Result<()> {
             Ok(())
         }
 

--- a/crates/brush-serde/src/export.rs
+++ b/crates/brush-serde/src/export.rs
@@ -177,6 +177,9 @@ async fn read_splat_data(splats: Splats) -> Result<DynamicPly, ExportError> {
 }
 
 pub async fn splat_to_ply(splats: Splats) -> Result<Vec<u8>, ExportError> {
+    // Fold any 3D-filter floor into the stored scales/opacity so the ply holds
+    // ordinary derived values — the floor is never written as a separate field.
+    let splats = splats.bake_min_scale();
     let sh_degree = splats.sh_degree();
     let ply = read_splat_data(splats.clone()).await?;
 

--- a/crates/brush-train/src/config.rs
+++ b/crates/brush-train/src/config.rs
@@ -37,7 +37,7 @@ pub struct TrainConfig {
     pub lr_opac: f64,
 
     /// Learning rate for the scale parameters.
-    #[arg(long, help_heading = "Training options", default_value = "7e-3")]
+    #[arg(long, help_heading = "Training options", default_value = "3.5e-3")]
     pub lr_scale: f64,
 
     /// Learning rate for the rotation parameters.
@@ -71,10 +71,36 @@ pub struct TrainConfig {
     #[arg(long, help_heading = "Refine options", default_value = "15000")]
     pub growth_stop_iter: u32,
 
-    /// Force-split any splat whose screen-space extent exceeds this fraction of the
-    /// image dimension in any training view since the last refine. 0 disables.
-    #[arg(long, help_heading = "Refine options", default_value = "0.25")]
-    pub split_at_screen_size: f32,
+    /// Per-axis shrink ratio for the covariance-aware split. Each child axis
+    /// shrinks by `k_i = 1 - (1-k)·(s_i²/s_max²)`: the principal axis shrinks
+    /// by `k`, much-smaller axes are left ~unchanged. Offsets are
+    /// mass-conserving per axis (`±sqrt(1-k_i²)·s_i`). The natural value is
+    /// 1/√2 ≈ 0.707 (matches the variance-preserving 2-component mixture);
+    /// lower over-shrinks and triggers compensatory over-densification.
+    #[arg(long, help_heading = "Refine options", default_value = "0.707")]
+    pub split_anisotropic_k: f32,
+
+    /// Prune-and-resample any splat whose max screen-space extent exceeds this
+    /// fraction of the image dimension. The splat is treated as "poisoned":
+    /// killed, and the freed budget is re-sampled elsewhere. Runs every refine
+    /// (including post-growth). 0 disables.
+    #[arg(long, help_heading = "Refine options", default_value = "0.5")]
+    pub kill_at_screen_size: f32,
+
+    /// Weight on the differentiable per-splat screen-area penalty, applied in
+    /// the `project_backwards` kernel: the analytic gradient of
+    /// `weight·max(0, area_frac - threshold)² / num_visible` (area_frac =
+    /// π·sqrt(det(cov_2d))/(W·H)) is added to the 2D-covariance gradient and
+    /// flows back to scales/rotations/means. A gentle nudge toward small
+    /// on-screen footprints; `kill_at_screen_size` handles the hard outliers.
+    /// 0 disables.
+    #[arg(long, help_heading = "Training options", default_value = "0.01")]
+    pub screen_area_penalty: f32,
+
+    /// Threshold for `screen_area_penalty` (fraction of image area). Only the
+    /// excess `area_frac - threshold` is penalised.
+    #[arg(long, help_heading = "Training options", default_value = "0.05")]
+    pub screen_area_threshold: f32,
 
     /// Weight of SSIM loss (compared to l1 loss)
     #[clap(long, help_heading = "Training options", default_value = "0.2")]

--- a/crates/brush-train/src/config.rs
+++ b/crates/brush-train/src/config.rs
@@ -93,7 +93,7 @@ pub struct TrainConfig {
     /// is added to the 2D-covariance gradient and flows back to
     /// scales/rotations/means. A gentle nudge toward small on-screen
     /// footprints; `kill_at_screen_size` handles the hard outliers. 0 disables.
-    #[arg(long, help_heading = "Training options", default_value = "0.005")]
+    #[arg(long, help_heading = "Training options", default_value = "0.05")]
     pub screen_area_penalty: f32,
 
     /// Weight of SSIM loss (compared to l1 loss)

--- a/crates/brush-train/src/config.rs
+++ b/crates/brush-train/src/config.rs
@@ -37,7 +37,7 @@ pub struct TrainConfig {
     pub lr_opac: f64,
 
     /// Learning rate for the scale parameters.
-    #[arg(long, help_heading = "Training options", default_value = "3.5e-3")]
+    #[arg(long, help_heading = "Training options", default_value = "5e-3")]
     pub lr_scale: f64,
 
     /// Learning rate for the rotation parameters.

--- a/crates/brush-train/src/config.rs
+++ b/crates/brush-train/src/config.rs
@@ -89,18 +89,12 @@ pub struct TrainConfig {
 
     /// Weight on the differentiable per-splat screen-area penalty, applied in
     /// the `project_backwards` kernel: the analytic gradient of
-    /// `weight·max(0, area_frac - threshold)² / num_visible` (area_frac =
-    /// π·sqrt(det(cov_2d))/(W·H)) is added to the 2D-covariance gradient and
-    /// flows back to scales/rotations/means. A gentle nudge toward small
-    /// on-screen footprints; `kill_at_screen_size` handles the hard outliers.
-    /// 0 disables.
-    #[arg(long, help_heading = "Training options", default_value = "0.01")]
+    /// `weight·area_frac² / num_visible` (`area_frac` = `π·sqrt(det(cov_2d))/(W·H)`)
+    /// is added to the 2D-covariance gradient and flows back to
+    /// scales/rotations/means. A gentle nudge toward small on-screen
+    /// footprints; `kill_at_screen_size` handles the hard outliers. 0 disables.
+    #[arg(long, help_heading = "Training options", default_value = "0.005")]
     pub screen_area_penalty: f32,
-
-    /// Threshold for `screen_area_penalty` (fraction of image area). Only the
-    /// excess `area_frac - threshold` is penalised.
-    #[arg(long, help_heading = "Training options", default_value = "0.05")]
-    pub screen_area_threshold: f32,
 
     /// Weight of SSIM loss (compared to l1 loss)
     #[clap(long, help_heading = "Training options", default_value = "0.2")]

--- a/crates/brush-train/src/lod.rs
+++ b/crates/brush-train/src/lod.rs
@@ -98,7 +98,10 @@ pub async fn compute_pup_scores(
         let mut splats: Splats = splats.clone().train();
         splats.transforms = splats.transforms.map(|t: Tensor<2>| t.require_grad());
 
-        let diff_out = render_splats(splats.clone(), &view.camera, img_size, Vec3::ZERO).await;
+        // No screen-area penalty for LOD sensitivity scoring — keep the
+        // gradient on pure image loss.
+        let diff_out =
+            render_splats(splats.clone(), &view.camera, img_size, Vec3::ZERO, 0.0, 0.0).await;
         let pred_rgb = diff_out.img.slice(s![.., .., 0..3]);
 
         let gt_packed: Tensor<2, Int> = Tensor::from_data(gt_data, device);

--- a/crates/brush-train/src/lod.rs
+++ b/crates/brush-train/src/lod.rs
@@ -100,8 +100,7 @@ pub async fn compute_pup_scores(
 
         // No screen-area penalty for LOD sensitivity scoring — keep the
         // gradient on pure image loss.
-        let diff_out =
-            render_splats(splats.clone(), &view.camera, img_size, Vec3::ZERO, 0.0, 0.0).await;
+        let diff_out = render_splats(splats.clone(), &view.camera, img_size, Vec3::ZERO, 0.0).await;
         let pred_rgb = diff_out.img.slice(s![.., .., 0..3]);
 
         let gt_packed: Tensor<2, Int> = Tensor::from_data(gt_data, device);

--- a/crates/brush-train/src/stats.rs
+++ b/crates/brush-train/src/stats.rs
@@ -28,13 +28,6 @@ impl RefineRecord {
             .bool_and(self.vis_mask())
     }
 
-    pub(crate) fn above_screen_size(&self, threshold: f32) -> Tensor<1, Bool> {
-        self.max_screen_size
-            .clone()
-            .greater_elem(threshold)
-            .bool_and(self.vis_mask())
-    }
-
     pub(crate) fn gather_stats(
         &mut self,
         refine_weight: Tensor<1>,

--- a/crates/brush-train/src/train.rs
+++ b/crates/brush-train/src/train.rs
@@ -78,6 +78,15 @@ impl SplatTrainer {
 
         let ssim_enabled = config.ssim_weight > 0.0;
 
+        // Push the in-kernel screen-area regulariser config into the
+        // brush-render global so the host code's ProjectUniforms
+        // construction picks it up and the backward kernel applies the
+        // gradient contribution to v_cov2d.
+        brush_render::set_screen_area_penalty(
+            config.screen_area_penalty,
+            config.screen_area_threshold,
+        );
+
         // Growth is gated on the global iter. LOD phases run past
         // total_train_iters but their refines should never grow — clamp
         // here so growth_stop is never effectively past end-of-training.
@@ -366,6 +375,49 @@ impl SplatTrainer {
             .take()
             .expect("Can only refine if refine stats are initialized");
 
+        // Log per-splat screen-size distribution so we can track how
+        // many splats are visually large (and thus susceptible to the
+        // "big-low-α" failure mode). Uses `max_screen_size` (fraction of
+        // the smaller image dim covered by the larger 2D ellipse extent);
+        // area is approximated by squaring it (upper bound — exact for
+        // round splats, overestimates for needles). Cheap CPU pass on
+        // ~1M floats; gated on refine cadence anyway.
+        let ss_data = refiner
+            .max_screen_size
+            .clone()
+            .into_data_async()
+            .await
+            .expect("Failed to read screen size")
+            .into_vec::<f32>()
+            .expect("Failed to read screen size vec");
+        if !ss_data.is_empty() {
+            let mut sorted: Vec<f32> = ss_data.iter().copied().filter(|v| v.is_finite()).collect();
+            sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+            let n = sorted.len();
+            let pct = |p: f32| sorted[((p * (n - 1) as f32) as usize).min(n - 1)];
+            let n_total = n as f64;
+            let n_gt_025 = ss_data.iter().filter(|v| **v > 0.25).count();
+            let n_gt_010 = ss_data.iter().filter(|v| **v > 0.10).count();
+            let n_gt_005 = ss_data.iter().filter(|v| **v > 0.05).count();
+            // area fraction (upper bound) = max_dim^2
+            let n_area_gt_005 = ss_data.iter().filter(|v| (*v * *v) > 0.05).count();
+            let n_area_gt_010 = ss_data.iter().filter(|v| (*v * *v) > 0.10).count();
+            log::info!(
+                "screen_size iter={} n={} max_dim p50={:.4} p95={:.4} p99={:.4} max={:.4} frac>0.05={:.4} frac>0.10={:.4} frac>0.25={:.4} frac_area>0.05={:.4} frac_area>0.10={:.4}",
+                iter,
+                n,
+                pct(0.5),
+                pct(0.95),
+                pct(0.99),
+                pct(1.0),
+                n_gt_005 as f64 / n_total,
+                n_gt_010 as f64 / n_total,
+                n_gt_025 as f64 / n_total,
+                n_area_gt_005 as f64 / n_total,
+                n_area_gt_010 as f64 / n_total,
+            );
+        }
+
         let max_allowed_bounds = self.bounds.extent.max_element() * 100.0;
 
         // If not refining, update splat to step with gradients applied.
@@ -378,8 +430,12 @@ impl SplatTrainer {
         let alpha_mask = splats.opacities().lower_elem(MIN_OPACITY);
         let scales = splats.scales();
 
-        let scale_small = scales.clone().lower_elem(1e-10).any_dim(1).squeeze_dim(1);
+        // Note: we do NOT cull on a minimum scale. A genuinely flat splat
+        // (a thin "pancake" representing a surface) legitimately has a tiny
+        // smallest axis, so there's no correct min-scale threshold — the
+        // non-finite check below still removes actually-degenerate splats.
         let scale_big = scales
+            .clone()
             .greater_elem(max_allowed_bounds)
             .any_dim(1)
             .squeeze_dim(1);
@@ -409,11 +465,31 @@ impl SplatTrainer {
             .into_scalar_async::<i32>()
             .await
             .expect("Failed to count non-finite splats") as u32;
+
+        // "Poisoned" big-screen prune: kill splats whose max 2D screen extent
+        // exceeds the threshold (every refine, including post-growth). The
+        // freed budget is re-sampled below. This handles the hard outliers
+        // that the smooth split + area regulariser don't reach on their own.
+        let big_screen_mask = if self.config.kill_at_screen_size > 0.0 {
+            Some(
+                refiner
+                    .max_screen_size
+                    .clone()
+                    .greater_elem(self.config.kill_at_screen_size),
+            )
+        } else {
+            None
+        };
+
         let prune_mask = alpha_mask
-            .bool_or(scale_small)
             .bool_or(scale_big)
             .bool_or(bound_mask)
             .bool_or(non_finite_mask);
+        let prune_mask = if let Some(bsm) = big_screen_mask {
+            prune_mask.bool_or(bsm)
+        } else {
+            prune_mask
+        };
 
         let (mut splats, refiner, pruned_count) =
             prune_points(splats, &mut record, refiner, prune_mask).await;
@@ -436,35 +512,10 @@ impl SplatTrainer {
             split_inds.extend(resampled_inds);
         }
 
-        let pre_oversized = split_inds.len();
-        // Force-split oversized splats, gated by growth_stop_iter. Without
-        // the gate, oversized splats from an init ply keep splitting past
-        // the stop iter when there isn't enough training time for them to
-        // shrink first.
-        if self.config.split_at_screen_size > 0.0 && iter < self.config.growth_stop_iter {
-            let oversized = refiner.above_screen_size(self.config.split_at_screen_size);
-            let oversized_vec = oversized
-                .float()
-                .into_data_async()
-                .await
-                .expect("Failed to get oversized mask")
-                .into_vec::<f32>()
-                .expect("Failed to read oversized mask");
-            let mut budget = self
-                .config
-                .max_splats
-                .saturating_sub(splats.num_splats() + split_inds.len() as u32);
-            for (i, &v) in oversized_vec.iter().enumerate() {
-                if budget == 0 {
-                    break;
-                }
-                if v > 0.0 && split_inds.insert(i as i32) {
-                    budget -= 1;
-                }
-            }
-        }
-
-        let num_split_oversized = (split_inds.len() - pre_oversized) as u32;
+        // Big splats are no longer force-split in place — they're killed and
+        // resampled via `kill_at_screen_size` (the prune path above), so the
+        // "oversized split" count is always 0 now.
+        let num_split_oversized = 0u32;
 
         let pre_high_grad = split_inds.len();
         if iter < self.config.growth_stop_iter {
@@ -563,26 +614,59 @@ impl SplatTrainer {
             let cur_scales = cur_log_scale.clone().exp();
 
             let cur_opac = sigmoid(cur_raw_opac.clone());
-            let inv_opac: Tensor<1> = 1.0 - cur_opac;
-            let new_opac: Tensor<1> = 1.0 - inv_opac.sqrt();
+            let inv_opac: Tensor<1> = 1.0 - cur_opac.clone();
+            // Post-split child opacity: power law in transmittance,
+            //   a' = 1 - (1 - a)^p.
+            // Alpha compositing multiplies transmittance (1-a), so p encodes
+            // the effective overlap: p=1/2 reproduces the parent when the two
+            // children fully overlap (classic 3DGS); p=1 is full inheritance
+            // (no overlap). The covariance-aware split offsets the children
+            // ~2 child-stds apart (= 2·sqrt(1-k²)/k at k=1/√2), i.e. between 1
+            // and 2 effective overlapping copies — which is exactly where
+            // p = 1/√2 lands. A p-sweep confirmed the PSNR optimum at ~0.7
+            // with monotonically fewer low-opacity ambient splats. So p
+            // reuses the split's own constant.
+            let p = std::f32::consts::FRAC_1_SQRT_2;
+            let new_opac: Tensor<1> = 1.0 - inv_opac.powf_scalar(p);
             let new_raw_opac = inv_sigmoid(new_opac.clamp(MIN_OPACITY, 1.0 - MIN_OPACITY));
 
-            let f_clamped = std::f32::consts::FRAC_1_SQRT_2;
-            let offset_std = (1.0_f32 - f_clamped * f_clamped).sqrt();
-            let (new_log_scales, samples) = {
-                // Mirror split (.sample): 2-component mixture exactly
-                // preserves parent's covariance. Sample from parent's
-                // anisotropic gaussian with math-correct std.
-                let log_factor = f_clamped.ln();
-                let new_log_scales = cur_log_scale.clone() + log_factor;
-                let sample_local = Tensor::random(
-                    [refine_count, 3],
-                    Distribution::Normal(0.0, offset_std as f64),
-                    device,
-                ) * cur_scales;
-                let samples = quaternion_vec_multiply(cur_rots.clone(), sample_local);
-                (new_log_scales, samples)
-            };
+            // Smooth covariance-aware split. Per-axis shrink factor:
+            //   k_i = 1 - (1 - k) * (scale_i² / scale_max²)
+            // is k on the principal axis, smoothly approaching 1 on much-
+            // smaller axes. Mass-conserving on each axis independently:
+            //   new_scale_i = k_i * scale_i
+            //   offset_i    = sqrt(1 - k_i²) * scale_i (deterministic ±)
+            // Limits: isotropic → uniform shrink, diagonal offset (≈ the old
+            // iso mirror split). Needle → axial shrink + axial offset only.
+            // Pancake → in-plane shrink + offset, thin axis untouched. One
+            // function, no threshold.
+            //   k_i = 1 - (1 - k) · (s_i² / s_max²)        ∈ [k, 1]
+            //   new_scale_i = k_i · s_i
+            //   offset_i    = sqrt(1 - k_i²) · s_i         (deterministic ±)
+            // Mass-conserving on each axis: offset_i² + (k_i·s_i)² = s_i².
+            // k is pinned near 1/√2 (the variance-preserving 2-component
+            // mixture value); clamped to (0,1) for safety.
+            let k: f32 = self.config.split_anisotropic_k.max(1e-3).min(0.99);
+            let cur_scales_sq = cur_scales.clone().powi_scalar(2);
+            let max_scale_sq = cur_scales_sq.clone().max_dim(1).clamp_min(1e-30);
+            // ratio_i = s_i² / s_max²  (broadcast [N,3] / [N,1])
+            let ratio = cur_scales_sq / max_scale_sq;
+            // k_i = 1 - (1 - k) · ratio_i
+            let one_minus_k = 1.0_f32 - k;
+            let k_per_axis: Tensor<2> = -(ratio * one_minus_k) + 1.0;
+            let offset_factor_per_axis = (-k_per_axis.clone().powi_scalar(2) + 1.0)
+                .clamp_min(0.0)
+                .sqrt();
+            let offset_local = offset_factor_per_axis * cur_scales.clone();
+            let samples = quaternion_vec_multiply(cur_rots.clone(), offset_local);
+            // log_scale_diff_i = ln(k_i)  — applied additively to cur_log_scale below.
+            let log_scale_diff: Tensor<2> = k_per_axis.log();
+
+            let new_log_scales = cur_log_scale.clone() + log_scale_diff.clone();
+
+            // Children inherit the parent's rotation; the split is expressed
+            // entirely through the per-axis scale shrink + ±offset.
+            let child_rots = cur_rots.clone();
 
             // Shrink & offset existing splats.
 
@@ -605,9 +689,11 @@ impl SplatTrainer {
                 m.scatter(0, refine_inds.clone(), difference, IndexingUpdateOp::Add)
             });
 
+            // Child sits at parent_mean + samples (parent moves to
+            // parent_mean - samples) — anti-correlated, centroid-preserving.
             // Build new transforms row: means(3) + rotations(4) + log_scales(3)
             let new_transforms =
-                Tensor::cat(vec![cur_means + samples, cur_rots, new_log_scales], 1);
+                Tensor::cat(vec![cur_means + samples, child_rots, new_log_scales], 1);
             // Optimizer state lives on the inner (non-autodiff) device.
             let opt_device = device.clone().inner();
             let refine_inds_opt = refine_inds.to_device(&opt_device);
@@ -663,6 +749,7 @@ impl SplatTrainer {
             let new_opac = sigmoid(f) - minus_opac;
             inv_sigmoid(new_opac.clamp(1e-12, 1.0 - 1e-12))
         });
+
         self.optim = Some(create_optimizer_from_config().load_record(record));
         splats
     }

--- a/crates/brush-train/src/train.rs
+++ b/crates/brush-train/src/train.rs
@@ -139,7 +139,6 @@ impl SplatTrainer {
                 img_size,
                 background,
                 self.config.screen_area_penalty,
-                self.config.screen_area_threshold,
             )
             .instrument(trace_span!("Forward"))
             .await;
@@ -373,13 +372,9 @@ impl SplatTrainer {
             .take()
             .expect("Can only refine if refine stats are initialized");
 
-        // Log per-splat screen-size distribution so we can track how
-        // many splats are visually large (and thus susceptible to the
-        // "big-low-α" failure mode). Uses `max_screen_size` (fraction of
-        // the smaller image dim covered by the larger 2D ellipse extent);
-        // area is approximated by squaring it (upper bound — exact for
-        // round splats, overestimates for needles). Cheap CPU pass on
-        // ~1M floats; gated on refine cadence anyway.
+        // Track how many splats are visually large (the "big-low-α" failure
+        // mode). `max_screen_size` is the larger 2D ellipse extent as a
+        // fraction of the image dim; area is approximated by its square.
         let ss_data = refiner
             .max_screen_size
             .clone()
@@ -397,7 +392,6 @@ impl SplatTrainer {
             let n_gt_025 = ss_data.iter().filter(|v| **v > 0.25).count();
             let n_gt_010 = ss_data.iter().filter(|v| **v > 0.10).count();
             let n_gt_005 = ss_data.iter().filter(|v| **v > 0.05).count();
-            // area fraction (upper bound) = max_dim^2
             let n_area_gt_005 = ss_data.iter().filter(|v| (*v * *v) > 0.05).count();
             let n_area_gt_010 = ss_data.iter().filter(|v| (*v * *v) > 0.10).count();
             log::info!(
@@ -604,67 +598,48 @@ impl SplatTrainer {
             let cur_sh_coeffs = splats.sh_coeffs.val().select(0, refine_inds.clone());
             let cur_raw_opac = splats.raw_opacities.val().select(0, refine_inds.clone());
 
-            // The amount to offset the scale and opacity should maybe depend on how far away we have sampled these gaussians,
-            // but a fixed amount seems to work ok. The only note is that divide by _less_ than SQRT(2) seems to exponentially
-            // blow up, as more 'mass' is added each refine.
-            // let scale_div = Tensor::ones_like(&cur_log_scale) * SQRT_2.ln();
-            //
             let cur_scales = cur_log_scale.clone().exp();
 
             let cur_opac = sigmoid(cur_raw_opac.clone());
-            let inv_opac: Tensor<1> = 1.0 - cur_opac.clone();
-            // Post-split child opacity: power law in transmittance,
-            //   a' = 1 - (1 - a)^p.
-            // Alpha compositing multiplies transmittance (1-a), so p encodes
-            // the effective overlap: p=1/2 reproduces the parent when the two
-            // children fully overlap (classic 3DGS); p=1 is full inheritance
-            // (no overlap). The covariance-aware split offsets the children
-            // ~2 child-stds apart (= 2·sqrt(1-k²)/k at k=1/√2), i.e. between 1
-            // and 2 effective overlapping copies — which is exactly where
-            // p = 1/√2 lands. A p-sweep confirmed the PSNR optimum at ~0.7
-            // with monotonically fewer low-opacity ambient splats. So p
-            // reuses the split's own constant.
+            let inv_opac: Tensor<1> = 1.0 - cur_opac;
+            // Post-split child opacity as a power law in transmittance,
+            // `a' = 1 - (1 - a)^p`. Alpha compositing multiplies transmittance
+            // (1-a), so p encodes the children's effective overlap: p=1/2
+            // recreates the parent when they fully overlap (classic 3DGS),
+            // p=1 is full inheritance (no overlap). The split offsets children
+            // ~2 child-stds apart at k=1/√2, landing p there too.
             let p = std::f32::consts::FRAC_1_SQRT_2;
             let new_opac: Tensor<1> = 1.0 - inv_opac.powf_scalar(p);
             let new_raw_opac = inv_sigmoid(new_opac.clamp(MIN_OPACITY, 1.0 - MIN_OPACITY));
 
-            // Smooth covariance-aware split. Per-axis shrink factor:
-            //   k_i = 1 - (1 - k) * (scale_i² / scale_max²)
-            // is k on the principal axis, smoothly approaching 1 on much-
-            // smaller axes. Mass-conserving on each axis independently:
-            //   new_scale_i = k_i * scale_i
-            //   offset_i    = sqrt(1 - k_i²) * scale_i (deterministic ±)
-            // Limits: isotropic → uniform shrink, diagonal offset (≈ the old
-            // iso mirror split). Needle → axial shrink + axial offset only.
-            // Pancake → in-plane shrink + offset, thin axis untouched. One
-            // function, no threshold.
-            //   k_i = 1 - (1 - k) · (s_i² / s_max²)        ∈ [k, 1]
-            //   new_scale_i = k_i · s_i
-            //   offset_i    = sqrt(1 - k_i²) · s_i         (deterministic ±)
-            // Mass-conserving on each axis: offset_i² + (k_i·s_i)² = s_i².
-            // k is pinned near 1/√2 (the variance-preserving 2-component
-            // mixture value); clamped to (0,1) for safety.
-            let k: f32 = self.config.split_anisotropic_k.max(1e-3).min(0.99);
+            // Smooth covariance-aware split. Per-axis shrink + mass-conserving
+            // offset (one child at +offset, the other at -offset):
+            //   k_i      = 1 - (1 - k) · (s_i² / s_max²)   ∈ [k, 1]
+            //   scale_i  = k_i · s_i
+            //   offset_i = sqrt(1 - k_i²) · s_i
+            // The principal axis shrinks by k while much-smaller axes are left
+            // ~unchanged, so an isotropic splat shrinks uniformly (≈ the old
+            // iso mirror split), a needle splits along its long axis, and a
+            // pancake splits in-plane. k is pinned near 1/√2 (the
+            // variance-preserving 2-component value); clamped to (0,1).
+            let k = self.config.split_anisotropic_k.clamp(1e-3, 0.99);
             let cur_scales_sq = cur_scales.clone().powi_scalar(2);
             let max_scale_sq = cur_scales_sq.clone().max_dim(1).clamp_min(1e-30);
-            // ratio_i = s_i² / s_max²  (broadcast [N,3] / [N,1])
             let ratio = cur_scales_sq / max_scale_sq;
-            // k_i = 1 - (1 - k) · ratio_i
             let one_minus_k = 1.0_f32 - k;
             let k_per_axis: Tensor<2> = -(ratio * one_minus_k) + 1.0;
             let offset_factor_per_axis = (-k_per_axis.clone().powi_scalar(2) + 1.0)
                 .clamp_min(0.0)
                 .sqrt();
-            let offset_local = offset_factor_per_axis * cur_scales.clone();
+            let offset_local = offset_factor_per_axis * cur_scales;
             let samples = quaternion_vec_multiply(cur_rots.clone(), offset_local);
-            // log_scale_diff_i = ln(k_i)  — applied additively to cur_log_scale below.
             let log_scale_diff: Tensor<2> = k_per_axis.log();
 
-            let new_log_scales = cur_log_scale.clone() + log_scale_diff.clone();
+            let new_log_scales = cur_log_scale.clone() + log_scale_diff;
 
             // Children inherit the parent's rotation; the split is expressed
             // entirely through the per-axis scale shrink + ±offset.
-            let child_rots = cur_rots.clone();
+            let child_rots = cur_rots;
 
             // Shrink & offset existing splats.
 

--- a/crates/brush-train/src/train.rs
+++ b/crates/brush-train/src/train.rs
@@ -78,15 +78,6 @@ impl SplatTrainer {
 
         let ssim_enabled = config.ssim_weight > 0.0;
 
-        // Push the in-kernel screen-area regulariser config into the
-        // brush-render global so the host code's ProjectUniforms
-        // construction picks it up and the backward kernel applies the
-        // gradient contribution to v_cov2d.
-        brush_render::set_screen_area_penalty(
-            config.screen_area_penalty,
-            config.screen_area_threshold,
-        );
-
         // Growth is gated on the global iter. LOD phases run past
         // total_train_iters but their refines should never grow — clamp
         // here so growth_stop is never effectively past end-of-training.
@@ -142,9 +133,16 @@ impl SplatTrainer {
 
         let (mut grads, visible, num_visible, loss_inner) = {
             let render_input = splats.clone();
-            let diff_out = render_splats(render_input, &camera, img_size, background)
-                .instrument(trace_span!("Forward"))
-                .await;
+            let diff_out = render_splats(
+                render_input,
+                &camera,
+                img_size,
+                background,
+                self.config.screen_area_penalty,
+                self.config.screen_area_threshold,
+            )
+            .instrument(trace_span!("Forward"))
+            .await;
 
             let pred_image = diff_out.img;
             let refine_weight_holder = diff_out.refine_weight_holder;

--- a/crates/brush-train/src/train.rs
+++ b/crates/brush-train/src/train.rs
@@ -35,6 +35,18 @@ pub const BOUND_PERCENTILE: f32 = 0.8;
 
 const MIN_OPACITY: f32 = 1.0 / 255.0;
 
+/// Fraction of training after which the Mip-Splatting 3D-filter floor stops
+/// being recomputed and is held frozen (still applied), so splats settle
+/// against a fixed target instead of chasing a moving floor.
+const MIN_SCALE_FREEZE_FRAC: f32 = 0.9;
+
+/// Mip-Splatting 3D-filter strength (the paper's `s`): each splat gets a frozen
+/// per-splat world-space scale floor `f = sqrt(MIN_SCALE_FACTOR) · pixel size at
+/// the nearest observing camera`, i.e. a ~0.32px std-dev floor. Folded into
+/// scales/opacity at render (and baked at export), never optimized. Fundamental
+/// to well-behaved splats, so not a tunable.
+const MIN_SCALE_FACTOR: f32 = 0.1;
+
 type OptimizerType = OptimizerAdaptor<AdamScaled, Splats>;
 
 pub struct SplatTrainer {
@@ -46,6 +58,10 @@ pub struct SplatTrainer {
     bounds: BoundingBox,
     step_count: u32,
     max_sh_degree: u32,
+    /// Per-train-view (world center, focal in px at native res) for the
+    /// Mip-Splatting 3D filter. Empty disables it. The floor itself lives on
+    /// the splats (recomputed at each refine), not here.
+    view_cams: Vec<(glam::Vec3, f32)>,
     #[cfg(not(target_family = "wasm"))]
     lpips: Option<lpips::LpipsModel>,
 }
@@ -56,6 +72,35 @@ fn inv_sigmoid(x: Tensor<1>) -> Tensor<1> {
 
 fn create_optimizer_from_config() -> OptimizerType {
     AdamScaledConfig::new().with_epsilon(1e-15).init()
+}
+
+/// Per-splat world-space scale floor for the Mip-Splatting 3D filter:
+/// `f_i = sqrt(factor) · min_v(||mean_i - cam_v|| / focal_px_v)`. `means` and
+/// the result are on the inner (non-autodiff) backend; `f` is a frozen
+/// constant. Returns `None` if disabled or there are no cameras.
+fn compute_min_scale(
+    means: &Tensor<2>,
+    view_cams: &[(glam::Vec3, f32)],
+    factor: f32,
+) -> Option<Tensor<1>> {
+    if factor <= 0.0 || view_cams.is_empty() {
+        return None;
+    }
+    let device = means.device();
+    let n = means.dims()[0] as i32;
+
+    let mut min_ratio: Option<Tensor<1>> = None;
+    for (center, focal) in view_cams {
+        let c = Tensor::<1>::from_floats([center.x, center.y, center.z], &device).reshape([1, 3]);
+        let diff = means.clone() - c;
+        let dist = diff.clone().mul(diff).sum_dim(1).sqrt().reshape([n]);
+        let ratio = dist.div_scalar(focal.max(1e-6));
+        min_ratio = Some(match min_ratio {
+            Some(m) => m.min_pair(ratio),
+            None => ratio,
+        });
+    }
+    min_ratio.map(|r| r.mul_scalar(factor.sqrt()))
 }
 
 pub async fn get_splat_bounds(splats: Splats, percentile: f32) -> BoundingBox {
@@ -96,9 +141,16 @@ impl SplatTrainer {
             bounds,
             step_count: 0,
             max_sh_degree: 0,
+            view_cams: Vec::new(),
             #[cfg(not(target_family = "wasm"))]
             lpips,
         }
+    }
+
+    /// Supply per-train-view (world center, focal-px at native res) to enable
+    /// the Mip-Splatting 3D filter (gated on `config.min_scale_factor > 0`).
+    pub fn set_view_cams(&mut self, view_cams: Vec<(glam::Vec3, f32)>) {
+        self.view_cams = view_cams;
     }
 
     pub async fn step(&mut self, batch: SceneBatch, splats: Splats) -> (Splats, TrainStepStats) {
@@ -132,6 +184,8 @@ impl SplatTrainer {
         let median_scale = self.bounds.median_size();
 
         let (mut grads, visible, num_visible, loss_inner) = {
+            // The splats already carry their 3D-filter floor (set at refine);
+            // the render path folds it in. Optimizer/refine work on raw params.
             let render_input = splats.clone();
             let diff_out = render_splats(
                 render_input,
@@ -363,6 +417,12 @@ impl SplatTrainer {
     }
 
     pub async fn refine(&mut self, iter: u32, splats: Splats) -> (Splats, RefineStats) {
+        let progress = iter as f32 / self.config.total_train_iters.max(1) as f32;
+        // Refine manipulates the canonical (un-floored) params, so bake the
+        // current 3D-filter floor into them first — split/clone/prune then see
+        // the splat's true scales with no double-apply. A freshly recomputed
+        // floor is attached at the end (below), once positions/count are known.
+        let splats = splats.bake_min_scale();
         let device = splats.device();
         // `memory_cleanup` lives on the wgpu client, not on `Device`.
         let client = WgpuRuntime::<AutoCompiler>::client(&WgpuDevice::default());
@@ -555,6 +615,19 @@ impl SplatTrainer {
         self.bounds = get_splat_bounds(splats.clone(), BOUND_PERCENTILE).await;
         client.memory_cleanup();
 
+        // Recompute the per-splat 3D-filter floor against the new positions/
+        // count and attach it — the floor is part of the splat from here until
+        // the next refine. Past the freeze fraction we stop refreshing and leave
+        // it baked in, so the tail settles against fixed params.
+        if progress < MIN_SCALE_FREEZE_FRAC {
+            // `splats` is already on the inner backend here, so `means()` is too.
+            // No-op when there are no view cameras (e.g. unit tests).
+            let means = splats.means();
+            if let Some(f) = compute_min_scale(&means, &self.view_cams, MIN_SCALE_FACTOR) {
+                splats = splats.with_min_scale(f);
+            }
+        }
+
         let splat_count = splats.num_splats();
 
         (
@@ -613,32 +686,24 @@ impl SplatTrainer {
             let new_raw_opac = inv_sigmoid(new_opac.clamp(MIN_OPACITY, 1.0 - MIN_OPACITY));
 
             // Smooth covariance-aware split. Per-axis shrink + mass-conserving
-            // offset (one child at +offset, the other at -offset):
+            // deterministic offset (one child at +offset, the other at -offset):
             //   k_i      = 1 - (1 - k) · (s_i² / s_max²)   ∈ [k, 1]
-            //   scale_i  = k_i · s_i
-            //   offset_i = sqrt(1 - k_i²) · s_i
-            // The principal axis shrinks by k while much-smaller axes are left
-            // ~unchanged, so an isotropic splat shrinks uniformly (≈ the old
-            // iso mirror split), a needle splits along its long axis, and a
-            // pancake splits in-plane. k is pinned near 1/√2 (the
-            // variance-preserving 2-component value); clamped to (0,1).
+            //   scale_i  = k_i · s_i ;  offset_i = sqrt(1 - k_i²) · s_i
+            // Principal axis shrinks by k, much-smaller axes ~unchanged: an
+            // isotropic splat shrinks uniformly, a needle splits along its long
+            // axis, a pancake in-plane. k pinned near 1/√2. Children inherit the
+            // parent's rotation; the split is the scale shrink + ±offset.
             let k = self.config.split_anisotropic_k.clamp(1e-3, 0.99);
             let cur_scales_sq = cur_scales.clone().powi_scalar(2);
             let max_scale_sq = cur_scales_sq.clone().max_dim(1).clamp_min(1e-30);
             let ratio = cur_scales_sq / max_scale_sq;
-            let one_minus_k = 1.0_f32 - k;
-            let k_per_axis: Tensor<2> = -(ratio * one_minus_k) + 1.0;
-            let offset_factor_per_axis = (-k_per_axis.clone().powi_scalar(2) + 1.0)
+            let k_per_axis: Tensor<2> = -(ratio * (1.0_f32 - k)) + 1.0;
+            let offset_factor = (-k_per_axis.clone().powi_scalar(2) + 1.0)
                 .clamp_min(0.0)
                 .sqrt();
-            let offset_local = offset_factor_per_axis * cur_scales;
+            let offset_local = offset_factor * cur_scales;
             let samples = quaternion_vec_multiply(cur_rots.clone(), offset_local);
-            let log_scale_diff: Tensor<2> = k_per_axis.log();
-
-            let new_log_scales = cur_log_scale.clone() + log_scale_diff;
-
-            // Children inherit the parent's rotation; the split is expressed
-            // entirely through the per-axis scale shrink + ±offset.
+            let new_log_scales = cur_log_scale.clone() + k_per_axis.log();
             let child_rots = cur_rots;
 
             // Shrink & offset existing splats.


### PR DESCRIPTION
## Motivation

3DGS optimization produces two kinds of splats that break the small-screen-footprint assumption the rasterizer relies on, and project/sort/deform badly:
- **Needles** — extreme anisotropy (one covariance axis far larger than the others); rotation gradients are ill-defined and they look bad when projected.
- **Giant low-α splats** — cover a large fraction of the frame and abuse non-continuous depth sorting to cheat a bit of PSNR on tricky views.

Measured on a stock bonsai run, >25% of splats had aspect ratio >10 and the worst splat spanned ~90× the image dimension; garden: 53% needles, worst splat 3857× the frame. This PR tries to attack both. This in theory has a small PSNR cost but hopefully leads to more "useful" splats.

## Changes

- **Different splat split** (replaces the old isotropic mirror split + experimental thresholds with one function, no branching). Per-axis shrink `k_i = 1 − (1−k)·(s_i²/s_max²)` with mass-conserving deterministic ±offset `√(1−k_i²)·s_i`. A round splat shrinks uniformly (≈ the old split); a needle shrinks + offsets only along its long axis (two half-length children instead of two needles); a pancake is split in-plane. `k = 1/√2` (the variance-preserving 2-component value — not a free knob; lower over-shrinks and over-densifies).
- **Power-law post-split opacity** `a' = 1 − (1−a)^(1/√2)`. Alpha compositing multiplies transmittance `(1−a)`, so the exponent encodes effective child overlap; since the offset children overlap only partially, `1/√2` (the same constant as the split geometry, where the children land ~2 child-stds apart) is the physically-consistent value. Replaces the classic full-overlap `1−√(1−a)`.
- **`--kill-at-screen-size` (default 0.5)** — splats whose max screen extent exceeds this fraction of the image are treated as "poisoned": pruned and the budget resampled, every refine (incl. post-growth). Beats in-place force-splitting and a differentiable penalty for the giant-splat outliers.
- **`--screen-area-penalty` (default 0.05)** — small differentiable regularizer; analytic ∂/∂cov of `(area_frac − τ)²` added to the 2D-covariance gradient in `project_backwards` (area = π·√det(cov₂d)/(W·H)). A gentle nudge toward small footprints; `kill` handles the hard outliers.
- **`lr_scale` default 7e-3 → 3.5e-3** — the old default let scales overshoot into anisotropic configs; 3.5e-3 is the shape/PSNR sweet spot.
- Add the 3D filter from Mip splatting to prevent splats going below nyquist.
- New rerun/log instrumentation: per-splat scale/opacity/anisotropy and screen-size distribution stats.
