### PR TITLE
Add per-view appearance compensation: bilateral grid + PPISP hybrid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Most of the loss and backward path was rewritten over the cycle. SSIM moved to a
 
 The growth path got a real overhaul: longer-edge split, "uni" noise, and a fix for far-away splats being deleted too early ([#265](https://github.com/ArthurBrussee/brush/pull/265)). Force-split kicks in for splats that grow too big, then later gated by `growth_stop_iter` to avoid pathological end-of-training behaviour ([#390](https://github.com/ArthurBrussee/brush/pull/390), [#398](https://github.com/ArthurBrussee/brush/pull/398)). Random frustum init helps when there are no good initial points ([#372](https://github.com/ArthurBrussee/brush/pull/372)). NaN handling was tightened up with a new fuzz suite ([#389](https://github.com/ArthurBrussee/brush/pull/389)).
 
+#### Appearance compensation (PPISP grid hybrid, bilateral grid & PPISP)
+
+Training can now learn per-view photometric corrections so exposure / white-balance / vignetting variation between input images isn't baked into the splats. The recommended `--ppisp-grid` mode learns per-camera PPISP vignetting plus per-view bilateral grids of PPISP exposure + color parameters (spirulae-splat's hybrid); `--bilateral-grid` (BilaRF affine grids) and `--ppisp` (full per-frame PPISP) are available as comparison modes. All are fused CubeCL kernels with custom autodiff in the new `brush-appearance` crate; corrections apply to the rendered image before the loss and only exist at training time — exported splats keep canonical colors. The grids use a sparse per-view optimizer (per-step cost independent of dataset size) with optional gradient subsampling, and `--train-on-eval` lets evaluation apply the learned per-view corrections.
+
 #### Mip-Splatting
 
 The 2D mip filter from Mip-Splatting is now implemented, with a `render_mode` flag and a UI toggle. Contributed by @fhahlbohm ([#337](https://github.com/ArthurBrussee/brush/pull/337)).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -911,6 +911,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "brush-appearance"
+version = "0.3.0"
+dependencies = [
+ "brush-cube",
+ "brush-render",
+ "burn",
+ "burn-cubecl",
+ "burn-fusion",
+ "burn-ir",
+ "getrandom 0.4.2",
+ "tokio",
+ "wasm-bindgen-test",
+]
+
+[[package]]
 name = "brush-async"
 version = "0.3.0"
 dependencies = [
@@ -1218,6 +1233,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "ball-tree",
+ "brush-appearance",
  "brush-cube",
  "brush-dataset",
  "brush-loss",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "apps/brush-c",
     "apps/brush-cli",
     "apps/brush-js",
+    "crates/brush-appearance",
     "crates/brush-async",
     "crates/brush-bench-test",
     "crates/brush-cube",

--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ It also supports masking images:
 - Images with transparency. This will force the final splat to match the transparency of the input.
 - A folder of images called 'masks'. This ignores parts of the image that are masked out.
 
+### Appearance compensation
+
+For captures with varying exposure, white balance, or lens vignetting between images, Brush can learn per-view photometric corrections during training so the variation isn't baked into the splats. The corrections only apply while training — exported splats keep canonical colors and render unmodified.
+
+- `--ppisp-grid` (recommended) learns per-camera lens vignetting ([PPISP](https://research.nvidia.com/labs/sil/projects/ppisp/)-style, shared across views with matching intrinsics) plus a per-view bilateral grid of PPISP exposure + color parameters (as in [spirulae-splat](https://github.com/harry7557558/spirulae-splat)'s hybrid). Variants: `--ppisp-grid-expose-only`, `--ppisp-grid-crf`, `--ppisp-crf-per-camera`.
+- `--bilateral-grid` ([BilaRF](https://bilarfpro.github.io/)-style affine grids) and `--ppisp` (the full per-frame PPISP model) are kept as comparison modes.
+
+Tunables: `--bilagrid-dims x,y,guidance`, `--bilagrid-tv-weight`, `--bilagrid-mean-reg`, `--bilagrid-lr`, `--bilagrid-grad-subsample`, `--ppisp-lr`, `--ppisp-reg-scale`.
+
+By default evaluation compares the raw, uncorrected render against ground truth — on appearance-varying captures that mostly measures the offset between the splats and the average appearance. Pass `--train-on-eval` to keep eval views in the training set; eval then applies each view's learned correction, which is the more meaningful comparison for these models.
+
 ## Viewer
 Brush also works well as a splat viewer, including on the web. It can load .ply & .compressed.ply files. You can stream in data from a URL (for a web app, simply append `?url=`).
 

--- a/_typos.toml
+++ b/_typos.toml
@@ -2,3 +2,7 @@
 lod = "lod"
 Lod = "Lod"
 ba = "ba"
+# LichtFeld Studio (reference implementation for the bilateral grid kernels).
+Feld = "Feld"
+# Short for "n delta" in the appearance kernels/tests.
+nd = "nd"

--- a/apps/brush-app/src/ui/settings_popup.rs
+++ b/apps/brush-app/src/ui/settings_popup.rs
@@ -221,6 +221,81 @@ pub(crate) fn draw_settings(ui: &mut Ui, args: &mut TrainStreamConfig, enabled: 
         );
     });
 
+    ui.collapsing("Appearance compensation", |ui| {
+        let tc = &mut args.train_config;
+        ui.add_enabled(
+            enabled,
+            egui::Checkbox::new(
+                &mut tc.ppisp_grid,
+                "PPISP grid (per-view exposure/color + vignetting)",
+            ),
+        );
+        if tc.ppisp_grid {
+            ui.add_enabled(
+                enabled,
+                egui::Checkbox::new(&mut tc.ppisp_grid_expose_only, "Exposure-only grid"),
+            );
+            ui.add_enabled(
+                enabled,
+                egui::Checkbox::new(&mut tc.ppisp_grid_crf, "Per-cell tone curve in grid"),
+            );
+            ui.add_enabled(
+                enabled,
+                egui::Checkbox::new(&mut tc.ppisp_crf_per_camera, "Per-camera tone curve"),
+            );
+        }
+        ui.add_enabled(
+            enabled,
+            egui::Checkbox::new(
+                &mut tc.bilateral_grid,
+                "Affine bilateral grid (comparison mode)",
+            ),
+        );
+        if tc.bilateral_grid {
+            slider(
+                ui,
+                &mut tc.bilagrid_tv_weight,
+                0.0..=50.0,
+                "TV regularizer weight",
+                false,
+                enabled,
+            );
+            slider(
+                ui,
+                &mut tc.bilagrid_lr,
+                1e-4..=1e-2,
+                "Grid learning rate",
+                true,
+                enabled,
+            );
+        }
+        ui.add_enabled(
+            enabled,
+            egui::Checkbox::new(
+                &mut tc.ppisp,
+                "Full PPISP (comparison mode: exposure / vignetting / tone curve)",
+            ),
+        );
+        if tc.ppisp {
+            slider(
+                ui,
+                &mut tc.ppisp_lr,
+                1e-4..=1e-2,
+                "PPISP learning rate",
+                true,
+                enabled,
+            );
+            slider(
+                ui,
+                &mut tc.ppisp_reg_scale,
+                0.0..=5.0,
+                "Regularization scale",
+                false,
+                enabled,
+            );
+        }
+    });
+
     {
         let tc = &mut args.train_config;
         let lod_label = if tc.lod_levels == 1 {
@@ -323,6 +398,13 @@ pub(crate) fn draw_settings(ui: &mut Ui, args: &mut TrainStreamConfig, enabled: 
                 .clamping(egui::SliderClamping::Never)
                 .prefix("1 out of ")
                 .suffix(" frames"),
+        );
+        ui.add_enabled(
+            enabled,
+            egui::Checkbox::new(
+                &mut args.load_config.train_on_eval,
+                "Keep eval views in training (apply learned appearance at eval)",
+            ),
         );
     }
 

--- a/crates/brush-appearance/Cargo.toml
+++ b/crates/brush-appearance/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "brush-appearance"
+edition.workspace = true
+version.workspace = true
+readme.workspace = true
+license.workspace = true
+
+[dependencies]
+brush-render.path = "../brush-render"
+brush-cube.path = "../brush-cube"
+
+burn = { workspace = true, features = ["autodiff"] }
+burn-cubecl.workspace = true
+burn-fusion.workspace = true
+burn-ir.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }
+wasm-bindgen-test = "0.3"
+
+[target.'cfg(target_family = "wasm")'.dev-dependencies]
+getrandom = { version = "0.4", features = ["wasm_js"] }
+
+[lints]
+workspace = true
+
+[package.metadata.cargo-shear]
+ignored = ["getrandom"]

--- a/crates/brush-appearance/src/bilagrid.rs
+++ b/crates/brush-appearance/src/bilagrid.rs
@@ -1,0 +1,547 @@
+//! Host side of the per-view bilateral grids: backend trait + kernel
+//! launches, Fusion dispatch, Burn autodiff ops and the `BilagridModel`
+//! module holding the learned grids.
+
+use brush_cube::{MainBackend, MainBackendBase};
+use brush_render::burn_glue::{
+    AutodiffMain, unwrap_ad_wgpu_float, wrap_ad_wgpu_float, wrap_wgpu_float,
+};
+use burn::{
+    backend::{
+        Backend, TensorMetadata,
+        autodiff::{
+            checkpoint::{base::Checkpointer, strategy::NoCheckpointing},
+            grads::Gradients,
+            ops::{Backward, Ops, OpsKind},
+        },
+        tensor::FloatTensor,
+    },
+    module::{Module, Param},
+    tensor::{DType, Device, Shape, Tensor, s},
+};
+use burn_cubecl::{CubeRuntime, tensor::CubeTensor};
+use burn_fusion::Fusion;
+
+use crate::bilagrid_kernels as kernels;
+use crate::{CasAtomicAdd, GradSubsample, HfAtomicAdd, alloc_zeros, contiguous, dispatch_custom};
+
+/// Backend hooks for the bilateral-grid kernels.
+pub trait BilagridOps<B: Backend> {
+    /// Slice the `view_idx`-th grid of `grids` `[N, 12, L, H, W]` by `rgb`
+    /// `[h, w, 3|4]`, returning the transformed image (alpha untouched).
+    fn bilagrid_slice_fwd(
+        grids: FloatTensor<B>,
+        rgb: FloatTensor<B>,
+        view_idx: usize,
+    ) -> FloatTensor<B>;
+
+    /// Returns `(dL/dgrids, dL/drgb)`. The grid gradient is full-size with
+    /// only the active view's slice populated.
+    fn bilagrid_slice_bwd(
+        grids: FloatTensor<B>,
+        rgb: FloatTensor<B>,
+        v_out: FloatTensor<B>,
+        view_idx: usize,
+        subsample: GradSubsample,
+    ) -> (FloatTensor<B>, FloatTensor<B>);
+
+    /// Total-variation loss over all grids; returns a `[1]` scalar tensor.
+    fn bilagrid_tv_fwd(grids: FloatTensor<B>) -> FloatTensor<B>;
+
+    /// Backward of [`Self::bilagrid_tv_fwd`]; `v_loss` is the upstream `[1]`
+    /// scalar gradient.
+    fn bilagrid_tv_bwd(grids: FloatTensor<B>, v_loss: FloatTensor<B>) -> FloatTensor<B>;
+}
+
+/// `(n, channels, l, h, w)` of a `[N, C, L, H, W]` grid tensor.
+pub(crate) fn grid_dims5<R: CubeRuntime>(grids: &CubeTensor<R>) -> (u32, u32, u32, u32, u32) {
+    let dims = grids.shape().as_slice().to_vec();
+    assert_eq!(dims.len(), 5, "grids must be [N, C, L, H, W]");
+    // Dims of 1 would divide by zero in the interpolation / TV normalisation.
+    assert!(
+        dims[2] >= 2 && dims[3] >= 2 && dims[4] >= 2,
+        "bilateral grid dims must each be >= 2 (got {}x{}x{})",
+        dims[4],
+        dims[3],
+        dims[2],
+    );
+    (
+        dims[0] as u32,
+        dims[1] as u32,
+        dims[2] as u32,
+        dims[3] as u32,
+        dims[4] as u32,
+    )
+}
+
+/// Affine-grid dims: asserts the 12-coefficient payload.
+fn grid_dims<R: CubeRuntime>(grids: &CubeTensor<R>) -> (u32, u32, u32, u32) {
+    let (n, c, gl, gh, gw) = grid_dims5(grids);
+    assert_eq!(c, 12, "affine grids must be [N, 12, L, H, W]");
+    (n, gl, gh, gw)
+}
+
+fn img_dims<R: CubeRuntime>(rgb: &CubeTensor<R>) -> (u32, u32, u32) {
+    let dims = rgb.shape().as_slice().to_vec();
+    assert_eq!(dims.len(), 3, "rgb must be [h, w, c]");
+    let ch = dims[2] as u32;
+    assert!(ch == 3 || ch == 4, "rgb must have 3 or 4 channels");
+    (dims[0] as u32, dims[1] as u32, ch)
+}
+
+fn launch_slice_fwd<R: CubeRuntime>(
+    grids: CubeTensor<R>,
+    rgb: CubeTensor<R>,
+    view_idx: usize,
+) -> CubeTensor<R> {
+    use burn_cubecl::cubecl::prelude::{CubeCount, CubeDim};
+
+    let grids = contiguous(grids);
+    let rgb = contiguous(rgb);
+    let (n, gl, gh, gw) = grid_dims(&grids);
+    let (h, w, ch) = img_dims(&rgb);
+    assert!((view_idx as u32) < n, "view index out of range");
+
+    let out = alloc_zeros(&rgb, rgb.shape(), DType::F32);
+    let client = rgb.client.clone();
+    kernels::bilagrid_slice_fwd_kernel::launch::<R>(
+        &client,
+        CubeCount::Static((h * w).div_ceil(kernels::BLOCK_SIZE), 1, 1),
+        CubeDim::new_1d(kernels::BLOCK_SIZE),
+        grids.into_tensor_arg(),
+        rgb.into_tensor_arg(),
+        out.clone().into_tensor_arg(),
+        gl,
+        gh,
+        gw,
+        h,
+        w,
+        view_idx as u32 * 12 * gl * gh * gw,
+        ch,
+        ch == 4,
+    );
+    out
+}
+
+fn launch_slice_bwd<R: CubeRuntime>(
+    grids: CubeTensor<R>,
+    rgb: CubeTensor<R>,
+    v_out: CubeTensor<R>,
+    view_idx: usize,
+    subsample: GradSubsample,
+) -> (CubeTensor<R>, CubeTensor<R>) {
+    use burn_cubecl::cubecl::prelude::{CubeCount, CubeDim};
+
+    let grids = contiguous(grids);
+    let rgb = contiguous(rgb);
+    let v_out = contiguous(v_out);
+    let (n, gl, gh, gw) = grid_dims(&grids);
+    let (h, w, ch) = img_dims(&rgb);
+    assert!((view_idx as u32) < n, "view index out of range");
+
+    let grad_grids = alloc_zeros(&grids, grids.shape(), DType::F32);
+    let grad_rgb = alloc_zeros(&rgb, rgb.shape(), DType::F32);
+    let client = rgb.client.clone();
+
+    let cube_count = CubeCount::Static((h * w).div_ceil(kernels::BLOCK_SIZE), 1, 1);
+    let cube_dim = CubeDim::new_1d(kernels::BLOCK_SIZE);
+    let grid_offset = view_idx as u32 * 12 * gl * gh * gw;
+    let every = subsample.every.max(1);
+
+    if brush_cube::supports_float_atomics::<R>(&client) {
+        kernels::bilagrid_slice_bwd_kernel::launch::<HfAtomicAdd, R>(
+            &client,
+            cube_count,
+            cube_dim,
+            grids.into_tensor_arg(),
+            rgb.into_tensor_arg(),
+            v_out.into_tensor_arg(),
+            grad_grids.clone().into_tensor_arg(),
+            grad_rgb.clone().into_tensor_arg(),
+            gl,
+            gh,
+            gw,
+            h,
+            w,
+            grid_offset,
+            ch,
+            every,
+            subsample.seed,
+            ch == 4,
+        );
+    } else {
+        kernels::bilagrid_slice_bwd_kernel::launch::<CasAtomicAdd, R>(
+            &client,
+            cube_count,
+            cube_dim,
+            grids.into_tensor_arg(),
+            rgb.into_tensor_arg(),
+            v_out.into_tensor_arg(),
+            grad_grids.clone().into_tensor_arg(),
+            grad_rgb.clone().into_tensor_arg(),
+            gl,
+            gh,
+            gw,
+            h,
+            w,
+            grid_offset,
+            ch,
+            every,
+            subsample.seed,
+            ch == 4,
+        );
+    }
+    #[allow(clippy::tuple_array_conversions)]
+    (grad_grids, grad_rgb)
+}
+
+/// Cap on TV partial-sum cubes; the stage-1 kernel grid-strides past this.
+const TV_MAX_CUBES: u32 = 2048;
+
+fn launch_tv_fwd<R: CubeRuntime>(grids: CubeTensor<R>) -> CubeTensor<R> {
+    use burn_cubecl::cubecl::prelude::{CubeCount, CubeDim};
+
+    let grids = contiguous(grids);
+    let (n, c, gl, gh, gw) = grid_dims5(&grids);
+    let total = n * gl * gh * gw;
+    let num_cubes = total.div_ceil(kernels::BLOCK_SIZE).min(TV_MAX_CUBES);
+
+    let partials = alloc_zeros(&grids, Shape::new([num_cubes as usize]), DType::F32);
+    let client = grids.client.clone();
+    kernels::bilagrid_tv_fwd_kernel::launch::<R>(
+        &client,
+        CubeCount::Static(num_cubes, 1, 1),
+        CubeDim::new_1d(kernels::BLOCK_SIZE),
+        grids.into_tensor_arg(),
+        partials.clone().into_tensor_arg(),
+        n,
+        gl,
+        gh,
+        gw,
+        c,
+    );
+    partials
+}
+
+fn launch_tv_bwd<R: CubeRuntime>(grids: CubeTensor<R>, v_loss: CubeTensor<R>) -> CubeTensor<R> {
+    use burn_cubecl::cubecl::prelude::{CubeCount, CubeDim};
+
+    let grids = contiguous(grids);
+    let v_loss = contiguous(v_loss);
+    let (n, c, gl, gh, gw) = grid_dims5(&grids);
+    let total = n * gl * gh * gw;
+
+    let grad_grids = alloc_zeros(&grids, grids.shape(), DType::F32);
+    let client = grids.client.clone();
+    kernels::bilagrid_tv_bwd_kernel::launch::<R>(
+        &client,
+        CubeCount::Static(total.div_ceil(kernels::BLOCK_SIZE), 1, 1),
+        CubeDim::new_1d(kernels::BLOCK_SIZE),
+        grids.into_tensor_arg(),
+        v_loss.into_tensor_arg(),
+        grad_grids.clone().into_tensor_arg(),
+        n,
+        gl,
+        gh,
+        gw,
+        c,
+    );
+    grad_grids
+}
+
+impl BilagridOps<Self> for MainBackendBase {
+    fn bilagrid_slice_fwd(
+        grids: FloatTensor<Self>,
+        rgb: FloatTensor<Self>,
+        view_idx: usize,
+    ) -> FloatTensor<Self> {
+        launch_slice_fwd(grids, rgb, view_idx)
+    }
+
+    fn bilagrid_slice_bwd(
+        grids: FloatTensor<Self>,
+        rgb: FloatTensor<Self>,
+        v_out: FloatTensor<Self>,
+        view_idx: usize,
+        subsample: GradSubsample,
+    ) -> (FloatTensor<Self>, FloatTensor<Self>) {
+        launch_slice_bwd(grids, rgb, v_out, view_idx, subsample)
+    }
+
+    fn bilagrid_tv_fwd(grids: FloatTensor<Self>) -> FloatTensor<Self> {
+        use burn::backend::ops::FloatTensorOps;
+        let partials = launch_tv_fwd(grids);
+        Self::float_sum(partials)
+    }
+
+    fn bilagrid_tv_bwd(grids: FloatTensor<Self>, v_loss: FloatTensor<Self>) -> FloatTensor<Self> {
+        launch_tv_bwd(grids, v_loss)
+    }
+}
+
+impl BilagridOps<Self> for Fusion<MainBackendBase> {
+    fn bilagrid_slice_fwd(
+        grids: FloatTensor<Self>,
+        rgb: FloatTensor<Self>,
+        view_idx: usize,
+    ) -> FloatTensor<Self> {
+        let shape = rgb.shape();
+        let [out] = dispatch_custom(
+            "bilagrid_slice_fwd",
+            [grids, rgb],
+            [(shape, DType::F32)],
+            move |desc, h| {
+                let ([grids, rgb], [out]) = desc.as_fixed();
+                let res = MainBackendBase::bilagrid_slice_fwd(
+                    h.get_float_tensor::<MainBackendBase>(grids),
+                    h.get_float_tensor::<MainBackendBase>(rgb),
+                    view_idx,
+                );
+                h.register_float_tensor::<MainBackendBase>(&out.id, res);
+            },
+        );
+        out
+    }
+
+    fn bilagrid_slice_bwd(
+        grids: FloatTensor<Self>,
+        rgb: FloatTensor<Self>,
+        v_out: FloatTensor<Self>,
+        view_idx: usize,
+        subsample: GradSubsample,
+    ) -> (FloatTensor<Self>, FloatTensor<Self>) {
+        let grids_shape = grids.shape();
+        let rgb_shape = rgb.shape();
+        let [grad_grids, grad_rgb] = dispatch_custom(
+            "bilagrid_slice_bwd",
+            [grids, rgb, v_out],
+            [(grids_shape, DType::F32), (rgb_shape, DType::F32)],
+            move |desc, h| {
+                let ([grids, rgb, v_out], [grad_grids, grad_rgb]) = desc.as_fixed();
+                let (gg, gr) = MainBackendBase::bilagrid_slice_bwd(
+                    h.get_float_tensor::<MainBackendBase>(grids),
+                    h.get_float_tensor::<MainBackendBase>(rgb),
+                    h.get_float_tensor::<MainBackendBase>(v_out),
+                    view_idx,
+                    subsample,
+                );
+                h.register_float_tensor::<MainBackendBase>(&grad_grids.id, gg);
+                h.register_float_tensor::<MainBackendBase>(&grad_rgb.id, gr);
+            },
+        );
+        #[allow(clippy::tuple_array_conversions)]
+        (grad_grids, grad_rgb)
+    }
+
+    fn bilagrid_tv_fwd(grids: FloatTensor<Self>) -> FloatTensor<Self> {
+        let [out] = dispatch_custom(
+            "bilagrid_tv_fwd",
+            [grids],
+            [(Shape::new([1]), DType::F32)],
+            move |desc, h| {
+                let ([grids], [out]) = desc.as_fixed();
+                let res =
+                    MainBackendBase::bilagrid_tv_fwd(h.get_float_tensor::<MainBackendBase>(grids));
+                h.register_float_tensor::<MainBackendBase>(&out.id, res);
+            },
+        );
+        out
+    }
+
+    fn bilagrid_tv_bwd(grids: FloatTensor<Self>, v_loss: FloatTensor<Self>) -> FloatTensor<Self> {
+        let shape = grids.shape();
+        let [out] = dispatch_custom(
+            "bilagrid_tv_bwd",
+            [grids, v_loss],
+            [(shape, DType::F32)],
+            move |desc, h| {
+                let ([grids, v_loss], [out]) = desc.as_fixed();
+                let res = MainBackendBase::bilagrid_tv_bwd(
+                    h.get_float_tensor::<MainBackendBase>(grids),
+                    h.get_float_tensor::<MainBackendBase>(v_loss),
+                );
+                h.register_float_tensor::<MainBackendBase>(&out.id, res);
+            },
+        );
+        out
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Autodiff ops
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+struct BilagridSliceBackward;
+
+#[derive(Debug, Clone)]
+struct BilagridSliceState<B: Backend> {
+    grids: FloatTensor<B>,
+    rgb: FloatTensor<B>,
+    view_idx: usize,
+    subsample: GradSubsample,
+}
+
+impl<B: Backend + BilagridOps<B>> Backward<B, 2> for BilagridSliceBackward {
+    type State = BilagridSliceState<B>;
+
+    fn backward(
+        self,
+        ops: Ops<Self::State, 2>,
+        grads: &mut Gradients,
+        _checkpointer: &mut Checkpointer,
+    ) {
+        let state = ops.state;
+        let v_out = grads.consume::<B>(&ops.node);
+        let [grids_parent, rgb_parent] = ops.parents;
+        let (grad_grids, grad_rgb) = B::bilagrid_slice_bwd(
+            state.grids,
+            state.rgb,
+            v_out,
+            state.view_idx,
+            state.subsample,
+        );
+        if let Some(node) = grids_parent {
+            grads.register::<B>(node.id, grad_grids);
+        }
+        if let Some(node) = rgb_parent {
+            grads.register::<B>(node.id, grad_rgb);
+        }
+    }
+}
+
+#[derive(Debug)]
+struct BilagridTvBackward;
+
+impl<B: Backend + BilagridOps<B>> Backward<B, 1> for BilagridTvBackward {
+    type State = FloatTensor<B>;
+
+    fn backward(
+        self,
+        ops: Ops<Self::State, 1>,
+        grads: &mut Gradients,
+        _checkpointer: &mut Checkpointer,
+    ) {
+        let v_loss = grads.consume::<B>(&ops.node);
+        let [grids_parent] = ops.parents;
+        let grad_grids = B::bilagrid_tv_bwd(ops.state, v_loss);
+        if let Some(node) = grids_parent {
+            grads.register::<B>(node.id, grad_grids);
+        }
+    }
+}
+
+/// Apply the `view_idx`-th bilateral grid to a rendered `[H, W, 3|4]` image.
+/// Differentiable w.r.t. both `grids` and `rgb`; the alpha channel (if any)
+/// passes through untouched. Inputs must be on an autodiff-enabled Wgpu
+/// device.
+pub fn bilagrid_apply(
+    grids: Tensor<5>,
+    rgb: Tensor<3>,
+    view_idx: usize,
+    subsample: GradSubsample,
+) -> Tensor<3> {
+    let grids_ad = unwrap_ad_wgpu_float(grids);
+    let rgb_ad = unwrap_ad_wgpu_float(rgb);
+
+    let prep = BilagridSliceBackward
+        .prepare::<NoCheckpointing>([grids_ad.node.clone(), rgb_ad.node.clone()])
+        .compute_bound()
+        .stateful();
+
+    let grids_p = grids_ad.primitive;
+    let rgb_p = rgb_ad.primitive;
+    let out = <MainBackend as BilagridOps<MainBackend>>::bilagrid_slice_fwd(
+        grids_p.clone(),
+        rgb_p.clone(),
+        view_idx,
+    );
+
+    let out_ad: FloatTensor<AutodiffMain> = match prep {
+        OpsKind::Tracked(prep) => prep.finish(
+            BilagridSliceState {
+                grids: grids_p,
+                rgb: rgb_p,
+                view_idx,
+                subsample,
+            },
+            out,
+        ),
+        OpsKind::UnTracked(prep) => prep.finish(out),
+    };
+    wrap_ad_wgpu_float::<3>(out_ad)
+}
+
+/// Forward-only version of [`bilagrid_apply`] for non-autodiff tensors
+/// (e.g. eval-time visualisation).
+pub fn bilagrid_apply_inner(grids: Tensor<5>, rgb: Tensor<3>, view_idx: usize) -> Tensor<3> {
+    use brush_render::burn_glue::unwrap_wgpu_float;
+    let grids_p = unwrap_wgpu_float(grids);
+    let rgb_p = unwrap_wgpu_float(rgb);
+    let out =
+        <MainBackend as BilagridOps<MainBackend>>::bilagrid_slice_fwd(grids_p, rgb_p, view_idx);
+    wrap_wgpu_float::<3>(out)
+}
+
+/// Total-variation regulariser over all views' grids. Returns a `[1]`
+/// tensor; differentiable w.r.t. `grids`.
+pub fn bilagrid_tv_loss(grids: Tensor<5>) -> Tensor<1> {
+    let grids_ad = unwrap_ad_wgpu_float(grids);
+
+    let prep = BilagridTvBackward
+        .prepare::<NoCheckpointing>([grids_ad.node.clone()])
+        .compute_bound()
+        .stateful();
+
+    let grids_p = grids_ad.primitive;
+    let out = <MainBackend as BilagridOps<MainBackend>>::bilagrid_tv_fwd(grids_p.clone());
+
+    let out_ad: FloatTensor<AutodiffMain> = match prep {
+        OpsKind::Tracked(prep) => prep.finish(grids_p, out),
+        OpsKind::UnTracked(prep) => prep.finish(out),
+    };
+    wrap_ad_wgpu_float::<1>(out_ad)
+}
+
+// ---------------------------------------------------------------------------
+// Module
+// ---------------------------------------------------------------------------
+
+/// One 3D bilateral grid per training view, initialised to the identity
+/// affine transform.
+#[derive(Module, Debug)]
+pub struct BilagridModel {
+    /// `[num_views, 12, guidance, grid_y, grid_x]`.
+    pub grids: Param<Tensor<5>>,
+}
+
+impl BilagridModel {
+    pub fn new(
+        num_views: usize,
+        grid_x: usize,
+        grid_y: usize,
+        grid_guidance: usize,
+        device: &Device,
+    ) -> Self {
+        // Identity 3x4 affine: coefficient channels 0, 5, 10 (the diagonal
+        // of the 3x3 part) are 1, everything else 0.
+        let mut grids = Tensor::zeros([num_views, 12, grid_guidance, grid_y, grid_x], device);
+        let ones = Tensor::ones([num_views, 1, grid_guidance, grid_y, grid_x], device);
+        for c in [0, 5, 10] {
+            grids = grids.slice_assign(s![.., c..c + 1], ones.clone());
+        }
+        Self {
+            grids: Param::from_tensor(grids),
+        }
+    }
+
+    /// Apply this view's grid to a rendered `[H, W, 3|4]` image.
+    pub fn apply(&self, img: Tensor<3>, view_idx: usize) -> Tensor<3> {
+        bilagrid_apply(self.grids.val(), img, view_idx, GradSubsample::default())
+    }
+
+    /// Total-variation regulariser (unweighted).
+    pub fn tv_loss(&self) -> Tensor<1> {
+        bilagrid_tv_loss(self.grids.val())
+    }
+}

--- a/crates/brush-appearance/src/bilagrid_kernels.rs
+++ b/crates/brush-appearance/src/bilagrid_kernels.rs
@@ -1,0 +1,448 @@
+//! Fused bilateral-grid kernels (port of `LichtFeld` Studio's CUDA kernels,
+//! which match gsplat's `lib_bilagrid` / `F.grid_sample(align_corners=True,
+//! padding_mode="border")` semantics).
+//!
+//! A bilateral grid is a `[12, L, H, W]` field of 3x4 affine color
+//! transforms. Slicing trilinearly interpolates the 12 coefficients at
+//! `(x, y) = pixel position` (scaled to the grid) and `z = BT601 grayscale
+//! of the input RGB`, then applies `rgb_out = A * rgb_in + b`.
+//!
+//! The grid tensor argument holds *all* views' grids `[N, 12, L, H, W]`;
+//! `grid_offset` selects the active view so the backward can scatter into a
+//! full-size gradient tensor directly.
+
+use burn_cubecl::cubecl;
+use burn_cubecl::cubecl::cube;
+use burn_cubecl::cubecl::prelude::*;
+
+use crate::AtomicAddF32;
+use brush_cube::is_finite_f32;
+
+/// BT601 RGB→gray weights (used by every reference implementation).
+pub const C2G_R: f32 = 0.299;
+pub const C2G_G: f32 = 0.587;
+pub const C2G_B: f32 = 0.114;
+
+pub const BLOCK_SIZE: u32 = 256;
+
+/// Per-pixel slicing coordinates and interpolation weights.
+#[derive(CubeType, Copy, Clone)]
+#[expand(derive(Clone, Copy))]
+pub(crate) struct SliceCoords {
+    pub x0: u32,
+    pub x1: u32,
+    pub y0: u32,
+    pub y1: u32,
+    pub z0: u32,
+    pub z1: u32,
+    pub fx: f32,
+    pub fy: f32,
+    pub fz: f32,
+    /// Continuous guidance coordinate (needed by the backward's exact-plane
+    /// gradient guard).
+    pub z: f32,
+}
+
+#[cube]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn slice_coords(
+    wi: u32,
+    hi: u32,
+    sr: f32,
+    sg: f32,
+    sb: f32,
+    gl: u32,
+    gh: u32,
+    gw: u32,
+    img_h: u32,
+    img_w: u32,
+) -> SliceCoords {
+    // align_corners=True: pixel (0..w-1) maps to grid (0..W-1).
+    let x = f32::cast_from(wi) / f32::cast_from(max(img_w - 1, 1u32)) * f32::cast_from(gw - 1);
+    let y = f32::cast_from(hi) / f32::cast_from(max(img_h - 1, 1u32)) * f32::cast_from(gh - 1);
+    let z = (C2G_R * sr + C2G_G * sg + C2G_B * sb) * f32::cast_from(gl - 1);
+
+    let x0 = u32::cast_from(f32::floor(x));
+    let y0 = u32::cast_from(f32::floor(y));
+    let x1 = min(x0 + 1, gw - 1);
+    let y1 = min(y0 + 1, gh - 1);
+    // The guidance coordinate can run past the grid (rgb outside [0, 1]) —
+    // clamp like padding_mode="border". fx/fy/fz are measured against the
+    // *clamped* z0 to match the reference kernels.
+    let z0i = i32::cast_from(f32::floor(z));
+    let gl_max = i32::cast_from(gl - 1);
+    let z0c = clamp(z0i, 0i32, gl_max);
+    let z1c = clamp(z0i + 1i32, 0i32, gl_max);
+
+    SliceCoords {
+        x0,
+        x1,
+        y0,
+        y1,
+        z0: u32::cast_from(z0c),
+        z1: u32::cast_from(z1c),
+        fx: x - f32::floor(x),
+        fy: y - f32::floor(y),
+        fz: z - f32::cast_from(z0c),
+        z,
+    }
+}
+
+/// `rgb_out[c] += interp(grid channel) * coeff` over the 12 affine
+/// coefficients; one thread per pixel.
+#[cube(launch)]
+#[allow(clippy::too_many_arguments)]
+pub fn bilagrid_slice_fwd_kernel(
+    grid: &Tensor<f32>,
+    rgb: &Tensor<f32>,
+    out: &mut Tensor<f32>,
+    gl: u32,
+    gh: u32,
+    gw: u32,
+    img_h: u32,
+    img_w: u32,
+    grid_offset: u32,
+    channels: u32,
+    #[comptime] has_alpha: bool,
+) {
+    let idx = CUBE_POS_X * BLOCK_SIZE + UNIT_POS_X;
+    if idx >= img_h * img_w {
+        terminate!();
+    }
+    let hi = idx / img_w;
+    let wi = idx % img_w;
+    let base = (idx * channels) as usize;
+
+    let sr = rgb[base];
+    let sg = rgb[base + 1];
+    let sb = rgb[base + 2];
+
+    let c = slice_coords(wi, hi, sr, sg, sb, gl, gh, gw, img_h, img_w);
+
+    let cell = gl * gh * gw;
+    let mut dr = 0.0f32;
+    let mut dg = 0.0f32;
+    let mut db = 0.0f32;
+
+    #[unroll]
+    for ci in 0u32..12u32 {
+        let cbase = grid_offset + ci * cell;
+        let v000 = grid[(cbase + (c.z0 * gh + c.y0) * gw + c.x0) as usize];
+        let v001 = grid[(cbase + (c.z0 * gh + c.y0) * gw + c.x1) as usize];
+        let v010 = grid[(cbase + (c.z0 * gh + c.y1) * gw + c.x0) as usize];
+        let v011 = grid[(cbase + (c.z0 * gh + c.y1) * gw + c.x1) as usize];
+        let v100 = grid[(cbase + (c.z1 * gh + c.y0) * gw + c.x0) as usize];
+        let v101 = grid[(cbase + (c.z1 * gh + c.y0) * gw + c.x1) as usize];
+        let v110 = grid[(cbase + (c.z1 * gh + c.y1) * gw + c.x0) as usize];
+        let v111 = grid[(cbase + (c.z1 * gh + c.y1) * gw + c.x1) as usize];
+
+        let c00 = v000 * (1.0f32 - c.fx) + v001 * c.fx;
+        let c01 = v010 * (1.0f32 - c.fx) + v011 * c.fx;
+        let c10 = v100 * (1.0f32 - c.fx) + v101 * c.fx;
+        let c11 = v110 * (1.0f32 - c.fx) + v111 * c.fx;
+        let c0 = c00 * (1.0f32 - c.fy) + c01 * c.fy;
+        let c1 = c10 * (1.0f32 - c.fy) + c11 * c.fy;
+        let val = c0 * (1.0f32 - c.fz) + c1 * c.fz;
+
+        let si = ci % 4u32;
+        let di = ci / 4u32;
+        let coeff = select(
+            si == 0u32,
+            sr,
+            select(si == 1u32, sg, select(si == 2u32, sb, 1.0f32)),
+        );
+        let contrib = val * coeff;
+        dr += select(di == 0u32, contrib, 0.0f32);
+        dg += select(di == 1u32, contrib, 0.0f32);
+        db += select(di == 2u32, contrib, 0.0f32);
+    }
+
+    out[base] = select(is_finite_f32(dr), dr, 0.5f32);
+    out[base + 1] = select(is_finite_f32(dg), dg, 0.5f32);
+    out[base + 2] = select(is_finite_f32(db), db, 0.5f32);
+    if has_alpha {
+        out[base + 3] = rgb[base + 3];
+    }
+}
+
+/// Independent per-plane Bernoulli election with probability `1/every`:
+/// a PCG-style hash of the plane index mixed with the per-step seed (see
+/// `GradSubsample`). Stochastic per-warp selection instead of a regular
+/// stripe pattern.
+#[cube]
+// `is_multiple_of` is not available inside `#[cube]` kernels.
+#[allow(clippy::manual_is_multiple_of)]
+pub(crate) fn plane_elected(plane_idx: u32, seed: u32, every: u32) -> bool {
+    // Golden-ratio spread of the seed before combining: both inputs may be
+    // small integers, and xor alone mixes those poorly.
+    let mut x = plane_idx + seed * 2654435769u32;
+    x = x * 747796405u32 + 2891336453u32;
+    x = ((x >> ((x >> 28) + 4)) ^ x) * 277803737u32;
+    ((x >> 22) ^ x) % every == 0
+}
+
+/// Backward: per-pixel scatter of `dL/dgrid` (atomic) and write of
+/// `dL/drgb` (the affine read-out plus the guidance-coordinate term).
+#[cube(launch)]
+#[allow(clippy::too_many_arguments, clippy::needless_pass_by_ref_mut)]
+pub fn bilagrid_slice_bwd_kernel<A: AtomicAddF32>(
+    grid: &Tensor<f32>,
+    rgb: &Tensor<f32>,
+    v_out: &Tensor<f32>,
+    grad_grid: &mut Tensor<Atomic<A::Storage>>,
+    grad_rgb: &mut Tensor<f32>,
+    gl: u32,
+    gh: u32,
+    gw: u32,
+    img_h: u32,
+    img_w: u32,
+    grid_offset: u32,
+    channels: u32,
+    subsample: u32,
+    subsample_seed: u32,
+    #[comptime] has_alpha: bool,
+) {
+    let idx = CUBE_POS_X * BLOCK_SIZE + UNIT_POS_X;
+    if idx >= img_h * img_w {
+        terminate!();
+    }
+    let hi = idx / img_w;
+    let wi = idx % img_w;
+    let base = (idx * channels) as usize;
+    // Plane-uniform gradient subsampling (see `GradSubsample`): non-elected
+    // planes still compute the exact rgb gradient, but skip the atomic
+    // scatter into the grid.
+    let do_scatter = plane_elected(idx / PLANE_DIM, subsample_seed, subsample);
+    let sscale = f32::cast_from(subsample);
+
+    let sr_raw = rgb[base];
+    let sg_raw = rgb[base + 1];
+    let sb_raw = rgb[base + 2];
+    let sr = select(is_finite_f32(sr_raw), sr_raw, 0.5f32);
+    let sg = select(is_finite_f32(sg_raw), sg_raw, 0.5f32);
+    let sb = select(is_finite_f32(sb_raw), sb_raw, 0.5f32);
+
+    let c = slice_coords(wi, hi, sr, sg, sb, gl, gh, gw, img_h, img_w);
+
+    let dr_raw = v_out[base];
+    let dg_raw = v_out[base + 1];
+    let db_raw = v_out[base + 2];
+    let dr = select(is_finite_f32(dr_raw), dr_raw, 0.0f32);
+    let dg = select(is_finite_f32(dg_raw), dg_raw, 0.0f32);
+    let db = select(is_finite_f32(db_raw), db_raw, 0.0f32);
+
+    let cell = gl * gh * gw;
+    let mut vr = 0.0f32;
+    let mut vg = 0.0f32;
+    let mut vb = 0.0f32;
+    let mut gz = 0.0f32;
+
+    // Subgroup vote: rendered images are smooth, so a plane's 32 pixels
+    // usually land in the same grid cell. When every lane agrees on all
+    // eight corner cells, merge the scatter with `plane_sum` and emit one
+    // atomic per (corner, coeff) from the first lane — a ~32x cut in
+    // global atomics, which dominate this kernel. WGSL subgroup ops act on
+    // active lanes and don't require uniform control flow, and the branch
+    // below is plane-uniform by construction.
+    let cell_uniform = plane_min(c.x0) == plane_max(c.x0)
+        && plane_min(c.y0) == plane_max(c.y0)
+        && plane_min(c.z0) == plane_max(c.z0)
+        && plane_min(c.x1) == plane_max(c.x1)
+        && plane_min(c.y1) == plane_max(c.y1)
+        && plane_min(c.z1) == plane_max(c.z1);
+
+    #[unroll]
+    for corner in 0u32..8u32 {
+        let cx = select((corner & 1u32) != 0u32, c.x1, c.x0);
+        let cy = select((corner & 2u32) != 0u32, c.y1, c.y0);
+        let cz = select((corner & 4u32) != 0u32, c.z1, c.z0);
+        let wx = select((corner & 1u32) != 0u32, c.fx, 1.0f32 - c.fx);
+        let wy = select((corner & 2u32) != 0u32, c.fy, 1.0f32 - c.fy);
+        let wz = select((corner & 4u32) != 0u32, c.fz, 1.0f32 - c.fz);
+        let wt = wx * wy * wz;
+        // d(weight)/d(fz): the z-factor flips sign on the near corners.
+        let dfdz = wx * wy * select((corner & 4u32) != 0u32, 1.0f32, -1.0f32);
+
+        let mut trilerp = 0.0f32;
+        #[unroll]
+        for ci in 0u32..12u32 {
+            let gidx = (grid_offset + ci * cell + (cz * gh + cy) * gw + cx) as usize;
+            let si = ci % 4u32;
+            let di = ci / 4u32;
+            let r_coeff = select(
+                si == 0u32,
+                sr,
+                select(si == 1u32, sg, select(si == 2u32, sb, 1.0f32)),
+            );
+            let gout = select(di == 0u32, dr, select(di == 1u32, dg, db));
+            let v = grid[gidx];
+
+            // dL/drgb through the affine application (A * rgb): only the
+            // first three columns multiply the input color.
+            let contrib = v * wt * gout;
+            vr += select(si == 0u32, contrib, 0.0f32);
+            vg += select(si == 1u32, contrib, 0.0f32);
+            vb += select(si == 2u32, contrib, 0.0f32);
+
+            let grad_weight = r_coeff * gout;
+            trilerp += v * grad_weight;
+            if cell_uniform {
+                let merged = plane_sum(wt * grad_weight);
+                if do_scatter && UNIT_POS_PLANE == 0u32 {
+                    A::add(&grad_grid[gidx], merged * sscale);
+                }
+            } else if do_scatter {
+                A::add(&grad_grid[gidx], wt * grad_weight * sscale);
+            }
+        }
+        gz += dfdz * f32::cast_from(gl - 1) * trilerp;
+    }
+
+    // Zero the guidance gradient when z sits exactly on a grid plane
+    // (matches the reference kernels' subgradient choice there).
+    let guard = f32::cast_from(c.z0) != c.z && f32::cast_from(c.z1) != c.z;
+    gz = select(guard, gz, 0.0f32);
+
+    grad_rgb[base] = vr + C2G_R * gz;
+    grad_rgb[base + 1] = vg + C2G_G * gz;
+    grad_rgb[base + 2] = vb + C2G_B * gz;
+    if has_alpha {
+        // Alpha passes through the correction untouched.
+        grad_rgb[base + 3] = v_out[base + 3];
+    }
+}
+
+/// Total-variation forward, stage 1: grid-stride partial sums, one value
+/// per cube. The host sums the partials (`Tensor::sum`) for the scalar
+/// loss. Normalisation matches gsplat's `total_variation_loss`:
+/// each direction's squared diffs are averaged over that direction's
+/// element count (channels included) and the result is averaged over views.
+#[cube(launch)]
+pub fn bilagrid_tv_fwd_kernel(
+    grids: &Tensor<f32>,
+    partials: &mut Tensor<f32>,
+    n: u32,
+    gl: u32,
+    gh: u32,
+    gw: u32,
+    #[comptime] grid_channels: u32,
+) {
+    let total = n * gl * gh * gw;
+    let stride = CUBE_COUNT_X * BLOCK_SIZE;
+    let mut idx = CUBE_POS_X * BLOCK_SIZE + UNIT_POS_X;
+
+    let sx = 1.0f32 / f32::cast_from(gl * gh * (gw - 1));
+    let sy = 1.0f32 / f32::cast_from(gl * (gh - 1) * gw);
+    let sz = 1.0f32 / f32::cast_from((gl - 1) * gh * gw);
+
+    let mut local = 0.0f32;
+    while idx < total {
+        let wi = idx % gw;
+        let hi = (idx / gw) % gh;
+        let li = (idx / (gw * gh)) % gl;
+        let ni = idx / (gw * gh * gl);
+
+        #[unroll]
+        for ci in 0u32..grid_channels {
+            let cell_idx = (((ni * grid_channels + ci) * gl + li) * gh + hi) * gw + wi;
+            let val = grids[cell_idx as usize];
+
+            if wi > 0u32 {
+                let v0 = grids[(cell_idx - 1u32) as usize];
+                let d = val - v0;
+                local += d * d * sx;
+            }
+            if hi > 0u32 {
+                let v0 = grids[(cell_idx - gw) as usize];
+                let d = val - v0;
+                local += d * d * sy;
+            }
+            if li > 0u32 {
+                let v0 = grids[(cell_idx - gw * gh) as usize];
+                let d = val - v0;
+                local += d * d * sz;
+            }
+        }
+        idx += stride;
+    }
+    local /= f32::cast_from(grid_channels * n);
+
+    // Cube-level reduction: plane sums, then thread 0 folds the planes.
+    let sg_sum = plane_sum(local);
+    let mut sg_partials = Shared::new_slice(BLOCK_SIZE as usize);
+    let subgroup_id = UNIT_POS_X / PLANE_DIM;
+    if UNIT_POS_PLANE == 0u32 {
+        sg_partials[subgroup_id as usize] = sg_sum;
+    }
+    sync_cube();
+    if UNIT_POS_X == 0u32 {
+        let num_subgroups = BLOCK_SIZE / PLANE_DIM;
+        let mut tot = 0.0f32;
+        let mut i = 0u32;
+        while i < num_subgroups {
+            tot += sg_partials[i as usize];
+            i += 1u32;
+        }
+        partials[CUBE_POS_X as usize] = tot;
+    }
+}
+
+/// Total-variation backward: deterministic direct write, one thread per
+/// `(n, l, h, w)` cell covering all 12 channels. `v_loss` is the upstream
+/// scalar gradient as a 1-element tensor (kept on-GPU).
+#[cube(launch)]
+pub fn bilagrid_tv_bwd_kernel(
+    grids: &Tensor<f32>,
+    v_loss: &Tensor<f32>,
+    grad_grids: &mut Tensor<f32>,
+    n: u32,
+    gl: u32,
+    gh: u32,
+    gw: u32,
+    #[comptime] grid_channels: u32,
+) {
+    let idx = CUBE_POS_X * BLOCK_SIZE + UNIT_POS_X;
+    let total = n * gl * gh * gw;
+    if idx >= total {
+        terminate!();
+    }
+    let wi = idx % gw;
+    let hi = (idx / gw) % gh;
+    let li = (idx / (gw * gh)) % gl;
+    let ni = idx / (gw * gh * gl);
+
+    // d/dv of the normalised TV sum: each (v - v0) pair contributes
+    // 2 (v - v0) * s / (12 n) = (v - v0) * s / (6 n) to both sides.
+    let s = v_loss[0] / f32::cast_from(6u32 * n);
+    let sx = s / f32::cast_from(gl * gh * (gw - 1));
+    let sy = s / f32::cast_from(gl * (gh - 1) * gw);
+    let sz = s / f32::cast_from((gl - 1) * gh * gw);
+
+    #[unroll]
+    for ci in 0u32..grid_channels {
+        let cell_idx = (((ni * grid_channels + ci) * gl + li) * gh + hi) * gw + wi;
+        let val = grids[cell_idx as usize];
+        let mut g = 0.0f32;
+
+        if wi > 0u32 {
+            g += (val - grids[(cell_idx - 1u32) as usize]) * sx;
+        }
+        if wi < gw - 1 {
+            g += (val - grids[(cell_idx + 1u32) as usize]) * sx;
+        }
+        if hi > 0u32 {
+            g += (val - grids[(cell_idx - gw) as usize]) * sy;
+        }
+        if hi < gh - 1 {
+            g += (val - grids[(cell_idx + gw) as usize]) * sy;
+        }
+        if li > 0u32 {
+            g += (val - grids[(cell_idx - gw * gh) as usize]) * sz;
+        }
+        if li < gl - 1 {
+            g += (val - grids[(cell_idx + gw * gh) as usize]) * sz;
+        }
+
+        grad_grids[cell_idx as usize] = g;
+    }
+}

--- a/crates/brush-appearance/src/lib.rs
+++ b/crates/brush-appearance/src/lib.rs
@@ -1,0 +1,233 @@
+//! Per-view appearance compensation for Brush training.
+//!
+//! Two independently-toggleable models, both applied to the *rendered* image
+//! before the photometric loss so the splats themselves learn canonical
+//! (appearance-free) colors:
+//!
+//! - [`bilagrid`]: per-view 3D bilateral grids ("Bilateral Guided Radiance
+//!   Field Processing", `BilaRF`). Each training view owns a `[12, L, H, W]`
+//!   grid of 3x4 affine color transforms, sliced per pixel by screen position
+//!   and grayscale guidance. Fused forward/backward `CubeCL` kernels (ported
+//!   from `LichtFeld` Studio / gsplat's fused implementation) plus a fused
+//!   total-variation regulariser.
+//!
+//! - [`ppisp`]: physically-plausible ISP compensation (NVIDIA PPISP). Models
+//!   per-frame exposure + color homography and per-camera vignetting + CRF
+//!   with a handful of parameters each, applied per pixel by a fused kernel.
+//!   The parameter regularisation is plain tensor ops (the params are tiny).
+//!
+//! Both follow the `brush-loss` pattern: a backend trait implemented for the
+//! raw `CubeCL` backend and the Fusion backend, plus custom Burn autodiff ops
+//! so gradients flow to both the appearance params and the rendered image.
+
+pub mod bilagrid;
+mod bilagrid_kernels;
+pub mod ppisp;
+pub mod ppisp_grid;
+mod ppisp_grid_kernels;
+mod ppisp_kernels;
+mod ppisp_math;
+pub mod train_state;
+
+use burn::backend::wgpu::WgpuRuntime;
+use burn::tensor::{DType, Shape};
+use burn_cubecl::{CubeRuntime, fusion::FusionCubeRuntime, tensor::CubeTensor};
+use burn_fusion::{
+    FusionHandle,
+    stream::{Operation, StreamId},
+};
+use burn_ir::{CustomOpIr, HandleContainer, OperationIr, OperationOutput, TensorIr};
+
+pub(crate) use brush_cube::{AtomicAddF32, CasAtomicAdd, HfAtomicAdd};
+
+pub(crate) fn alloc_zeros<R: CubeRuntime>(
+    template: &CubeTensor<R>,
+    shape: Shape,
+    dtype: DType,
+) -> CubeTensor<R> {
+    burn_cubecl::ops::numeric::zeros_client::<R>(
+        template.client.clone(),
+        template.device.clone(),
+        shape,
+        dtype,
+    )
+}
+
+/// Wraps a closure as a fusion `Operation` (same pattern as `brush-loss`).
+struct ClosureOp<F> {
+    desc: CustomOpIr,
+    op: F,
+}
+
+impl<F> std::fmt::Debug for ClosureOp<F> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ClosureOp({:?})", self.desc)
+    }
+}
+
+impl<F> Operation<FusionCubeRuntime<WgpuRuntime>> for ClosureOp<F>
+where
+    F: Fn(&CustomOpIr, &mut HandleContainer<FusionHandle<FusionCubeRuntime<WgpuRuntime>>>)
+        + Send
+        + Sync
+        + 'static,
+{
+    fn execute(&self, h: &mut HandleContainer<FusionHandle<FusionCubeRuntime<WgpuRuntime>>>) {
+        (self.op)(&self.desc, h);
+    }
+}
+
+pub(crate) type FusionTensor = burn_fusion::FusionTensor<FusionCubeRuntime<WgpuRuntime>>;
+
+/// Register a custom op with `N` inputs and `M` outputs on the Fusion
+/// stream. Generalises `brush-loss`'s single-output helper: each output is
+/// described by `(shape, dtype)`; `op` runs against the inner backend when
+/// fusion executes the queued op.
+pub(crate) fn dispatch_custom<const N: usize, const M: usize, F>(
+    name: &'static str,
+    inputs: [FusionTensor; N],
+    outputs: [(Shape, DType); M],
+    op: F,
+) -> [FusionTensor; M]
+where
+    F: Fn(&CustomOpIr, &mut HandleContainer<FusionHandle<FusionCubeRuntime<WgpuRuntime>>>)
+        + Send
+        + Sync
+        + 'static,
+{
+    let client = inputs[0].client.clone();
+    let outs =
+        outputs.map(|(shape, dtype)| TensorIr::uninit(client.create_empty_handle(), shape, dtype));
+    let stream = StreamId::current();
+    let desc = CustomOpIr::new(name, &inputs.map(|t| t.into_ir()), &outs);
+    let wrapped = ClosureOp {
+        desc: desc.clone(),
+        op,
+    };
+    client
+        .register(stream, OperationIr::Custom(desc), wrapped)
+        .outputs()
+}
+
+/// Resolve a possibly-fused float tensor into a contiguous `CubeTensor`.
+pub(crate) fn contiguous<R: CubeRuntime>(t: CubeTensor<R>) -> CubeTensor<R> {
+    burn_cubecl::kernel::into_contiguous(t)
+}
+
+// Re-export the user-facing API at the crate root.
+/// Grid-gradient subsampling: each plane (subgroup) independently elects
+/// itself with probability `1/every` per step — a Bernoulli draw from a
+/// PCG hash of the plane index and the per-step `seed` — and elected
+/// planes scatter grid gradients scaled by `every` to stay unbiased. The
+/// image gradient is always exact. `every = 1` disables.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GradSubsample {
+    pub every: u32,
+    pub seed: u32,
+}
+
+impl GradSubsample {
+    /// The subsample schedule for a global training step.
+    pub fn for_step(every: u32, step: u32) -> Self {
+        // PCG-style mix of the step index; any fixed integer hash works.
+        let mut s = step.wrapping_mul(747_796_405).wrapping_add(2_891_336_453);
+        s = ((s >> ((s >> 28) + 4)) ^ s).wrapping_mul(277_803_737);
+        Self {
+            every: every.max(1),
+            seed: (s >> 22) ^ s,
+        }
+    }
+}
+
+impl Default for GradSubsample {
+    fn default() -> Self {
+        Self { every: 1, seed: 0 }
+    }
+}
+
+pub use bilagrid::{BilagridModel, bilagrid_apply, bilagrid_tv_loss};
+pub use ppisp::{PpispModel, PpispStages, ppisp_apply};
+pub use ppisp_grid::{GridPayload, ppisp_grid_apply};
+pub use train_state::{ActiveAppearance, AppearanceTrainState};
+
+/// Static configuration for the appearance models.
+#[derive(Debug, Clone)]
+pub struct AppearanceConfig {
+    /// Hybrid mode: per-camera vignetting + per-view PPISP grid
+    /// (+ optional per-camera CRF). Replaces the two legacy modes.
+    pub ppisp_grid: bool,
+    /// Hybrid grid payload includes the 8 color-homography latents
+    /// (`false` = exposure-only grid, one log2 scalar per cell).
+    pub grid_color: bool,
+    /// Hybrid grid payload includes per-cell CRF offsets.
+    pub grid_crf: bool,
+    /// Learn a per-camera CRF applied after the hybrid grid.
+    pub crf_per_camera: bool,
+    /// Legacy comparison mode: per-view affine bilateral grids.
+    pub bilagrid: bool,
+    /// Legacy comparison mode: full per-frame PPISP.
+    pub ppisp: bool,
+    /// Grid dims `(x, y, guidance)` — spatial width/height and the
+    /// grayscale guidance dimension (both grid kinds).
+    pub bilagrid_dims: (usize, usize, usize),
+    /// Weight of the grid total-variation regulariser.
+    pub bilagrid_tv_weight: f32,
+    /// Weight of the EMA-anchored mean-to-identity regulariser (hybrid
+    /// payload grids; 0 disables).
+    pub bilagrid_mean_reg: f32,
+    /// Grid learning rate (warmup + exponential decay applied).
+    pub bilagrid_lr: f64,
+    /// Adam betas for the sparse per-view grid updates.
+    pub bilagrid_betas: (f64, f64),
+    /// Grid-gradient subsampling: only every Nth subgroup scatters grid
+    /// gradients (1 disables). See [`GradSubsample`]. Defaults to 4 —
+    /// quality-neutral for the heavily regularised grids, and removes most
+    /// of the grid backward's atomic cost.
+    pub grad_subsample: u32,
+    /// PPISP learning rate (warmup + exponential decay applied).
+    pub ppisp_lr: f64,
+    /// Scale on all PPISP regularisation terms.
+    pub ppisp_reg_scale: f32,
+}
+
+impl Default for AppearanceConfig {
+    fn default() -> Self {
+        Self {
+            ppisp_grid: false,
+            grid_color: true,
+            grid_crf: false,
+            crf_per_camera: false,
+            bilagrid: false,
+            ppisp: false,
+            bilagrid_dims: (16, 16, 8),
+            bilagrid_tv_weight: 10.0,
+            bilagrid_mean_reg: 10.0,
+            bilagrid_lr: 2e-3,
+            bilagrid_betas: (0.9, 0.999),
+            grad_subsample: 4,
+            ppisp_lr: 2e-3,
+            ppisp_reg_scale: 1.0,
+        }
+    }
+}
+
+/// Warmup + exponential-decay LR schedule used for both appearance models
+/// (matches the PPISP / `LichtFeld` bilateral-grid schedules): linear warmup
+/// from `start_factor * base` over `warmup_steps`, then exponential decay
+/// toward `final_factor * base` at `decay_steps`.
+pub fn warmup_exp_lr(
+    step: u32,
+    base: f64,
+    warmup_steps: u32,
+    start_factor: f64,
+    final_factor: f64,
+    decay_steps: u32,
+) -> f64 {
+    if step < warmup_steps {
+        let t = (step as f64 + 1.0) / warmup_steps as f64;
+        base * (start_factor + (1.0 - start_factor) * t)
+    } else {
+        let decay_step = (step - warmup_steps) as f64;
+        base * final_factor.powf(decay_step / decay_steps.max(1) as f64)
+    }
+}

--- a/crates/brush-appearance/src/ppisp.rs
+++ b/crates/brush-appearance/src/ppisp.rs
@@ -1,0 +1,716 @@
+//! Host side of PPISP: backend trait + kernel launches, Fusion dispatch,
+//! Burn autodiff op, the `PpispModel` module and its (tensor-op based)
+//! parameter regularisation.
+
+use brush_cube::{MainBackend, MainBackendBase};
+use brush_render::burn_glue::{
+    AutodiffMain, unwrap_ad_wgpu_float, wrap_ad_wgpu_float, wrap_wgpu_float,
+};
+use burn::{
+    backend::{
+        Backend, TensorMetadata,
+        autodiff::{
+            checkpoint::{base::Checkpointer, strategy::NoCheckpointing},
+            grads::Gradients,
+            ops::{Backward, Ops, OpsKind},
+        },
+        tensor::FloatTensor,
+    },
+    module::{Module, Param},
+    tensor::{DType, Device, Shape, Tensor, TensorData},
+};
+use burn_cubecl::{CubeRuntime, tensor::CubeTensor};
+use burn_fusion::Fusion;
+
+use crate::ppisp_kernels as kernels;
+use crate::{alloc_zeros, contiguous, dispatch_custom};
+
+/// Number of scalar parameter gradients produced per pixel
+/// (see `ppisp_kernels` for the slot layout).
+const NUM_PARAM_GRADS: usize = kernels::NUM_PARAM_GRADS as usize;
+
+/// Which PPISP stages a pass applies. The full model is all three; the
+/// hybrid grid mode runs camera-only passes (vignetting before the grid,
+/// optionally CRF after it) with the per-frame stages handled by the grid.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PpispStages {
+    /// Per-frame exposure + color homography.
+    pub frame: bool,
+    /// Per-camera vignetting.
+    pub vignetting: bool,
+    /// Per-camera CRF tone curve.
+    pub crf: bool,
+}
+
+impl PpispStages {
+    pub const ALL: Self = Self {
+        frame: true,
+        vignetting: true,
+        crf: true,
+    };
+    pub const VIGNETTING_ONLY: Self = Self {
+        frame: false,
+        vignetting: true,
+        crf: false,
+    };
+    pub const CRF_ONLY: Self = Self {
+        frame: false,
+        vignetting: false,
+        crf: true,
+    };
+}
+
+/// Backend hooks for the PPISP kernels.
+pub trait PpispOps<B: Backend> {
+    /// Apply the full pipeline to `rgb` `[h, w, 3|4]` (alpha untouched).
+    #[allow(clippy::too_many_arguments)]
+    fn ppisp_fwd(
+        exposure: FloatTensor<B>,
+        vignetting: FloatTensor<B>,
+        color: FloatTensor<B>,
+        crf: FloatTensor<B>,
+        rgb: FloatTensor<B>,
+        camera_idx: usize,
+        frame_idx: usize,
+        stages: PpispStages,
+    ) -> FloatTensor<B>;
+
+    /// Raw backward: returns `(partials [num_cubes, 36], dL/drgb)`. The
+    /// caller reduces `partials` and scatters into full-shape param grads.
+    #[allow(clippy::too_many_arguments)]
+    fn ppisp_bwd_raw(
+        exposure: FloatTensor<B>,
+        vignetting: FloatTensor<B>,
+        color: FloatTensor<B>,
+        crf: FloatTensor<B>,
+        rgb: FloatTensor<B>,
+        v_out: FloatTensor<B>,
+        camera_idx: usize,
+        frame_idx: usize,
+        stages: PpispStages,
+    ) -> (FloatTensor<B>, FloatTensor<B>);
+}
+
+fn ppisp_dims<R: CubeRuntime>(rgb: &CubeTensor<R>) -> (u32, u32, u32) {
+    let dims = rgb.shape().as_slice().to_vec();
+    assert_eq!(dims.len(), 3, "rgb must be [h, w, c]");
+    let ch = dims[2] as u32;
+    assert!(ch == 3 || ch == 4, "rgb must have 3 or 4 channels");
+    (dims[0] as u32, dims[1] as u32, ch)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn launch_fwd<R: CubeRuntime>(
+    exposure: CubeTensor<R>,
+    vignetting: CubeTensor<R>,
+    color: CubeTensor<R>,
+    crf: CubeTensor<R>,
+    rgb: CubeTensor<R>,
+    camera_idx: usize,
+    frame_idx: usize,
+    stages: PpispStages,
+) -> CubeTensor<R> {
+    use burn_cubecl::cubecl::prelude::{CubeCount, CubeDim};
+
+    let exposure = contiguous(exposure);
+    let vignetting = contiguous(vignetting);
+    let color = contiguous(color);
+    let crf = contiguous(crf);
+    let rgb = contiguous(rgb);
+    let (h, w, ch) = ppisp_dims(&rgb);
+
+    let out = alloc_zeros(&rgb, rgb.shape(), DType::F32);
+    let client = rgb.client.clone();
+    kernels::ppisp_fwd_kernel::launch::<R>(
+        &client,
+        CubeCount::Static((h * w).div_ceil(kernels::BLOCK_SIZE), 1, 1),
+        CubeDim::new_1d(kernels::BLOCK_SIZE),
+        exposure.into_tensor_arg(),
+        vignetting.into_tensor_arg(),
+        color.into_tensor_arg(),
+        crf.into_tensor_arg(),
+        rgb.into_tensor_arg(),
+        out.clone().into_tensor_arg(),
+        h,
+        w,
+        camera_idx as u32,
+        frame_idx as u32,
+        ch,
+        ch == 4,
+        stages.frame,
+        stages.vignetting,
+        stages.crf,
+    );
+    out
+}
+
+#[allow(clippy::too_many_arguments)]
+fn launch_bwd<R: CubeRuntime>(
+    exposure: CubeTensor<R>,
+    vignetting: CubeTensor<R>,
+    color: CubeTensor<R>,
+    crf: CubeTensor<R>,
+    rgb: CubeTensor<R>,
+    v_out: CubeTensor<R>,
+    camera_idx: usize,
+    frame_idx: usize,
+    stages: PpispStages,
+) -> (CubeTensor<R>, CubeTensor<R>) {
+    use burn_cubecl::cubecl::prelude::{CubeCount, CubeDim};
+
+    let exposure = contiguous(exposure);
+    let vignetting = contiguous(vignetting);
+    let color = contiguous(color);
+    let crf = contiguous(crf);
+    let rgb = contiguous(rgb);
+    let v_out = contiguous(v_out);
+    let (h, w, ch) = ppisp_dims(&rgb);
+
+    let num_cubes = (h * w).div_ceil(kernels::BLOCK_SIZE);
+    let grad_rgb = alloc_zeros(&rgb, rgb.shape(), DType::F32);
+    let partials = alloc_zeros(
+        &rgb,
+        Shape::new([num_cubes as usize, NUM_PARAM_GRADS]),
+        DType::F32,
+    );
+    let client = rgb.client.clone();
+    kernels::ppisp_bwd_kernel::launch::<R>(
+        &client,
+        CubeCount::Static(num_cubes, 1, 1),
+        CubeDim::new_1d(kernels::BLOCK_SIZE),
+        exposure.into_tensor_arg(),
+        vignetting.into_tensor_arg(),
+        color.into_tensor_arg(),
+        crf.into_tensor_arg(),
+        rgb.into_tensor_arg(),
+        v_out.into_tensor_arg(),
+        grad_rgb.clone().into_tensor_arg(),
+        partials.clone().into_tensor_arg(),
+        h,
+        w,
+        camera_idx as u32,
+        frame_idx as u32,
+        ch,
+        ch == 4,
+        stages.frame,
+        stages.vignetting,
+        stages.crf,
+    );
+    #[allow(clippy::tuple_array_conversions)]
+    (partials, grad_rgb)
+}
+
+impl PpispOps<Self> for MainBackendBase {
+    fn ppisp_fwd(
+        exposure: FloatTensor<Self>,
+        vignetting: FloatTensor<Self>,
+        color: FloatTensor<Self>,
+        crf: FloatTensor<Self>,
+        rgb: FloatTensor<Self>,
+        camera_idx: usize,
+        frame_idx: usize,
+        stages: PpispStages,
+    ) -> FloatTensor<Self> {
+        launch_fwd(
+            exposure, vignetting, color, crf, rgb, camera_idx, frame_idx, stages,
+        )
+    }
+
+    fn ppisp_bwd_raw(
+        exposure: FloatTensor<Self>,
+        vignetting: FloatTensor<Self>,
+        color: FloatTensor<Self>,
+        crf: FloatTensor<Self>,
+        rgb: FloatTensor<Self>,
+        v_out: FloatTensor<Self>,
+        camera_idx: usize,
+        frame_idx: usize,
+        stages: PpispStages,
+    ) -> (FloatTensor<Self>, FloatTensor<Self>) {
+        launch_bwd(
+            exposure, vignetting, color, crf, rgb, v_out, camera_idx, frame_idx, stages,
+        )
+    }
+}
+
+impl PpispOps<Self> for Fusion<MainBackendBase> {
+    fn ppisp_fwd(
+        exposure: FloatTensor<Self>,
+        vignetting: FloatTensor<Self>,
+        color: FloatTensor<Self>,
+        crf: FloatTensor<Self>,
+        rgb: FloatTensor<Self>,
+        camera_idx: usize,
+        frame_idx: usize,
+        stages: PpispStages,
+    ) -> FloatTensor<Self> {
+        let shape = rgb.shape();
+        let [out] = dispatch_custom(
+            "ppisp_fwd",
+            [exposure, vignetting, color, crf, rgb],
+            [(shape, DType::F32)],
+            move |desc, h| {
+                let ([exposure, vignetting, color, crf, rgb], [out]) = desc.as_fixed();
+                let res = MainBackendBase::ppisp_fwd(
+                    h.get_float_tensor::<MainBackendBase>(exposure),
+                    h.get_float_tensor::<MainBackendBase>(vignetting),
+                    h.get_float_tensor::<MainBackendBase>(color),
+                    h.get_float_tensor::<MainBackendBase>(crf),
+                    h.get_float_tensor::<MainBackendBase>(rgb),
+                    camera_idx,
+                    frame_idx,
+                    stages,
+                );
+                h.register_float_tensor::<MainBackendBase>(&out.id, res);
+            },
+        );
+        out
+    }
+
+    fn ppisp_bwd_raw(
+        exposure: FloatTensor<Self>,
+        vignetting: FloatTensor<Self>,
+        color: FloatTensor<Self>,
+        crf: FloatTensor<Self>,
+        rgb: FloatTensor<Self>,
+        v_out: FloatTensor<Self>,
+        camera_idx: usize,
+        frame_idx: usize,
+        stages: PpispStages,
+    ) -> (FloatTensor<Self>, FloatTensor<Self>) {
+        let rgb_shape = rgb.shape();
+        let [h_dim, w_dim, _] = rgb_shape.dims();
+        let num_cubes = ((h_dim * w_dim) as u32).div_ceil(kernels::BLOCK_SIZE) as usize;
+        let [partials, grad_rgb] = dispatch_custom(
+            "ppisp_bwd_raw",
+            [exposure, vignetting, color, crf, rgb, v_out],
+            [
+                (Shape::new([num_cubes, NUM_PARAM_GRADS]), DType::F32),
+                (rgb_shape, DType::F32),
+            ],
+            move |desc, h| {
+                let ([exposure, vignetting, color, crf, rgb, v_out], [partials, grad_rgb]) =
+                    desc.as_fixed();
+                let (p, g) = MainBackendBase::ppisp_bwd_raw(
+                    h.get_float_tensor::<MainBackendBase>(exposure),
+                    h.get_float_tensor::<MainBackendBase>(vignetting),
+                    h.get_float_tensor::<MainBackendBase>(color),
+                    h.get_float_tensor::<MainBackendBase>(crf),
+                    h.get_float_tensor::<MainBackendBase>(rgb),
+                    h.get_float_tensor::<MainBackendBase>(v_out),
+                    camera_idx,
+                    frame_idx,
+                    stages,
+                );
+                h.register_float_tensor::<MainBackendBase>(&partials.id, p);
+                h.register_float_tensor::<MainBackendBase>(&grad_rgb.id, g);
+            },
+        );
+        #[allow(clippy::tuple_array_conversions)]
+        (partials, grad_rgb)
+    }
+}
+
+/// Full backward: reduce the per-cube partials and scatter the 36 summed
+/// parameter gradients into full-shape gradient tensors at the active
+/// frame/camera rows. Returns `(d_exposure, d_vignetting, d_color, d_crf,
+/// d_rgb)`.
+#[allow(clippy::too_many_arguments, clippy::type_complexity)]
+fn ppisp_backward<B: Backend + PpispOps<B>>(
+    exposure: FloatTensor<B>,
+    vignetting: FloatTensor<B>,
+    color: FloatTensor<B>,
+    crf: FloatTensor<B>,
+    rgb: FloatTensor<B>,
+    v_out: FloatTensor<B>,
+    camera_idx: usize,
+    frame_idx: usize,
+    stages: PpispStages,
+) -> (
+    FloatTensor<B>,
+    FloatTensor<B>,
+    FloatTensor<B>,
+    FloatTensor<B>,
+    FloatTensor<B>,
+) {
+    use burn::tensor::Slice;
+    let sl = |r: std::ops::Range<usize>| -> Slice { r.into() };
+
+    let device = B::float_device(&rgb);
+    let num_frames = exposure.shape().dims::<1>()[0];
+    let num_cameras = vignetting.shape().dims::<3>()[0];
+
+    let (partials, grad_rgb) = B::ppisp_bwd_raw(
+        exposure, vignetting, color, crf, rgb, v_out, camera_idx, frame_idx, stages,
+    );
+
+    // [num_cubes, 36] → [1, 36] (deterministic on-GPU sum).
+    let summed = B::float_sum_dim(partials, 0);
+
+    let slice_1d =
+        |t: FloatTensor<B>, lo: usize, hi: usize| B::float_slice(t, &[sl(0..1), sl(lo..hi)]);
+
+    // Exposure: [F] with slot 0 at `frame_idx`.
+    let g_exp = B::float_zeros(
+        Shape::new([num_frames]),
+        &device,
+        burn::tensor::FloatDType::F32,
+    );
+    let g_exp = B::float_slice_assign(
+        g_exp,
+        &[sl(frame_idx..frame_idx + 1)],
+        B::float_reshape(slice_1d(summed.clone(), 0, 1), Shape::new([1])),
+    );
+
+    // Vignetting: [C, 3, 5] with slots 1..16 at `camera_idx`.
+    let g_vig = B::float_zeros(
+        Shape::new([num_cameras, 3, 5]),
+        &device,
+        burn::tensor::FloatDType::F32,
+    );
+    let g_vig = B::float_slice_assign(
+        g_vig,
+        &[sl(camera_idx..camera_idx + 1), sl(0..3), sl(0..5)],
+        B::float_reshape(slice_1d(summed.clone(), 1, 16), Shape::new([1, 3, 5])),
+    );
+
+    // Color: [F, 8] with slots 16..24 at `frame_idx`.
+    let g_color = B::float_zeros(
+        Shape::new([num_frames, 8]),
+        &device,
+        burn::tensor::FloatDType::F32,
+    );
+    let g_color = B::float_slice_assign(
+        g_color,
+        &[sl(frame_idx..frame_idx + 1), sl(0..8)],
+        B::float_reshape(slice_1d(summed.clone(), 16, 24), Shape::new([1, 8])),
+    );
+
+    // CRF: [C, 3, 4] with slots 24..36 at `camera_idx`.
+    let g_crf = B::float_zeros(
+        Shape::new([num_cameras, 3, 4]),
+        &device,
+        burn::tensor::FloatDType::F32,
+    );
+    let g_crf = B::float_slice_assign(
+        g_crf,
+        &[sl(camera_idx..camera_idx + 1), sl(0..3), sl(0..4)],
+        B::float_reshape(slice_1d(summed, 24, 36), Shape::new([1, 3, 4])),
+    );
+
+    (g_exp, g_vig, g_color, g_crf, grad_rgb)
+}
+
+// ---------------------------------------------------------------------------
+// Autodiff op
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+struct PpispBackward;
+
+#[derive(Debug, Clone)]
+struct PpispState<B: Backend> {
+    exposure: FloatTensor<B>,
+    vignetting: FloatTensor<B>,
+    color: FloatTensor<B>,
+    crf: FloatTensor<B>,
+    rgb: FloatTensor<B>,
+    camera_idx: usize,
+    frame_idx: usize,
+    stages: PpispStages,
+}
+
+impl<B: Backend + PpispOps<B>> Backward<B, 5> for PpispBackward {
+    type State = PpispState<B>;
+
+    fn backward(
+        self,
+        ops: Ops<Self::State, 5>,
+        grads: &mut Gradients,
+        _checkpointer: &mut Checkpointer,
+    ) {
+        let state = ops.state;
+        let v_out = grads.consume::<B>(&ops.node);
+        let [exp_parent, vig_parent, color_parent, crf_parent, rgb_parent] = ops.parents;
+        let (g_exp, g_vig, g_color, g_crf, g_rgb) = ppisp_backward::<B>(
+            state.exposure,
+            state.vignetting,
+            state.color,
+            state.crf,
+            state.rgb,
+            v_out,
+            state.camera_idx,
+            state.frame_idx,
+            state.stages,
+        );
+        if let Some(node) = exp_parent {
+            grads.register::<B>(node.id, g_exp);
+        }
+        if let Some(node) = vig_parent {
+            grads.register::<B>(node.id, g_vig);
+        }
+        if let Some(node) = color_parent {
+            grads.register::<B>(node.id, g_color);
+        }
+        if let Some(node) = crf_parent {
+            grads.register::<B>(node.id, g_crf);
+        }
+        if let Some(node) = rgb_parent {
+            grads.register::<B>(node.id, g_rgb);
+        }
+    }
+}
+
+/// Apply PPISP to a rendered `[H, W, 3|4]` image (alpha untouched).
+/// Differentiable w.r.t. all four parameter tensors and `rgb`. Inputs must
+/// be on an autodiff-enabled Wgpu device.
+///
+/// - `exposure`: `[num_frames]` log2-exposure offsets.
+/// - `vignetting`: `[num_cameras, 3, 5]` per-channel `cx, cy, a0, a1, a2`.
+/// - `color`: `[num_frames, 8]` latent homography offsets.
+/// - `crf`: `[num_cameras, 3, 4]` raw `toe, shoulder, gamma, center`.
+pub fn ppisp_apply(
+    exposure: Tensor<1>,
+    vignetting: Tensor<3>,
+    color: Tensor<2>,
+    crf: Tensor<3>,
+    rgb: Tensor<3>,
+    camera_idx: usize,
+    frame_idx: usize,
+    stages: PpispStages,
+) -> Tensor<3> {
+    let exp_ad = unwrap_ad_wgpu_float(exposure);
+    let vig_ad = unwrap_ad_wgpu_float(vignetting);
+    let color_ad = unwrap_ad_wgpu_float(color);
+    let crf_ad = unwrap_ad_wgpu_float(crf);
+    let rgb_ad = unwrap_ad_wgpu_float(rgb);
+
+    let prep = PpispBackward
+        .prepare::<NoCheckpointing>([
+            exp_ad.node.clone(),
+            vig_ad.node.clone(),
+            color_ad.node.clone(),
+            crf_ad.node.clone(),
+            rgb_ad.node.clone(),
+        ])
+        .compute_bound()
+        .stateful();
+
+    let exp_p = exp_ad.primitive;
+    let vig_p = vig_ad.primitive;
+    let color_p = color_ad.primitive;
+    let crf_p = crf_ad.primitive;
+    let rgb_p = rgb_ad.primitive;
+
+    let out = <MainBackend as PpispOps<MainBackend>>::ppisp_fwd(
+        exp_p.clone(),
+        vig_p.clone(),
+        color_p.clone(),
+        crf_p.clone(),
+        rgb_p.clone(),
+        camera_idx,
+        frame_idx,
+        stages,
+    );
+
+    let out_ad: FloatTensor<AutodiffMain> = match prep {
+        OpsKind::Tracked(prep) => prep.finish(
+            PpispState {
+                exposure: exp_p,
+                vignetting: vig_p,
+                color: color_p,
+                crf: crf_p,
+                rgb: rgb_p,
+                camera_idx,
+                frame_idx,
+                stages,
+            },
+            out,
+        ),
+        OpsKind::UnTracked(prep) => prep.finish(out),
+    };
+    wrap_ad_wgpu_float::<3>(out_ad)
+}
+
+/// Forward-only version of [`ppisp_apply`] for non-autodiff tensors.
+pub fn ppisp_apply_inner(
+    exposure: Tensor<1>,
+    vignetting: Tensor<3>,
+    color: Tensor<2>,
+    crf: Tensor<3>,
+    rgb: Tensor<3>,
+    camera_idx: usize,
+    frame_idx: usize,
+    stages: PpispStages,
+) -> Tensor<3> {
+    use brush_render::burn_glue::unwrap_wgpu_float;
+    let out = <MainBackend as PpispOps<MainBackend>>::ppisp_fwd(
+        unwrap_wgpu_float(exposure),
+        unwrap_wgpu_float(vignetting),
+        unwrap_wgpu_float(color),
+        unwrap_wgpu_float(crf),
+        unwrap_wgpu_float(rgb),
+        camera_idx,
+        frame_idx,
+        stages,
+    );
+    wrap_wgpu_float::<3>(out)
+}
+
+// ---------------------------------------------------------------------------
+// Module + regularisation
+// ---------------------------------------------------------------------------
+
+/// Inverse of `min_value + softplus(x)` at `y`, for identity-CRF init.
+fn softplus_inverse(y: f32, min_value: f32) -> f32 {
+    let x = (y - min_value).max(1e-5);
+    (x.exp_m1()).ln()
+}
+
+/// PPISP parameters: per-frame exposure + color, per-camera vignetting +
+/// CRF, plus the (frozen) view → camera-group mapping.
+#[derive(Module, Debug)]
+pub struct PpispModel {
+    /// `[num_frames]` log2-exposure offsets.
+    pub exposure: Param<Tensor<1>>,
+    /// `[num_cameras, 3, 5]` per-channel vignetting.
+    pub vignetting: Param<Tensor<3>>,
+    /// `[num_frames, 8]` latent color-homography offsets.
+    pub color: Param<Tensor<2>>,
+    /// `[num_cameras, 3, 4]` raw CRF params.
+    pub crf: Param<Tensor<3>>,
+    /// Per-view camera-group index (frozen metadata, not optimized).
+    #[module(skip)]
+    pub camera_indices: Vec<u32>,
+}
+
+/// Fixed regularisation weights from the PPISP reference implementation.
+/// Scaled as a whole by the trainer's `ppisp_reg_scale`.
+const W_EXPOSURE_MEAN: f32 = 1.0;
+const W_VIG_CENTER: f32 = 0.02;
+const W_VIG_CHANNEL: f32 = 0.1;
+const W_VIG_NON_POS: f32 = 0.01;
+const W_COLOR_MEAN: f32 = 1.0;
+const W_CRF_CHANNEL: f32 = 0.1;
+
+/// ZCA pinv blocks as a `[8, 8]` block-diagonal matrix (latent → real
+/// chromaticity offsets) for the color-mean regulariser.
+#[rustfmt::skip]
+const COLOR_PINV_BLOCK_DIAG: [f32; 64] = [
+    0.0480542, -0.0043631, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+    -0.0043631, 0.0481283, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+    0.0, 0.0, 0.0580570, -0.0179872, 0.0, 0.0, 0.0, 0.0,
+    0.0, 0.0, -0.0179872, 0.0431061, 0.0, 0.0, 0.0, 0.0,
+    0.0, 0.0, 0.0, 0.0, 0.0433336, -0.0180537, 0.0, 0.0,
+    0.0, 0.0, 0.0, 0.0, -0.0180537, 0.0580500, 0.0, 0.0,
+    0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0128369, -0.0034654,
+    0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -0.0034654, 0.0128158,
+];
+
+/// `smooth_l1(x, beta)` elementwise.
+fn smooth_l1<const D: usize>(x: Tensor<D>, beta: f32) -> Tensor<D> {
+    let ax = x.clone().abs();
+    let quad = x.powi_scalar(2) * (0.5 / beta);
+    let lin = ax.clone() - 0.5 * beta;
+    lin.mask_where(ax.lower_elem(beta), quad)
+}
+
+impl PpispModel {
+    pub fn new(
+        num_cameras: usize,
+        num_frames: usize,
+        camera_indices: Vec<u32>,
+        device: &Device,
+    ) -> Self {
+        assert_eq!(
+            camera_indices.len(),
+            num_frames,
+            "need one camera-group index per training view"
+        );
+        // Identity-like CRF init (toe = shoulder = 1, gamma = 1, center = 0.5).
+        let crf_row = [
+            softplus_inverse(1.0, 0.3),
+            softplus_inverse(1.0, 0.3),
+            softplus_inverse(1.0, 0.1),
+            0.0,
+        ];
+        let mut crf_data = Vec::with_capacity(num_cameras * 3 * 4);
+        for _ in 0..num_cameras * 3 {
+            crf_data.extend_from_slice(&crf_row);
+        }
+        let crf = Tensor::from_data(TensorData::new(crf_data, [num_cameras, 3, 4]), device);
+
+        Self {
+            exposure: Param::from_tensor(Tensor::zeros([num_frames], device)),
+            vignetting: Param::from_tensor(Tensor::zeros([num_cameras, 3, 5], device)),
+            color: Param::from_tensor(Tensor::zeros([num_frames, 8], device)),
+            crf: Param::from_tensor(crf),
+            camera_indices,
+        }
+    }
+
+    /// Apply the full pipeline to a rendered `[H, W, 3|4]` image for
+    /// training view `view_idx`.
+    pub fn apply(&self, img: Tensor<3>, view_idx: usize) -> Tensor<3> {
+        self.apply_stages(img, view_idx, PpispStages::ALL)
+    }
+
+    /// Apply a subset of the pipeline (e.g. the per-camera-only passes of
+    /// the hybrid grid mode).
+    pub fn apply_stages(&self, img: Tensor<3>, view_idx: usize, stages: PpispStages) -> Tensor<3> {
+        let camera_idx = self.camera_indices[view_idx] as usize;
+        ppisp_apply(
+            self.exposure.val(),
+            self.vignetting.val(),
+            self.color.val(),
+            self.crf.val(),
+            img,
+            camera_idx,
+            view_idx,
+            stages,
+        )
+    }
+
+    /// Weighted parameter regularisation (the reference's six terms). Tiny
+    /// tensors, so plain Burn ops on the autodiff backend.
+    pub fn reg_loss(&self) -> Tensor<1> {
+        let exposure = self.exposure.val();
+        let vig = self.vignetting.val();
+        let color = self.color.val();
+        let crf = self.crf.val();
+        let device = exposure.device();
+        let [num_cameras, _, _] = vig.dims();
+
+        // Exposure mean ~ 0 (resolves SH <-> exposure ambiguity).
+        let loss = smooth_l1(exposure.mean(), 0.1) * W_EXPOSURE_MEAN;
+
+        // Color mean ~ 0 across frames, in real-offset space.
+        let pinv: Tensor<2> =
+            Tensor::<1>::from_floats(COLOR_PINV_BLOCK_DIAG.as_slice(), &device).reshape([8, 8]);
+        let offsets = color.matmul(pinv); // [F, 8]
+        let color_mean = offsets.mean_dim(0); // [1, 8]
+        let loss = loss + smooth_l1(color_mean, 0.005).mean() * W_COLOR_MEAN;
+
+        // Vignetting center near image center.
+        let centers = vig.clone().slice(burn::tensor::s![.., .., 0..2]);
+        let loss =
+            loss + centers.powi_scalar(2).sum() * (W_VIG_CENTER / (num_cameras as f32 * 3.0));
+
+        // Vignetting alphas should be <= 0.
+        let alphas = vig.clone().slice(burn::tensor::s![.., .., 2..5]);
+        let loss = loss
+            + burn::tensor::activation::relu(alphas).sum()
+                * (W_VIG_NON_POS / (num_cameras as f32 * 9.0));
+
+        // Similar vignetting across RGB channels (variance penalty).
+        let vig_mean = vig.clone().mean_dim(1); // [C, 1, 5]
+        let vig_dev = vig - vig_mean;
+        let loss = loss
+            + vig_dev.powi_scalar(2).sum() * (W_VIG_CHANNEL / (num_cameras as f32 * 5.0 * 3.0));
+
+        // Similar CRF across RGB channels.
+        let crf_mean = crf.clone().mean_dim(1); // [C, 1, 4]
+        let crf_dev = crf - crf_mean;
+        loss + crf_dev.powi_scalar(2).sum() * (W_CRF_CHANNEL / (num_cameras as f32 * 4.0 * 3.0))
+    }
+}

--- a/crates/brush-appearance/src/ppisp_grid.rs
+++ b/crates/brush-appearance/src/ppisp_grid.rs
@@ -1,0 +1,476 @@
+//! Host side of the hybrid PPISP grid: backend trait + kernel launches,
+//! Fusion dispatch and Burn autodiff op. The grid tensor layout matches the
+//! affine bilateral grid (`[N, C, L, H, W]`), with `C` determined by the
+//! payload; zero-filled grids (and zero vignetting params) are the identity
+//! transform.
+
+use brush_cube::{MainBackend, MainBackendBase};
+use brush_render::burn_glue::{
+    AutodiffMain, unwrap_ad_wgpu_float, wrap_ad_wgpu_float, wrap_wgpu_float,
+};
+use burn::{
+    backend::{
+        Backend, TensorMetadata,
+        autodiff::{
+            checkpoint::{base::Checkpointer, strategy::NoCheckpointing},
+            grads::Gradients,
+            ops::{Backward, Ops, OpsKind},
+        },
+        tensor::FloatTensor,
+    },
+    tensor::{DType, Shape, Tensor},
+};
+use burn_cubecl::{CubeRuntime, tensor::CubeTensor};
+use burn_fusion::Fusion;
+
+use crate::bilagrid::grid_dims5;
+use crate::ppisp_grid_kernels as kernels;
+use crate::{CasAtomicAdd, GradSubsample, HfAtomicAdd, alloc_zeros, contiguous, dispatch_custom};
+
+const NUM_VIG_GRADS: usize = kernels::NUM_VIG_GRADS as usize;
+
+/// Which PPISP stages the fused grid pass applies (per-cell exposure is
+/// always present).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GridPayload {
+    /// Latent color-homography offsets in the grid (8 channels).
+    pub color: bool,
+    /// CRF raw-param offsets from the identity tone curve in the grid
+    /// (12 channels).
+    pub crf: bool,
+    /// Per-camera vignetting fused before the grid.
+    pub vignetting: bool,
+}
+
+impl GridPayload {
+    pub fn channels(self) -> usize {
+        kernels::payload_channels(self.color, self.crf) as usize
+    }
+}
+
+/// Backend hooks for the hybrid PPISP-grid kernels.
+pub trait PpispGridOps<B: Backend> {
+    #[allow(clippy::too_many_arguments)]
+    fn ppisp_grid_fwd(
+        grids: FloatTensor<B>,
+        vignetting: FloatTensor<B>,
+        rgb: FloatTensor<B>,
+        view_idx: usize,
+        camera_idx: usize,
+        payload: GridPayload,
+    ) -> FloatTensor<B>;
+
+    /// Returns `(dL/dgrids, vignetting partials [num_cubes, 15], dL/drgb)`;
+    /// the grid gradient is full-size with only the active view's slice
+    /// populated, and the caller reduces the vignetting partials.
+    #[allow(clippy::too_many_arguments)]
+    fn ppisp_grid_bwd_raw(
+        grids: FloatTensor<B>,
+        vignetting: FloatTensor<B>,
+        rgb: FloatTensor<B>,
+        v_out: FloatTensor<B>,
+        view_idx: usize,
+        camera_idx: usize,
+        payload: GridPayload,
+        subsample: GradSubsample,
+    ) -> (FloatTensor<B>, FloatTensor<B>, FloatTensor<B>);
+}
+
+fn img_dims<R: CubeRuntime>(rgb: &CubeTensor<R>) -> (u32, u32, u32) {
+    let dims = rgb.shape().as_slice().to_vec();
+    assert_eq!(dims.len(), 3, "rgb must be [h, w, c]");
+    let ch = dims[2] as u32;
+    assert!(ch == 3 || ch == 4, "rgb must have 3 or 4 channels");
+    (dims[0] as u32, dims[1] as u32, ch)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn launch_fwd<R: CubeRuntime>(
+    grids: CubeTensor<R>,
+    vignetting: CubeTensor<R>,
+    rgb: CubeTensor<R>,
+    view_idx: usize,
+    camera_idx: usize,
+    payload: GridPayload,
+) -> CubeTensor<R> {
+    use burn_cubecl::cubecl::prelude::{CubeCount, CubeDim};
+
+    let grids = contiguous(grids);
+    let vignetting = contiguous(vignetting);
+    let rgb = contiguous(rgb);
+    let (n, gc, gl, gh, gw) = grid_dims5(&grids);
+    assert_eq!(gc as usize, payload.channels(), "grid payload mismatch");
+    let (h, w, ch) = img_dims(&rgb);
+    assert!((view_idx as u32) < n, "view index out of range");
+
+    let out = alloc_zeros(&rgb, rgb.shape(), DType::F32);
+    let client = rgb.client.clone();
+    kernels::ppisp_grid_fwd_kernel::launch::<R>(
+        &client,
+        CubeCount::Static((h * w).div_ceil(kernels::BLOCK_SIZE), 1, 1),
+        CubeDim::new_1d(kernels::BLOCK_SIZE),
+        grids.into_tensor_arg(),
+        vignetting.into_tensor_arg(),
+        rgb.into_tensor_arg(),
+        out.clone().into_tensor_arg(),
+        gl,
+        gh,
+        gw,
+        h,
+        w,
+        view_idx as u32 * gc * gl * gh * gw,
+        ch,
+        camera_idx as u32,
+        ch == 4,
+        payload.vignetting,
+        payload.color,
+        payload.crf,
+    );
+    out
+}
+
+#[allow(clippy::too_many_arguments)]
+fn launch_bwd<R: CubeRuntime>(
+    grids: CubeTensor<R>,
+    vignetting: CubeTensor<R>,
+    rgb: CubeTensor<R>,
+    v_out: CubeTensor<R>,
+    view_idx: usize,
+    camera_idx: usize,
+    payload: GridPayload,
+    subsample: GradSubsample,
+) -> (CubeTensor<R>, CubeTensor<R>, CubeTensor<R>) {
+    use burn_cubecl::cubecl::prelude::{CubeCount, CubeDim};
+
+    let grids = contiguous(grids);
+    let vignetting = contiguous(vignetting);
+    let rgb = contiguous(rgb);
+    let v_out = contiguous(v_out);
+    let (n, gc, gl, gh, gw) = grid_dims5(&grids);
+    assert_eq!(gc as usize, payload.channels(), "grid payload mismatch");
+    let (h, w, ch) = img_dims(&rgb);
+    assert!((view_idx as u32) < n, "view index out of range");
+    let every = subsample.every.max(1);
+    let num_cubes = (h * w).div_ceil(kernels::BLOCK_SIZE);
+
+    let grad_grids = alloc_zeros(&grids, grids.shape(), DType::F32);
+    let grad_rgb = alloc_zeros(&rgb, rgb.shape(), DType::F32);
+    let vig_partials = alloc_zeros(
+        &rgb,
+        Shape::new([num_cubes as usize, NUM_VIG_GRADS]),
+        DType::F32,
+    );
+    let client = rgb.client.clone();
+
+    let cube_count = CubeCount::Static(num_cubes, 1, 1);
+    let cube_dim = CubeDim::new_1d(kernels::BLOCK_SIZE);
+    let grid_offset = view_idx as u32 * gc * gl * gh * gw;
+
+    macro_rules! launch {
+        ($atomic:ty) => {
+            kernels::ppisp_grid_bwd_kernel::launch::<$atomic, R>(
+                &client,
+                cube_count,
+                cube_dim,
+                grids.into_tensor_arg(),
+                vignetting.into_tensor_arg(),
+                rgb.into_tensor_arg(),
+                v_out.into_tensor_arg(),
+                grad_grids.clone().into_tensor_arg(),
+                grad_rgb.clone().into_tensor_arg(),
+                vig_partials.clone().into_tensor_arg(),
+                gl,
+                gh,
+                gw,
+                h,
+                w,
+                grid_offset,
+                ch,
+                camera_idx as u32,
+                every,
+                subsample.seed,
+                ch == 4,
+                payload.vignetting,
+                payload.color,
+                payload.crf,
+            )
+        };
+    }
+    if brush_cube::supports_float_atomics::<R>(&client) {
+        launch!(HfAtomicAdd);
+    } else {
+        launch!(CasAtomicAdd);
+    }
+    (grad_grids, vig_partials, grad_rgb)
+}
+
+impl PpispGridOps<Self> for MainBackendBase {
+    fn ppisp_grid_fwd(
+        grids: FloatTensor<Self>,
+        vignetting: FloatTensor<Self>,
+        rgb: FloatTensor<Self>,
+        view_idx: usize,
+        camera_idx: usize,
+        payload: GridPayload,
+    ) -> FloatTensor<Self> {
+        launch_fwd(grids, vignetting, rgb, view_idx, camera_idx, payload)
+    }
+
+    fn ppisp_grid_bwd_raw(
+        grids: FloatTensor<Self>,
+        vignetting: FloatTensor<Self>,
+        rgb: FloatTensor<Self>,
+        v_out: FloatTensor<Self>,
+        view_idx: usize,
+        camera_idx: usize,
+        payload: GridPayload,
+        subsample: GradSubsample,
+    ) -> (FloatTensor<Self>, FloatTensor<Self>, FloatTensor<Self>) {
+        launch_bwd(
+            grids, vignetting, rgb, v_out, view_idx, camera_idx, payload, subsample,
+        )
+    }
+}
+
+impl PpispGridOps<Self> for Fusion<MainBackendBase> {
+    fn ppisp_grid_fwd(
+        grids: FloatTensor<Self>,
+        vignetting: FloatTensor<Self>,
+        rgb: FloatTensor<Self>,
+        view_idx: usize,
+        camera_idx: usize,
+        payload: GridPayload,
+    ) -> FloatTensor<Self> {
+        let shape = rgb.shape();
+        let [out] = dispatch_custom(
+            "ppisp_grid_fwd",
+            [grids, vignetting, rgb],
+            [(shape, DType::F32)],
+            move |desc, h| {
+                let ([grids, vignetting, rgb], [out]) = desc.as_fixed();
+                let res = MainBackendBase::ppisp_grid_fwd(
+                    h.get_float_tensor::<MainBackendBase>(grids),
+                    h.get_float_tensor::<MainBackendBase>(vignetting),
+                    h.get_float_tensor::<MainBackendBase>(rgb),
+                    view_idx,
+                    camera_idx,
+                    payload,
+                );
+                h.register_float_tensor::<MainBackendBase>(&out.id, res);
+            },
+        );
+        out
+    }
+
+    fn ppisp_grid_bwd_raw(
+        grids: FloatTensor<Self>,
+        vignetting: FloatTensor<Self>,
+        rgb: FloatTensor<Self>,
+        v_out: FloatTensor<Self>,
+        view_idx: usize,
+        camera_idx: usize,
+        payload: GridPayload,
+        subsample: GradSubsample,
+    ) -> (FloatTensor<Self>, FloatTensor<Self>, FloatTensor<Self>) {
+        let grids_shape = grids.shape();
+        let rgb_shape = rgb.shape();
+        let [h_dim, w_dim, _] = rgb_shape.dims();
+        let num_cubes = ((h_dim * w_dim) as u32).div_ceil(kernels::BLOCK_SIZE) as usize;
+        let [grad_grids, vig_partials, grad_rgb] = dispatch_custom(
+            "ppisp_grid_bwd",
+            [grids, vignetting, rgb, v_out],
+            [
+                (grids_shape, DType::F32),
+                (Shape::new([num_cubes, NUM_VIG_GRADS]), DType::F32),
+                (rgb_shape, DType::F32),
+            ],
+            move |desc, h| {
+                let ([grids, vignetting, rgb, v_out], [grad_grids, vig_partials, grad_rgb]) =
+                    desc.as_fixed();
+                let (gg, vp, gr) = MainBackendBase::ppisp_grid_bwd_raw(
+                    h.get_float_tensor::<MainBackendBase>(grids),
+                    h.get_float_tensor::<MainBackendBase>(vignetting),
+                    h.get_float_tensor::<MainBackendBase>(rgb),
+                    h.get_float_tensor::<MainBackendBase>(v_out),
+                    view_idx,
+                    camera_idx,
+                    payload,
+                    subsample,
+                );
+                h.register_float_tensor::<MainBackendBase>(&grad_grids.id, gg);
+                h.register_float_tensor::<MainBackendBase>(&vig_partials.id, vp);
+                h.register_float_tensor::<MainBackendBase>(&grad_rgb.id, gr);
+            },
+        );
+        #[allow(clippy::tuple_array_conversions)]
+        (grad_grids, vig_partials, grad_rgb)
+    }
+}
+
+/// Full backward: kernel launch + reduce the vignetting partials into a
+/// full-shape `[num_cameras, 3, 5]` gradient at the active camera row.
+#[allow(clippy::too_many_arguments, clippy::type_complexity)]
+fn ppisp_grid_backward<B: Backend + PpispGridOps<B>>(
+    grids: FloatTensor<B>,
+    vignetting: FloatTensor<B>,
+    rgb: FloatTensor<B>,
+    v_out: FloatTensor<B>,
+    view_idx: usize,
+    camera_idx: usize,
+    payload: GridPayload,
+    subsample: GradSubsample,
+) -> (FloatTensor<B>, FloatTensor<B>, FloatTensor<B>) {
+    use burn::tensor::Slice;
+    let sl = |r: std::ops::Range<usize>| -> Slice { r.into() };
+
+    let device = B::float_device(&rgb);
+    let num_cameras = vignetting.shape().dims::<3>()[0];
+
+    let (grad_grids, vig_partials, grad_rgb) = B::ppisp_grid_bwd_raw(
+        grids, vignetting, rgb, v_out, view_idx, camera_idx, payload, subsample,
+    );
+
+    let summed = B::float_sum_dim(vig_partials, 0); // [1, 15]
+    let g_vig = B::float_zeros(
+        Shape::new([num_cameras, 3, 5]),
+        &device,
+        burn::tensor::FloatDType::F32,
+    );
+    let g_vig = B::float_slice_assign(
+        g_vig,
+        &[sl(camera_idx..camera_idx + 1), sl(0..3), sl(0..5)],
+        B::float_reshape(summed, Shape::new([1, 3, 5])),
+    );
+
+    (grad_grids, g_vig, grad_rgb)
+}
+
+// ---------------------------------------------------------------------------
+// Autodiff op
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+struct PpispGridBackward;
+
+#[derive(Debug, Clone)]
+struct PpispGridState<B: Backend> {
+    grids: FloatTensor<B>,
+    vignetting: FloatTensor<B>,
+    rgb: FloatTensor<B>,
+    view_idx: usize,
+    camera_idx: usize,
+    payload: GridPayload,
+    subsample: GradSubsample,
+}
+
+impl<B: Backend + PpispGridOps<B>> Backward<B, 3> for PpispGridBackward {
+    type State = PpispGridState<B>;
+
+    fn backward(
+        self,
+        ops: Ops<Self::State, 3>,
+        grads: &mut Gradients,
+        _checkpointer: &mut Checkpointer,
+    ) {
+        let state = ops.state;
+        let v_out = grads.consume::<B>(&ops.node);
+        let [grids_parent, vig_parent, rgb_parent] = ops.parents;
+        let (grad_grids, grad_vig, grad_rgb) = ppisp_grid_backward::<B>(
+            state.grids,
+            state.vignetting,
+            state.rgb,
+            v_out,
+            state.view_idx,
+            state.camera_idx,
+            state.payload,
+            state.subsample,
+        );
+        if let Some(node) = grids_parent {
+            grads.register::<B>(node.id, grad_grids);
+        }
+        if let Some(node) = vig_parent {
+            grads.register::<B>(node.id, grad_vig);
+        }
+        if let Some(node) = rgb_parent {
+            grads.register::<B>(node.id, grad_rgb);
+        }
+    }
+}
+
+/// Apply per-camera vignetting + the `view_idx`-th PPISP grid to a rendered
+/// `[H, W, 3|4]` image (alpha untouched). Differentiable w.r.t. `grids`,
+/// `vignetting` (`[num_cameras, 3, 5]`) and `rgb`.
+#[allow(clippy::too_many_arguments)]
+pub fn ppisp_grid_apply(
+    grids: Tensor<5>,
+    vignetting: Tensor<3>,
+    rgb: Tensor<3>,
+    view_idx: usize,
+    camera_idx: usize,
+    payload: GridPayload,
+    subsample: GradSubsample,
+) -> Tensor<3> {
+    let grids_ad = unwrap_ad_wgpu_float(grids);
+    let vig_ad = unwrap_ad_wgpu_float(vignetting);
+    let rgb_ad = unwrap_ad_wgpu_float(rgb);
+
+    let prep = PpispGridBackward
+        .prepare::<NoCheckpointing>([
+            grids_ad.node.clone(),
+            vig_ad.node.clone(),
+            rgb_ad.node.clone(),
+        ])
+        .compute_bound()
+        .stateful();
+
+    let grids_p = grids_ad.primitive;
+    let vig_p = vig_ad.primitive;
+    let rgb_p = rgb_ad.primitive;
+    let out = <MainBackend as PpispGridOps<MainBackend>>::ppisp_grid_fwd(
+        grids_p.clone(),
+        vig_p.clone(),
+        rgb_p.clone(),
+        view_idx,
+        camera_idx,
+        payload,
+    );
+
+    let out_ad: FloatTensor<AutodiffMain> = match prep {
+        OpsKind::Tracked(prep) => prep.finish(
+            PpispGridState {
+                grids: grids_p,
+                vignetting: vig_p,
+                rgb: rgb_p,
+                view_idx,
+                camera_idx,
+                payload,
+                subsample,
+            },
+            out,
+        ),
+        OpsKind::UnTracked(prep) => prep.finish(out),
+    };
+    wrap_ad_wgpu_float::<3>(out_ad)
+}
+
+/// Forward-only version of [`ppisp_grid_apply`] for non-autodiff tensors
+/// (eval-time correction).
+pub fn ppisp_grid_apply_inner(
+    grids: Tensor<5>,
+    vignetting: Tensor<3>,
+    rgb: Tensor<3>,
+    view_idx: usize,
+    camera_idx: usize,
+    payload: GridPayload,
+) -> Tensor<3> {
+    use brush_render::burn_glue::unwrap_wgpu_float;
+    let out = <MainBackend as PpispGridOps<MainBackend>>::ppisp_grid_fwd(
+        unwrap_wgpu_float(grids),
+        unwrap_wgpu_float(vignetting),
+        unwrap_wgpu_float(rgb),
+        view_idx,
+        camera_idx,
+        payload,
+    );
+    wrap_wgpu_float::<3>(out)
+}

--- a/crates/brush-appearance/src/ppisp_grid_kernels.rs
+++ b/crates/brush-appearance/src/ppisp_grid_kernels.rs
@@ -1,0 +1,579 @@
+//! Hybrid "PPISP grid" kernels (spirulae-splat's `bilagrid_type="ppisp"`),
+//! with the per-camera vignetting stage fused in.
+//!
+//! Per-pixel pipeline, all in one pass:
+//!
+//! ```text
+//! rgb → per-camera vignetting → slice grid payload → exposure → color → (CRF)
+//! ```
+//!
+//! The grid payload per cell:
+//!
+//! | channels | meaning | flag |
+//! |---|---|---|
+//! | 0 | log2 exposure | always |
+//! | 1..9 | latent color-homography offsets (B/R/G/N) | `with_color` |
+//! | last 12 | CRF raw-param *offsets from identity* | `with_crf` |
+//!
+//! The grid is sliced at the same coordinates as the affine bilateral grid,
+//! with the grayscale guidance taken from the *vignetted* color (the grid's
+//! input). All-zeros is the identity transform for every payload, and zero
+//! vignetting params are an identity falloff.
+//!
+//! The backward chains gradients through every stage in reverse:
+//! `dL/dgrid` scatters to the 8 corners (atomic, subgroup-vote merged,
+//! optionally plane-subsampled), the 15 per-camera vignetting gradients
+//! reduce per cube into a partials buffer (deterministic host-side sum, no
+//! atomics — same scheme as the PPISP kernels), and `dL/drgb` is exact and
+//! includes the guidance-coordinate term.
+
+use burn_cubecl::cubecl;
+use burn_cubecl::cubecl::cube;
+use burn_cubecl::cubecl::prelude::*;
+
+use crate::AtomicAddF32;
+use crate::bilagrid_kernels::{C2G_B, C2G_G, C2G_R, plane_elected, slice_coords};
+use crate::ppisp_math::{
+    LN2, color_correct_bwd, color_correct_fwd, crf_channel_bwd, crf_channel_fwd, homography,
+    vig_falloff_raw, vig_uv,
+};
+use brush_cube::{Vec3A, is_finite_f32};
+
+pub const BLOCK_SIZE: u32 = 256;
+
+/// Max payload channels (exposure + color + CRF); local arrays are sized to
+/// this, unused entries are dead code after comptime unrolling.
+const MAX_PAYLOAD: u32 = 21;
+
+/// Per-camera vignetting gradients reduced per cube (3 channels x 5).
+pub const NUM_VIG_GRADS: u32 = 15;
+/// Worst-case subgroup count per cube (`PLANE_DIM >= 4` everywhere).
+const MAX_SUBGROUPS: u32 = BLOCK_SIZE / 4;
+
+/// CRF identity init in raw space (`softplus_inverse(1, 0.3)` for
+/// toe/shoulder, `softplus_inverse(1, 0.1)` for gamma, `sigmoid^-1(0.5)`
+/// for center). The grid stores *offsets* from these.
+const CRF_IDENT_TOE: f32 = 0.013_658_988;
+const CRF_IDENT_SHOULDER: f32 = 0.013_658_988;
+const CRF_IDENT_GAMMA: f32 = 0.378_164_53;
+const CRF_IDENT_CENTER: f32 = 0.0;
+
+/// Payload channel count for a flag combination (host + comptime helper).
+pub const fn payload_channels(with_color: bool, with_crf: bool) -> u32 {
+    1 + if with_color { 8 } else { 0 } + if with_crf { 12 } else { 0 }
+}
+
+/// CRF channel base offset within the payload.
+const fn crf_base(with_color: bool) -> u32 {
+    if with_color { 9 } else { 1 }
+}
+
+#[cube(launch)]
+#[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
+pub fn ppisp_grid_fwd_kernel(
+    grid: &Tensor<f32>,
+    vignetting: &Tensor<f32>,
+    rgb: &Tensor<f32>,
+    out: &mut Tensor<f32>,
+    gl: u32,
+    gh: u32,
+    gw: u32,
+    img_h: u32,
+    img_w: u32,
+    grid_offset: u32,
+    channels: u32,
+    camera_idx: u32,
+    #[comptime] has_alpha: bool,
+    #[comptime] with_vignetting: bool,
+    #[comptime] with_color: bool,
+    #[comptime] with_crf: bool,
+) {
+    let idx = CUBE_POS_X * BLOCK_SIZE + UNIT_POS_X;
+    if idx >= img_h * img_w {
+        terminate!();
+    }
+    let hi = idx / img_w;
+    let wi = idx % img_w;
+    let base = (idx * channels) as usize;
+
+    let mut col = Vec3A::new(rgb[base], rgb[base + 1], rgb[base + 2]);
+
+    // 1. Per-camera vignetting.
+    if with_vignetting {
+        let (uvx, uvy) = vig_uv(wi, hi, img_w, img_h);
+        let vbase = (camera_idx * NUM_VIG_GRADS) as usize;
+        let f_r = clamp(
+            vig_falloff_raw(
+                uvx,
+                uvy,
+                vignetting[vbase],
+                vignetting[vbase + 1],
+                vignetting[vbase + 2],
+                vignetting[vbase + 3],
+                vignetting[vbase + 4],
+            ),
+            0.0f32,
+            1.0f32,
+        );
+        let f_g = clamp(
+            vig_falloff_raw(
+                uvx,
+                uvy,
+                vignetting[vbase + 5],
+                vignetting[vbase + 6],
+                vignetting[vbase + 7],
+                vignetting[vbase + 8],
+                vignetting[vbase + 9],
+            ),
+            0.0f32,
+            1.0f32,
+        );
+        let f_b = clamp(
+            vig_falloff_raw(
+                uvx,
+                uvy,
+                vignetting[vbase + 10],
+                vignetting[vbase + 11],
+                vignetting[vbase + 12],
+                vignetting[vbase + 13],
+                vignetting[vbase + 14],
+            ),
+            0.0f32,
+            1.0f32,
+        );
+        col = Vec3A::new(col.x() * f_r, col.y() * f_g, col.z() * f_b);
+    }
+
+    // 2. Slice the payload at the vignetted color's guidance coordinate.
+    let c = slice_coords(wi, hi, col.x(), col.y(), col.z(), gl, gh, gw, img_h, img_w);
+    let cell = gl * gh * gw;
+    let pc = comptime!(payload_channels(with_color, with_crf));
+
+    let mut p = Array::<f32>::new(MAX_PAYLOAD as usize);
+    #[unroll]
+    for ci in 0u32..pc {
+        let cbase = grid_offset + ci * cell;
+        let v000 = grid[(cbase + (c.z0 * gh + c.y0) * gw + c.x0) as usize];
+        let v001 = grid[(cbase + (c.z0 * gh + c.y0) * gw + c.x1) as usize];
+        let v010 = grid[(cbase + (c.z0 * gh + c.y1) * gw + c.x0) as usize];
+        let v011 = grid[(cbase + (c.z0 * gh + c.y1) * gw + c.x1) as usize];
+        let v100 = grid[(cbase + (c.z1 * gh + c.y0) * gw + c.x0) as usize];
+        let v101 = grid[(cbase + (c.z1 * gh + c.y0) * gw + c.x1) as usize];
+        let v110 = grid[(cbase + (c.z1 * gh + c.y1) * gw + c.x0) as usize];
+        let v111 = grid[(cbase + (c.z1 * gh + c.y1) * gw + c.x1) as usize];
+
+        let c00 = v000 * (1.0f32 - c.fx) + v001 * c.fx;
+        let c01 = v010 * (1.0f32 - c.fx) + v011 * c.fx;
+        let c10 = v100 * (1.0f32 - c.fx) + v101 * c.fx;
+        let c11 = v110 * (1.0f32 - c.fx) + v111 * c.fx;
+        let c0 = c00 * (1.0f32 - c.fy) + c01 * c.fy;
+        let c1 = c10 * (1.0f32 - c.fy) + c11 * c.fy;
+        p[ci as usize] = c0 * (1.0f32 - c.fz) + c1 * c.fz;
+    }
+
+    // 3. Apply: exposure → color homography → CRF.
+    col = col.scale(f32::exp(p[0] * LN2));
+    if with_color {
+        let (h, _) = homography(p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8]);
+        col = color_correct_fwd(col, h);
+    }
+    if with_crf {
+        let kb = comptime!(crf_base(with_color) as usize);
+        let xr = clamp(col.x(), 0.0f32, 1.0f32);
+        let xg = clamp(col.y(), 0.0f32, 1.0f32);
+        let xb = clamp(col.z(), 0.0f32, 1.0f32);
+        let o_r = crf_channel_fwd(
+            xr,
+            CRF_IDENT_TOE + p[kb],
+            CRF_IDENT_SHOULDER + p[comptime!(kb + 1)],
+            CRF_IDENT_GAMMA + p[comptime!(kb + 2)],
+            CRF_IDENT_CENTER + p[comptime!(kb + 3)],
+        );
+        let o_g = crf_channel_fwd(
+            xg,
+            CRF_IDENT_TOE + p[comptime!(kb + 4)],
+            CRF_IDENT_SHOULDER + p[comptime!(kb + 5)],
+            CRF_IDENT_GAMMA + p[comptime!(kb + 6)],
+            CRF_IDENT_CENTER + p[comptime!(kb + 7)],
+        );
+        let o_b = crf_channel_fwd(
+            xb,
+            CRF_IDENT_TOE + p[comptime!(kb + 8)],
+            CRF_IDENT_SHOULDER + p[comptime!(kb + 9)],
+            CRF_IDENT_GAMMA + p[comptime!(kb + 10)],
+            CRF_IDENT_CENTER + p[comptime!(kb + 11)],
+        );
+        col = Vec3A::new(o_r, o_g, o_b);
+    }
+
+    out[base] = select(is_finite_f32(col.x()), col.x(), 0.5f32);
+    out[base + 1] = select(is_finite_f32(col.y()), col.y(), 0.5f32);
+    out[base + 2] = select(is_finite_f32(col.z()), col.z(), 0.5f32);
+    if has_alpha {
+        out[base + 3] = rgb[base + 3];
+    }
+}
+
+/// Backward: chain through CRF → color → exposure → guidance term →
+/// vignetting; scatter `dL/dpayload` to the 8 grid corners and reduce the
+/// 15 vignetting gradients per cube. No early `terminate!` — out-of-range
+/// threads contribute zeros and still reach the reduction barrier.
+///
+/// `subsample`/`subsample_seed`: only planes elected by the per-step
+/// Bernoulli hash (see `plane_elected`) scatter grid gradients (scaled by
+/// `subsample` to stay unbiased); the rgb and vignetting gradients are
+/// always exact. `subsample = 1` disables.
+#[cube(launch)]
+#[allow(
+    clippy::too_many_arguments,
+    clippy::needless_pass_by_ref_mut,
+    clippy::fn_params_excessive_bools,
+    clippy::manual_range_contains
+)]
+pub fn ppisp_grid_bwd_kernel<A: AtomicAddF32>(
+    grid: &Tensor<f32>,
+    vignetting: &Tensor<f32>,
+    rgb: &Tensor<f32>,
+    v_out: &Tensor<f32>,
+    grad_grid: &mut Tensor<Atomic<A::Storage>>,
+    grad_rgb: &mut Tensor<f32>,
+    vig_partials: &mut Tensor<f32>,
+    gl: u32,
+    gh: u32,
+    gw: u32,
+    img_h: u32,
+    img_w: u32,
+    grid_offset: u32,
+    channels: u32,
+    camera_idx: u32,
+    subsample: u32,
+    subsample_seed: u32,
+    #[comptime] has_alpha: bool,
+    #[comptime] with_vignetting: bool,
+    #[comptime] with_color: bool,
+    #[comptime] with_crf: bool,
+) {
+    let idx = CUBE_POS_X * BLOCK_SIZE + UNIT_POS_X;
+
+    let mut vg = Array::<f32>::new(NUM_VIG_GRADS as usize);
+    #[unroll]
+    for k in 0u32..NUM_VIG_GRADS {
+        vg[k as usize] = 0.0f32;
+    }
+
+    if idx < img_h * img_w {
+        let hi = idx / img_w;
+        let wi = idx % img_w;
+        let base = (idx * channels) as usize;
+
+        let sr_raw = rgb[base];
+        let sg_raw = rgb[base + 1];
+        let sb_raw = rgb[base + 2];
+        let sr = select(is_finite_f32(sr_raw), sr_raw, 0.5f32);
+        let sg = select(is_finite_f32(sg_raw), sg_raw, 0.5f32);
+        let sb = select(is_finite_f32(sb_raw), sb_raw, 0.5f32);
+        let rgb_in = Vec3A::new(sr, sg, sb);
+
+        // --- Recompute the vignetting stage ---
+        let mut uvx = 0.0f32;
+        let mut uvy = 0.0f32;
+        let mut raw_r = 1.0f32;
+        let mut raw_g = 1.0f32;
+        let mut raw_b = 1.0f32;
+        let mut f_r = 1.0f32;
+        let mut f_g = 1.0f32;
+        let mut f_b = 1.0f32;
+        let vbase = (camera_idx * NUM_VIG_GRADS) as usize;
+        if with_vignetting {
+            let (ux, uy) = vig_uv(wi, hi, img_w, img_h);
+            uvx = ux;
+            uvy = uy;
+            raw_r = vig_falloff_raw(
+                uvx,
+                uvy,
+                vignetting[vbase],
+                vignetting[vbase + 1],
+                vignetting[vbase + 2],
+                vignetting[vbase + 3],
+                vignetting[vbase + 4],
+            );
+            raw_g = vig_falloff_raw(
+                uvx,
+                uvy,
+                vignetting[vbase + 5],
+                vignetting[vbase + 6],
+                vignetting[vbase + 7],
+                vignetting[vbase + 8],
+                vignetting[vbase + 9],
+            );
+            raw_b = vig_falloff_raw(
+                uvx,
+                uvy,
+                vignetting[vbase + 10],
+                vignetting[vbase + 11],
+                vignetting[vbase + 12],
+                vignetting[vbase + 13],
+                vignetting[vbase + 14],
+            );
+            f_r = clamp(raw_r, 0.0f32, 1.0f32);
+            f_g = clamp(raw_g, 0.0f32, 1.0f32);
+            f_b = clamp(raw_b, 0.0f32, 1.0f32);
+        }
+        // The grid stage's input.
+        let gin = Vec3A::new(rgb_in.x() * f_r, rgb_in.y() * f_g, rgb_in.z() * f_b);
+
+        let c = slice_coords(wi, hi, gin.x(), gin.y(), gin.z(), gl, gh, gw, img_h, img_w);
+
+        let dr_raw = v_out[base];
+        let dg_raw = v_out[base + 1];
+        let db_raw = v_out[base + 2];
+        let dr = select(is_finite_f32(dr_raw), dr_raw, 0.0f32);
+        let dg = select(is_finite_f32(dg_raw), dg_raw, 0.0f32);
+        let db = select(is_finite_f32(db_raw), db_raw, 0.0f32);
+
+        let cell = gl * gh * gw;
+        let pc = comptime!(payload_channels(with_color, with_crf));
+
+        // Pass 1: interpolate the payload and its derivative along the
+        // guidance axis.
+        let mut p = Array::<f32>::new(MAX_PAYLOAD as usize);
+        let mut dpdz = Array::<f32>::new(MAX_PAYLOAD as usize);
+        #[unroll]
+        for ci in 0u32..pc {
+            p[ci as usize] = 0.0f32;
+            dpdz[ci as usize] = 0.0f32;
+        }
+        #[unroll]
+        for corner in 0u32..8u32 {
+            let cx = select((corner & 1u32) != 0u32, c.x1, c.x0);
+            let cy = select((corner & 2u32) != 0u32, c.y1, c.y0);
+            let cz = select((corner & 4u32) != 0u32, c.z1, c.z0);
+            let wx = select((corner & 1u32) != 0u32, c.fx, 1.0f32 - c.fx);
+            let wy = select((corner & 2u32) != 0u32, c.fy, 1.0f32 - c.fy);
+            let wz = select((corner & 4u32) != 0u32, c.fz, 1.0f32 - c.fz);
+            let wt = wx * wy * wz;
+            let dfdz = wx * wy * select((corner & 4u32) != 0u32, 1.0f32, -1.0f32);
+
+            #[unroll]
+            for ci in 0u32..pc {
+                let v = grid[(grid_offset + ci * cell + (cz * gh + cy) * gw + cx) as usize];
+                p[ci as usize] += wt * v;
+                dpdz[ci as usize] += dfdz * f32::cast_from(gl - 1) * v;
+            }
+        }
+
+        // Recompute forward stages from the grid input.
+        let exp_factor = f32::exp(p[0] * LN2);
+        let after_exp = gin.scale(exp_factor);
+        let mut after_color = after_exp;
+        if with_color {
+            let (h, _) = homography(p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8]);
+            after_color = color_correct_fwd(after_exp, h);
+        }
+
+        // Backward chain → dL/dpayload + dL/d(grid input).
+        let mut grad = Vec3A::new(dr, dg, db);
+        let mut dldp = Array::<f32>::new(MAX_PAYLOAD as usize);
+        #[unroll]
+        for ci in 0u32..pc {
+            dldp[ci as usize] = 0.0f32;
+        }
+
+        if with_crf {
+            let kb = comptime!(crf_base(with_color) as usize);
+            let xr = clamp(after_color.x(), 0.0f32, 1.0f32);
+            let xg = clamp(after_color.y(), 0.0f32, 1.0f32);
+            let xb = clamp(after_color.z(), 0.0f32, 1.0f32);
+            let (gx_r, gt_r, gs_r, gg_r, gc_r) = crf_channel_bwd(
+                xr,
+                CRF_IDENT_TOE + p[kb],
+                CRF_IDENT_SHOULDER + p[comptime!(kb + 1)],
+                CRF_IDENT_GAMMA + p[comptime!(kb + 2)],
+                CRF_IDENT_CENTER + p[comptime!(kb + 3)],
+                grad.x(),
+            );
+            let (gx_g, gt_g, gs_g, gg_g, gc_g) = crf_channel_bwd(
+                xg,
+                CRF_IDENT_TOE + p[comptime!(kb + 4)],
+                CRF_IDENT_SHOULDER + p[comptime!(kb + 5)],
+                CRF_IDENT_GAMMA + p[comptime!(kb + 6)],
+                CRF_IDENT_CENTER + p[comptime!(kb + 7)],
+                grad.y(),
+            );
+            let (gx_b, gt_b, gs_b, gg_b, gc_b) = crf_channel_bwd(
+                xb,
+                CRF_IDENT_TOE + p[comptime!(kb + 8)],
+                CRF_IDENT_SHOULDER + p[comptime!(kb + 9)],
+                CRF_IDENT_GAMMA + p[comptime!(kb + 10)],
+                CRF_IDENT_CENTER + p[comptime!(kb + 11)],
+                grad.z(),
+            );
+            dldp[kb] = gt_r;
+            dldp[comptime!(kb + 1)] = gs_r;
+            dldp[comptime!(kb + 2)] = gg_r;
+            dldp[comptime!(kb + 3)] = gc_r;
+            dldp[comptime!(kb + 4)] = gt_g;
+            dldp[comptime!(kb + 5)] = gs_g;
+            dldp[comptime!(kb + 6)] = gg_g;
+            dldp[comptime!(kb + 7)] = gc_g;
+            dldp[comptime!(kb + 8)] = gt_b;
+            dldp[comptime!(kb + 9)] = gs_b;
+            dldp[comptime!(kb + 10)] = gg_b;
+            dldp[comptime!(kb + 11)] = gc_b;
+            grad = Vec3A::new(gx_r, gx_g, gx_b);
+        }
+
+        if with_color {
+            grad = color_correct_bwd(
+                after_exp, p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8], grad, &mut dldp, 1u32,
+            );
+        }
+
+        // Exposure: d out/d e = stage_output · ln 2.
+        dldp[0] = grad.dot(after_exp) * LN2;
+        grad = grad.scale(exp_factor);
+
+        // Guidance-coordinate chain: payload varies with z = gray(grid in).
+        let mut gz = 0.0f32;
+        #[unroll]
+        for ci in 0u32..pc {
+            gz += dldp[ci as usize] * dpdz[ci as usize];
+        }
+        let guard = f32::cast_from(c.z0) != c.z && f32::cast_from(c.z1) != c.z;
+        gz = select(guard, gz, 0.0f32);
+
+        // Total gradient at the grid input (stage chain + guidance term),
+        // which is the vignetting stage's output gradient.
+        grad = Vec3A::new(
+            grad.x() + C2G_R * gz,
+            grad.y() + C2G_G * gz,
+            grad.z() + C2G_B * gz,
+        );
+
+        // Vignetting backward (input is the raw render).
+        if with_vignetting {
+            let inside_r = raw_r >= 0.0f32 && raw_r <= 1.0f32;
+            let inside_g = raw_g >= 0.0f32 && raw_g <= 1.0f32;
+            let inside_b = raw_b >= 0.0f32 && raw_b <= 1.0f32;
+
+            // Channel R.
+            let dx = uvx - vignetting[vbase];
+            let dy = uvy - vignetting[vbase + 1];
+            let r2 = dx * dx + dy * dy;
+            let gf = grad.x() * rgb_in.x();
+            let gr2 = gf
+                * (vignetting[vbase + 2]
+                    + 2.0f32 * vignetting[vbase + 3] * r2
+                    + 3.0f32 * vignetting[vbase + 4] * r2 * r2);
+            vg[0] += select(inside_r, -gr2 * 2.0f32 * dx, 0.0f32);
+            vg[1] += select(inside_r, -gr2 * 2.0f32 * dy, 0.0f32);
+            vg[2] += select(inside_r, gf * r2, 0.0f32);
+            vg[3] += select(inside_r, gf * r2 * r2, 0.0f32);
+            vg[4] += select(inside_r, gf * r2 * r2 * r2, 0.0f32);
+
+            // Channel G.
+            let dx = uvx - vignetting[vbase + 5];
+            let dy = uvy - vignetting[vbase + 6];
+            let r2 = dx * dx + dy * dy;
+            let gf = grad.y() * rgb_in.y();
+            let gr2 = gf
+                * (vignetting[vbase + 7]
+                    + 2.0f32 * vignetting[vbase + 8] * r2
+                    + 3.0f32 * vignetting[vbase + 9] * r2 * r2);
+            vg[5] += select(inside_g, -gr2 * 2.0f32 * dx, 0.0f32);
+            vg[6] += select(inside_g, -gr2 * 2.0f32 * dy, 0.0f32);
+            vg[7] += select(inside_g, gf * r2, 0.0f32);
+            vg[8] += select(inside_g, gf * r2 * r2, 0.0f32);
+            vg[9] += select(inside_g, gf * r2 * r2 * r2, 0.0f32);
+
+            // Channel B.
+            let dx = uvx - vignetting[vbase + 10];
+            let dy = uvy - vignetting[vbase + 11];
+            let r2 = dx * dx + dy * dy;
+            let gf = grad.z() * rgb_in.z();
+            let gr2 = gf
+                * (vignetting[vbase + 12]
+                    + 2.0f32 * vignetting[vbase + 13] * r2
+                    + 3.0f32 * vignetting[vbase + 14] * r2 * r2);
+            vg[10] += select(inside_b, -gr2 * 2.0f32 * dx, 0.0f32);
+            vg[11] += select(inside_b, -gr2 * 2.0f32 * dy, 0.0f32);
+            vg[12] += select(inside_b, gf * r2, 0.0f32);
+            vg[13] += select(inside_b, gf * r2 * r2, 0.0f32);
+            vg[14] += select(inside_b, gf * r2 * r2 * r2, 0.0f32);
+
+            grad = Vec3A::new(grad.x() * f_r, grad.y() * f_g, grad.z() * f_b);
+        }
+
+        grad_rgb[base] = grad.x();
+        grad_rgb[base + 1] = grad.y();
+        grad_rgb[base + 2] = grad.z();
+        if has_alpha {
+            grad_rgb[base + 3] = v_out[base + 3];
+        }
+
+        // Pass 2: scatter dL/dpayload to the 8 corners. Plane-uniform
+        // gradient subsampling: only planes elected by the per-round hash
+        // contribute (scaled to stay unbiased) — the grid is heavily
+        // regularised and slow-moving, so a sparse estimate is enough (and
+        // atomics dominate this kernel).
+        let plane_idx = idx / PLANE_DIM;
+        if plane_elected(plane_idx, subsample_seed, subsample) {
+            let scale = f32::cast_from(subsample);
+            let cell_uniform = plane_min(c.x0) == plane_max(c.x0)
+                && plane_min(c.y0) == plane_max(c.y0)
+                && plane_min(c.z0) == plane_max(c.z0)
+                && plane_min(c.x1) == plane_max(c.x1)
+                && plane_min(c.y1) == plane_max(c.y1)
+                && plane_min(c.z1) == plane_max(c.z1);
+
+            #[unroll]
+            for corner in 0u32..8u32 {
+                let cx = select((corner & 1u32) != 0u32, c.x1, c.x0);
+                let cy = select((corner & 2u32) != 0u32, c.y1, c.y0);
+                let cz = select((corner & 4u32) != 0u32, c.z1, c.z0);
+                let wx = select((corner & 1u32) != 0u32, c.fx, 1.0f32 - c.fx);
+                let wy = select((corner & 2u32) != 0u32, c.fy, 1.0f32 - c.fy);
+                let wz = select((corner & 4u32) != 0u32, c.fz, 1.0f32 - c.fz);
+                let wt = wx * wy * wz;
+
+                #[unroll]
+                for ci in 0u32..pc {
+                    let gidx = (grid_offset + ci * cell + (cz * gh + cy) * gw + cx) as usize;
+                    let contrib = wt * dldp[ci as usize] * scale;
+                    if cell_uniform {
+                        let merged = plane_sum(contrib);
+                        if UNIT_POS_PLANE == 0u32 {
+                            A::add(&grad_grid[gidx], merged);
+                        }
+                    } else {
+                        A::add(&grad_grid[gidx], contrib);
+                    }
+                }
+            }
+        }
+    }
+
+    // --- Cube-level reduction of the 15 vignetting grads ---
+    if with_vignetting {
+        let mut sg_partials = Shared::new_slice((MAX_SUBGROUPS * NUM_VIG_GRADS) as usize);
+        let subgroup_id = UNIT_POS_X / PLANE_DIM;
+        #[unroll]
+        for k in 0u32..NUM_VIG_GRADS {
+            let v = plane_sum(vg[k as usize]);
+            if UNIT_POS_PLANE == 0u32 {
+                sg_partials[(subgroup_id * NUM_VIG_GRADS + k) as usize] = v;
+            }
+        }
+        sync_cube();
+        if UNIT_POS_X < NUM_VIG_GRADS {
+            let num_subgroups = BLOCK_SIZE / PLANE_DIM;
+            let mut tot = 0.0f32;
+            let mut i = 0u32;
+            while i < num_subgroups {
+                tot += sg_partials[(i * NUM_VIG_GRADS + UNIT_POS_X) as usize];
+                i += 1u32;
+            }
+            vig_partials[(CUBE_POS_X * NUM_VIG_GRADS + UNIT_POS_X) as usize] = tot;
+        }
+    }
+}

--- a/crates/brush-appearance/src/ppisp_kernels.rs
+++ b/crates/brush-appearance/src/ppisp_kernels.rs
@@ -1,0 +1,460 @@
+//! Fused PPISP kernels (port of NVIDIA's `ppisp` reference CUDA kernels).
+//!
+//! Per-pixel pipeline: exposure (per frame) → vignetting (per camera) →
+//! color homography (per frame) → CRF tone curve (per camera). The backward
+//! recomputes the forward stage-by-stage and chains gradients in reverse,
+//! accumulating the 36 parameter partials per thread, reducing them
+//! per-cube (plane sums + shared memory), and writing one `[36]` row per
+//! cube to a partials buffer — the host then `sum`s the buffer, which keeps
+//! the parameter gradients deterministic with no atomics.
+//!
+//! Parameter layouts (flattened f32):
+//! - exposure `[num_frames]` — log2-exposure offset.
+//! - vignetting `[num_cameras, 3, 5]` — per channel `cx, cy, a0, a1, a2`.
+//! - color `[num_frames, 8]` — latent 2D offsets for the B/R/G/N control
+//!   chromaticities of the homography.
+//! - crf `[num_cameras, 3, 4]` — per channel raw `toe, shoulder, gamma,
+//!   center` (softplus/sigmoid transformed in-kernel).
+
+use brush_cube::Vec3A;
+use burn_cubecl::cubecl;
+use burn_cubecl::cubecl::cube;
+use burn_cubecl::cubecl::prelude::*;
+
+pub const BLOCK_SIZE: u32 = 128;
+/// Number of scalar parameter gradients reduced per pixel:
+/// 1 exposure + 15 vignetting + 8 color + 12 CRF.
+pub const NUM_PARAM_GRADS: u32 = 36;
+/// Worst-case subgroup count per cube (`PLANE_DIM >= 4` everywhere).
+const MAX_SUBGROUPS: u32 = BLOCK_SIZE / 4;
+
+use crate::ppisp_math::{
+    LN2, color_correct_bwd, color_correct_fwd, crf_channel_bwd, crf_channel_fwd, homography,
+    vig_falloff_raw, vig_uv,
+};
+
+// ---------------------------------------------------------------------------
+// Forward kernel
+// ---------------------------------------------------------------------------
+
+#[cube(launch)]
+#[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
+pub fn ppisp_fwd_kernel(
+    exposure: &Tensor<f32>,
+    vignetting: &Tensor<f32>,
+    color: &Tensor<f32>,
+    crf: &Tensor<f32>,
+    rgb: &Tensor<f32>,
+    out: &mut Tensor<f32>,
+    img_h: u32,
+    img_w: u32,
+    camera_idx: u32,
+    frame_idx: u32,
+    channels: u32,
+    #[comptime] has_alpha: bool,
+    #[comptime] with_frame: bool,
+    #[comptime] with_vignetting: bool,
+    #[comptime] with_crf: bool,
+) {
+    let idx = CUBE_POS_X * BLOCK_SIZE + UNIT_POS_X;
+    if idx >= img_h * img_w {
+        terminate!();
+    }
+    let hi = idx / img_w;
+    let wi = idx % img_w;
+    let base = (idx * channels) as usize;
+
+    let mut c = Vec3A::new(rgb[base], rgb[base + 1], rgb[base + 2]);
+
+    // 1. Exposure (log2 space): 2^e = exp(e · ln 2).
+    if with_frame {
+        c = c.scale(f32::exp(exposure[frame_idx as usize] * LN2));
+    }
+
+    // 2. Vignetting (per channel).
+    if with_vignetting {
+        let (uvx, uvy) = vig_uv(wi, hi, img_w, img_h);
+        let vbase = (camera_idx * 15u32) as usize;
+        let f_r = clamp(
+            vig_falloff_raw(
+                uvx,
+                uvy,
+                vignetting[vbase],
+                vignetting[vbase + 1],
+                vignetting[vbase + 2],
+                vignetting[vbase + 3],
+                vignetting[vbase + 4],
+            ),
+            0.0f32,
+            1.0f32,
+        );
+        let f_g = clamp(
+            vig_falloff_raw(
+                uvx,
+                uvy,
+                vignetting[vbase + 5],
+                vignetting[vbase + 6],
+                vignetting[vbase + 7],
+                vignetting[vbase + 8],
+                vignetting[vbase + 9],
+            ),
+            0.0f32,
+            1.0f32,
+        );
+        let f_b = clamp(
+            vig_falloff_raw(
+                uvx,
+                uvy,
+                vignetting[vbase + 10],
+                vignetting[vbase + 11],
+                vignetting[vbase + 12],
+                vignetting[vbase + 13],
+                vignetting[vbase + 14],
+            ),
+            0.0f32,
+            1.0f32,
+        );
+        c = Vec3A::new(c.x() * f_r, c.y() * f_g, c.z() * f_b);
+    }
+
+    // 3. Color homography.
+    if with_frame {
+        let cbase = (frame_idx * 8u32) as usize;
+        let (h, _) = homography(
+            color[cbase],
+            color[cbase + 1],
+            color[cbase + 2],
+            color[cbase + 3],
+            color[cbase + 4],
+            color[cbase + 5],
+            color[cbase + 6],
+            color[cbase + 7],
+        );
+        c = color_correct_fwd(c, h);
+    }
+
+    // 4. CRF (per channel, on [0,1]-clamped input).
+    if with_crf {
+        let kbase = (camera_idx * 12u32) as usize;
+        let xr = clamp(c.x(), 0.0f32, 1.0f32);
+        let xg = clamp(c.y(), 0.0f32, 1.0f32);
+        let xb = clamp(c.z(), 0.0f32, 1.0f32);
+        out[base] = crf_channel_fwd(
+            xr,
+            crf[kbase],
+            crf[kbase + 1],
+            crf[kbase + 2],
+            crf[kbase + 3],
+        );
+        out[base + 1] = crf_channel_fwd(
+            xg,
+            crf[kbase + 4],
+            crf[kbase + 5],
+            crf[kbase + 6],
+            crf[kbase + 7],
+        );
+        out[base + 2] = crf_channel_fwd(
+            xb,
+            crf[kbase + 8],
+            crf[kbase + 9],
+            crf[kbase + 10],
+            crf[kbase + 11],
+        );
+    } else {
+        out[base] = c.x();
+        out[base + 1] = c.y();
+        out[base + 2] = c.z();
+    }
+    if has_alpha {
+        out[base + 3] = rgb[base + 3];
+    }
+}
+// ---------------------------------------------------------------------------
+// Backward kernel
+// ---------------------------------------------------------------------------
+
+/// Per-pixel backward. Writes `dL/drgb_in` and one `[NUM_PARAM_GRADS]` row of
+/// parameter-gradient partials per cube (deterministically summed on the
+/// host). All threads participate in the reduction, so out-of-range threads
+/// contribute zeros instead of terminating before the barrier.
+#[cube(launch)]
+#[allow(
+    clippy::too_many_arguments,
+    clippy::manual_range_contains,
+    clippy::fn_params_excessive_bools
+)]
+pub fn ppisp_bwd_kernel(
+    exposure: &Tensor<f32>,
+    vignetting: &Tensor<f32>,
+    color: &Tensor<f32>,
+    crf: &Tensor<f32>,
+    rgb: &Tensor<f32>,
+    v_out: &Tensor<f32>,
+    grad_rgb: &mut Tensor<f32>,
+    partials: &mut Tensor<f32>,
+    img_h: u32,
+    img_w: u32,
+    camera_idx: u32,
+    frame_idx: u32,
+    channels: u32,
+    #[comptime] has_alpha: bool,
+    #[comptime] with_frame: bool,
+    #[comptime] with_vignetting: bool,
+    #[comptime] with_crf: bool,
+) {
+    let idx = CUBE_POS_X * BLOCK_SIZE + UNIT_POS_X;
+
+    let mut pg = Array::<f32>::new(NUM_PARAM_GRADS as usize);
+    #[unroll]
+    for p in 0u32..NUM_PARAM_GRADS {
+        pg[p as usize] = 0.0f32;
+    }
+
+    if idx < img_h * img_w {
+        let hi = idx / img_w;
+        let wi = idx % img_w;
+        let base = (idx * channels) as usize;
+
+        let rgb_input = Vec3A::new(rgb[base], rgb[base + 1], rgb[base + 2]);
+
+        // --- Recompute forward, keeping each stage's input. Disabled stages
+        // collapse to identity at compile time. ---
+        let mut exp_param = 0.0f32;
+        let mut rgb_after_exp = rgb_input;
+        if with_frame {
+            exp_param = exposure[frame_idx as usize];
+            rgb_after_exp = rgb_input.scale(f32::exp(exp_param * LN2));
+        }
+
+        let mut uvx = 0.0f32;
+        let mut uvy = 0.0f32;
+        let mut raw_r = 1.0f32;
+        let mut raw_g = 1.0f32;
+        let mut raw_b = 1.0f32;
+        let mut f_r = 1.0f32;
+        let mut f_g = 1.0f32;
+        let mut f_b = 1.0f32;
+        let vbase = (camera_idx * 15u32) as usize;
+        if with_vignetting {
+            let (ux, uy) = vig_uv(wi, hi, img_w, img_h);
+            uvx = ux;
+            uvy = uy;
+            raw_r = vig_falloff_raw(
+                uvx,
+                uvy,
+                vignetting[vbase],
+                vignetting[vbase + 1],
+                vignetting[vbase + 2],
+                vignetting[vbase + 3],
+                vignetting[vbase + 4],
+            );
+            raw_g = vig_falloff_raw(
+                uvx,
+                uvy,
+                vignetting[vbase + 5],
+                vignetting[vbase + 6],
+                vignetting[vbase + 7],
+                vignetting[vbase + 8],
+                vignetting[vbase + 9],
+            );
+            raw_b = vig_falloff_raw(
+                uvx,
+                uvy,
+                vignetting[vbase + 10],
+                vignetting[vbase + 11],
+                vignetting[vbase + 12],
+                vignetting[vbase + 13],
+                vignetting[vbase + 14],
+            );
+            f_r = clamp(raw_r, 0.0f32, 1.0f32);
+            f_g = clamp(raw_g, 0.0f32, 1.0f32);
+            f_b = clamp(raw_b, 0.0f32, 1.0f32);
+        }
+        let rgb_after_vig = Vec3A::new(
+            rgb_after_exp.x() * f_r,
+            rgb_after_exp.y() * f_g,
+            rgb_after_exp.z() * f_b,
+        );
+
+        let cbase = (frame_idx * 8u32) as usize;
+        let mut c0 = 0.0f32;
+        let mut c1 = 0.0f32;
+        let mut c2 = 0.0f32;
+        let mut c3 = 0.0f32;
+        let mut c4 = 0.0f32;
+        let mut c5 = 0.0f32;
+        let mut c6 = 0.0f32;
+        let mut c7 = 0.0f32;
+        let mut rgb_after_color = rgb_after_vig;
+        if with_frame {
+            c0 = color[cbase];
+            c1 = color[cbase + 1];
+            c2 = color[cbase + 2];
+            c3 = color[cbase + 3];
+            c4 = color[cbase + 4];
+            c5 = color[cbase + 5];
+            c6 = color[cbase + 6];
+            c7 = color[cbase + 7];
+            let (h, _) = homography(c0, c1, c2, c3, c4, c5, c6, c7);
+            rgb_after_color = color_correct_fwd(rgb_after_vig, h);
+        }
+
+        // --- Backward chain (reverse order) ---
+        let mut grad = Vec3A::new(v_out[base], v_out[base + 1], v_out[base + 2]);
+
+        // 4. CRF backward (operates on the [0,1]-clamped input; the clamp's
+        // gradient gate matches the reference, which also drops gradient
+        // outside the open interval).
+        if with_crf {
+            let kbase = (camera_idx * 12u32) as usize;
+            let xr = clamp(rgb_after_color.x(), 0.0f32, 1.0f32);
+            let xg = clamp(rgb_after_color.y(), 0.0f32, 1.0f32);
+            let xb = clamp(rgb_after_color.z(), 0.0f32, 1.0f32);
+            let (gx_r, gt_r, gs_r, gg_r, gc_r) = crf_channel_bwd(
+                xr,
+                crf[kbase],
+                crf[kbase + 1],
+                crf[kbase + 2],
+                crf[kbase + 3],
+                grad.x(),
+            );
+            let (gx_g, gt_g, gs_g, gg_g, gc_g) = crf_channel_bwd(
+                xg,
+                crf[kbase + 4],
+                crf[kbase + 5],
+                crf[kbase + 6],
+                crf[kbase + 7],
+                grad.y(),
+            );
+            let (gx_b, gt_b, gs_b, gg_b, gc_b) = crf_channel_bwd(
+                xb,
+                crf[kbase + 8],
+                crf[kbase + 9],
+                crf[kbase + 10],
+                crf[kbase + 11],
+                grad.z(),
+            );
+            pg[24] += gt_r;
+            pg[25] += gs_r;
+            pg[26] += gg_r;
+            pg[27] += gc_r;
+            pg[28] += gt_g;
+            pg[29] += gs_g;
+            pg[30] += gg_g;
+            pg[31] += gc_g;
+            pg[32] += gt_b;
+            pg[33] += gs_b;
+            pg[34] += gg_b;
+            pg[35] += gc_b;
+            grad = Vec3A::new(gx_r, gx_g, gx_b);
+        }
+
+        // 3. Color correction backward (latent grads land in pg[16..24]).
+        if with_frame {
+            grad = color_correct_bwd(
+                rgb_after_vig,
+                c0,
+                c1,
+                c2,
+                c3,
+                c4,
+                c5,
+                c6,
+                c7,
+                grad,
+                &mut pg,
+                16u32,
+            );
+        }
+
+        // 2. Vignetting backward (per channel, replaying the falloff).
+        if with_vignetting {
+            let inside_r = raw_r >= 0.0f32 && raw_r <= 1.0f32;
+            let inside_g = raw_g >= 0.0f32 && raw_g <= 1.0f32;
+            let inside_b = raw_b >= 0.0f32 && raw_b <= 1.0f32;
+
+            // Channel R.
+            let dx = uvx - vignetting[vbase];
+            let dy = uvy - vignetting[vbase + 1];
+            let r2 = dx * dx + dy * dy;
+            let gf = grad.x() * rgb_after_exp.x();
+            let gr2 = gf
+                * (vignetting[vbase + 2]
+                    + 2.0f32 * vignetting[vbase + 3] * r2
+                    + 3.0f32 * vignetting[vbase + 4] * r2 * r2);
+            pg[1] += select(inside_r, -gr2 * 2.0f32 * dx, 0.0f32);
+            pg[2] += select(inside_r, -gr2 * 2.0f32 * dy, 0.0f32);
+            pg[3] += select(inside_r, gf * r2, 0.0f32);
+            pg[4] += select(inside_r, gf * r2 * r2, 0.0f32);
+            pg[5] += select(inside_r, gf * r2 * r2 * r2, 0.0f32);
+
+            // Channel G.
+            let dx = uvx - vignetting[vbase + 5];
+            let dy = uvy - vignetting[vbase + 6];
+            let r2 = dx * dx + dy * dy;
+            let gf = grad.y() * rgb_after_exp.y();
+            let gr2 = gf
+                * (vignetting[vbase + 7]
+                    + 2.0f32 * vignetting[vbase + 8] * r2
+                    + 3.0f32 * vignetting[vbase + 9] * r2 * r2);
+            pg[6] += select(inside_g, -gr2 * 2.0f32 * dx, 0.0f32);
+            pg[7] += select(inside_g, -gr2 * 2.0f32 * dy, 0.0f32);
+            pg[8] += select(inside_g, gf * r2, 0.0f32);
+            pg[9] += select(inside_g, gf * r2 * r2, 0.0f32);
+            pg[10] += select(inside_g, gf * r2 * r2 * r2, 0.0f32);
+
+            // Channel B.
+            let dx = uvx - vignetting[vbase + 10];
+            let dy = uvy - vignetting[vbase + 11];
+            let r2 = dx * dx + dy * dy;
+            let gf = grad.z() * rgb_after_exp.z();
+            let gr2 = gf
+                * (vignetting[vbase + 12]
+                    + 2.0f32 * vignetting[vbase + 13] * r2
+                    + 3.0f32 * vignetting[vbase + 14] * r2 * r2);
+            pg[11] += select(inside_b, -gr2 * 2.0f32 * dx, 0.0f32);
+            pg[12] += select(inside_b, -gr2 * 2.0f32 * dy, 0.0f32);
+            pg[13] += select(inside_b, gf * r2, 0.0f32);
+            pg[14] += select(inside_b, gf * r2 * r2, 0.0f32);
+            pg[15] += select(inside_b, gf * r2 * r2 * r2, 0.0f32);
+
+            grad = Vec3A::new(grad.x() * f_r, grad.y() * f_g, grad.z() * f_b);
+        }
+
+        // 1. Exposure backward.
+        if with_frame {
+            let factor = f32::exp(exp_param * LN2);
+            pg[0] += grad.dot(rgb_input.scale(factor)) * LN2;
+            grad = grad.scale(factor);
+        }
+
+        grad_rgb[base] = grad.x();
+        grad_rgb[base + 1] = grad.y();
+        grad_rgb[base + 2] = grad.z();
+        if has_alpha {
+            grad_rgb[base + 3] = v_out[base + 3];
+        }
+    }
+
+    // --- Cube-level reduction of the 36 param grads ---
+    let mut sg_partials = Shared::new_slice((MAX_SUBGROUPS * NUM_PARAM_GRADS) as usize);
+    let subgroup_id = UNIT_POS_X / PLANE_DIM;
+    #[unroll]
+    for p in 0u32..NUM_PARAM_GRADS {
+        let v = plane_sum(pg[p as usize]);
+        if UNIT_POS_PLANE == 0u32 {
+            sg_partials[(subgroup_id * NUM_PARAM_GRADS + p) as usize] = v;
+        }
+    }
+    sync_cube();
+    if UNIT_POS_X < NUM_PARAM_GRADS {
+        let num_subgroups = BLOCK_SIZE / PLANE_DIM;
+        let mut tot = 0.0f32;
+        let mut i = 0u32;
+        while i < num_subgroups {
+            tot += sg_partials[(i * NUM_PARAM_GRADS + UNIT_POS_X) as usize];
+            i += 1u32;
+        }
+        partials[(CUBE_POS_X * NUM_PARAM_GRADS + UNIT_POS_X) as usize] = tot;
+    }
+}

--- a/crates/brush-appearance/src/ppisp_math.rs
+++ b/crates/brush-appearance/src/ppisp_math.rs
@@ -1,0 +1,686 @@
+//! Shared PPISP math as `#[cube]` functions: the homography construction,
+//! CRF tone curve and vignetting falloff with their hand-derived backwards.
+//! Used by both the per-frame/per-camera PPISP kernels (`ppisp_kernels`) and
+//! the hybrid PPISP-grid kernels (`ppisp_grid_kernels`).
+
+use brush_cube::Vec3A;
+use burn_cubecl::cubecl;
+use burn_cubecl::cubecl::cube;
+use burn_cubecl::cubecl::prelude::*;
+
+pub(crate) const LN2: f32 = core::f32::consts::LN_2;
+
+// ZCA pinv blocks mapping latent color offsets to real chromaticity
+// offsets, row-major 2x2 (`m00 m01 m10 m11`) per control point
+// [Blue, Red, Green, Neutral]. Plain consts so they inline into cube code.
+const ZCA_B00: f32 = 0.048_054_2;
+const ZCA_B01: f32 = -0.004_363_1;
+const ZCA_B10: f32 = -0.004_363_1;
+const ZCA_B11: f32 = 0.048_128_3;
+const ZCA_R00: f32 = 0.058_057;
+const ZCA_R01: f32 = -0.017_987_2;
+const ZCA_R10: f32 = -0.017_987_2;
+const ZCA_R11: f32 = 0.043_106_1;
+const ZCA_G00: f32 = 0.043_333_6;
+const ZCA_G01: f32 = -0.018_053_7;
+const ZCA_G10: f32 = -0.018_053_7;
+const ZCA_G11: f32 = 0.058_05;
+const ZCA_N00: f32 = 0.012_836_9;
+const ZCA_N01: f32 = -0.003_465_4;
+const ZCA_N10: f32 = -0.003_465_4;
+const ZCA_N11: f32 = 0.012_815_8;
+
+// ---------------------------------------------------------------------------
+// Small row-major 3x3 matrix (the reference CUDA code is row-major; keeping
+// the same layout makes the port 1:1 auditable).
+// ---------------------------------------------------------------------------
+
+#[derive(CubeType, CubeTypeMut, Copy, Clone)]
+#[expand(derive(Clone, Copy))]
+pub struct M3 {
+    pub m00: f32,
+    pub m01: f32,
+    pub m02: f32,
+    pub m10: f32,
+    pub m11: f32,
+    pub m12: f32,
+    pub m20: f32,
+    pub m21: f32,
+    pub m22: f32,
+}
+
+#[cube]
+impl M3 {
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        m00: f32,
+        m01: f32,
+        m02: f32,
+        m10: f32,
+        m11: f32,
+        m12: f32,
+        m20: f32,
+        m21: f32,
+        m22: f32,
+    ) -> M3 {
+        M3 {
+            m00,
+            m01,
+            m02,
+            m10,
+            m11,
+            m12,
+            m20,
+            m21,
+            m22,
+        }
+    }
+
+    fn row0(self) -> Vec3A {
+        Vec3A::new(self.m00, self.m01, self.m02)
+    }
+    fn row1(self) -> Vec3A {
+        Vec3A::new(self.m10, self.m11, self.m12)
+    }
+    fn row2(self) -> Vec3A {
+        Vec3A::new(self.m20, self.m21, self.m22)
+    }
+
+    fn from_rows(r0: Vec3A, r1: Vec3A, r2: Vec3A) -> M3 {
+        M3::new(
+            r0.x(),
+            r0.y(),
+            r0.z(),
+            r1.x(),
+            r1.y(),
+            r1.z(),
+            r2.x(),
+            r2.y(),
+            r2.z(),
+        )
+    }
+
+    fn transpose(self) -> M3 {
+        M3::new(
+            self.m00, self.m10, self.m20, self.m01, self.m11, self.m21, self.m02, self.m12,
+            self.m22,
+        )
+    }
+
+    /// `self * v`.
+    fn mul_vec(self, v: Vec3A) -> Vec3A {
+        Vec3A::new(self.row0().dot(v), self.row1().dot(v), self.row2().dot(v))
+    }
+
+    /// `self^T * v`.
+    fn tmul_vec(self, v: Vec3A) -> Vec3A {
+        Vec3A::new(
+            self.m00 * v.x() + self.m10 * v.y() + self.m20 * v.z(),
+            self.m01 * v.x() + self.m11 * v.y() + self.m21 * v.z(),
+            self.m02 * v.x() + self.m12 * v.y() + self.m22 * v.z(),
+        )
+    }
+
+    /// `self * other`.
+    fn mul(self, other: M3) -> M3 {
+        let t = other.transpose();
+        M3::new(
+            self.row0().dot(t.row0()),
+            self.row0().dot(t.row1()),
+            self.row0().dot(t.row2()),
+            self.row1().dot(t.row0()),
+            self.row1().dot(t.row1()),
+            self.row1().dot(t.row2()),
+            self.row2().dot(t.row0()),
+            self.row2().dot(t.row1()),
+            self.row2().dot(t.row2()),
+        )
+    }
+
+    fn scale(self, s: f32) -> M3 {
+        M3::new(
+            self.m00 * s,
+            self.m01 * s,
+            self.m02 * s,
+            self.m10 * s,
+            self.m11 * s,
+            self.m12 * s,
+            self.m20 * s,
+            self.m21 * s,
+            self.m22 * s,
+        )
+    }
+
+    fn add(self, other: M3) -> M3 {
+        M3::new(
+            self.m00 + other.m00,
+            self.m01 + other.m01,
+            self.m02 + other.m02,
+            self.m10 + other.m10,
+            self.m11 + other.m11,
+            self.m12 + other.m12,
+            self.m20 + other.m20,
+            self.m21 + other.m21,
+            self.m22 + other.m22,
+        )
+    }
+}
+
+#[cube]
+pub(crate) fn cross3(a: Vec3A, b: Vec3A) -> Vec3A {
+    Vec3A::new(
+        a.y() * b.z() - a.z() * b.y(),
+        a.z() * b.x() - a.x() * b.z(),
+        a.x() * b.y() - a.y() * b.x(),
+    )
+}
+
+/// Outer product `a * b^T`.
+#[cube]
+pub(crate) fn outer3(a: Vec3A, b: Vec3A) -> M3 {
+    M3::from_rows(b.scale(a.x()), b.scale(a.y()), b.scale(a.z()))
+}
+
+#[cube]
+pub(crate) fn softplus(x: f32) -> f32 {
+    f32::ln(1.0f32 + f32::exp(x))
+}
+
+#[cube]
+pub(crate) fn sigmoid(x: f32) -> f32 {
+    1.0f32 / (1.0f32 + f32::exp(-x))
+}
+
+// ---------------------------------------------------------------------------
+// Homography from latent color params
+// ---------------------------------------------------------------------------
+
+/// Targets of the four control chromaticities `(t_b, t_r, t_g, t_gray)`
+/// after applying the ZCA-mapped latent offsets.
+#[cube]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn color_targets(
+    b0: f32,
+    b1: f32,
+    r0: f32,
+    r1: f32,
+    g0: f32,
+    g1: f32,
+    n0: f32,
+    n1: f32,
+) -> (Vec3A, Vec3A, Vec3A, Vec3A) {
+    let bdx = ZCA_B00 * b0 + ZCA_B01 * b1;
+    let bdy = ZCA_B10 * b0 + ZCA_B11 * b1;
+    let rdx = ZCA_R00 * r0 + ZCA_R01 * r1;
+    let rdy = ZCA_R10 * r0 + ZCA_R11 * r1;
+    let gdx = ZCA_G00 * g0 + ZCA_G01 * g1;
+    let gdy = ZCA_G10 * g0 + ZCA_G11 * g1;
+    let ndx = ZCA_N00 * n0 + ZCA_N01 * n1;
+    let ndy = ZCA_N10 * n0 + ZCA_N11 * n1;
+
+    let t_b = Vec3A::new(bdx, bdy, 1.0f32);
+    let t_r = Vec3A::new(1.0f32 + rdx, rdy, 1.0f32);
+    let t_g = Vec3A::new(gdx, 1.0f32 + gdy, 1.0f32);
+    let t_gray = Vec3A::new(1.0f32 / 3.0f32 + ndx, 1.0f32 / 3.0f32 + ndy, 1.0f32);
+    (t_b, t_r, t_g, t_gray)
+}
+
+/// `T` has columns `[t_b, t_r, t_g]`.
+#[cube]
+pub(crate) fn matrix_t(t_b: Vec3A, t_r: Vec3A, t_g: Vec3A) -> M3 {
+    M3::new(
+        t_b.x(),
+        t_r.x(),
+        t_g.x(),
+        t_b.y(),
+        t_r.y(),
+        t_g.y(),
+        t_b.z(),
+        t_r.z(),
+        t_g.z(),
+    )
+}
+
+/// Skew-symmetric `[t_gray]_x`.
+#[cube]
+pub(crate) fn skew_of(t: Vec3A) -> M3 {
+    M3::new(
+        0.0f32,
+        -t.z(),
+        t.y(),
+        t.z(),
+        0.0f32,
+        -t.x(),
+        -t.y(),
+        t.x(),
+        0.0f32,
+    )
+}
+
+/// `S^-1` for fixed sources `[B, R, G]` (constant).
+#[cube]
+pub(crate) fn s_inv() -> M3 {
+    M3::new(
+        -1.0f32, -1.0f32, 1.0f32, 1.0f32, 0.0f32, 0.0f32, 0.0f32, 1.0f32, 0.0f32,
+    )
+}
+
+/// Nullspace vector of `M` via cross products, with the reference's
+/// degeneracy fallbacks.
+#[cube]
+pub(crate) fn nullspace(m: M3) -> Vec3A {
+    let r0 = m.row0();
+    let r1 = m.row1();
+    let r2 = m.row2();
+    let mut lam = cross3(r0, r1);
+    if lam.dot(lam) < 1.0e-20f32 {
+        lam = cross3(r0, r2);
+        if lam.dot(lam) < 1.0e-20f32 {
+            lam = cross3(r1, r2);
+        }
+    }
+    lam
+}
+
+/// Forward homography (the unnormalised matrix is also needed by the
+/// backward, so return both).
+#[cube]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn homography(
+    b0: f32,
+    b1: f32,
+    r0: f32,
+    r1: f32,
+    g0: f32,
+    g1: f32,
+    n0: f32,
+    n1: f32,
+) -> (M3, M3) {
+    let (t_b, t_r, t_g, t_gray) = color_targets(b0, b1, r0, r1, g0, g1, n0, n1);
+    let t = matrix_t(t_b, t_r, t_g);
+    let skew = skew_of(t_gray);
+    let m = skew.mul(t);
+    let lam = nullspace(m);
+    let d = M3::new(
+        lam.x(),
+        0.0f32,
+        0.0f32,
+        0.0f32,
+        lam.y(),
+        0.0f32,
+        0.0f32,
+        0.0f32,
+        lam.z(),
+    );
+    let h_unnorm = t.mul(d).mul(s_inv());
+    let s = h_unnorm.m22;
+    let mut h = h_unnorm;
+    if f32::abs(s) > 1.0e-20f32 {
+        h = h_unnorm.scale(1.0f32 / s);
+    }
+    (h, h_unnorm)
+}
+
+// ---------------------------------------------------------------------------
+// Forward stage functions
+// ---------------------------------------------------------------------------
+
+/// Unclamped vignetting falloff polynomial and the radius terms.
+#[cube]
+pub(crate) fn vig_falloff_raw(
+    uvx: f32,
+    uvy: f32,
+    cx: f32,
+    cy: f32,
+    a0: f32,
+    a1: f32,
+    a2: f32,
+) -> f32 {
+    let dx = uvx - cx;
+    let dy = uvy - cy;
+    let r2 = dx * dx + dy * dy;
+    let r4 = r2 * r2;
+    let r6 = r4 * r2;
+    1.0f32 + a0 * r2 + a1 * r4 + a2 * r6
+}
+
+/// Color correction: RGB → RGI, homography, intensity renorm, back to RGB.
+#[cube]
+pub(crate) fn color_correct_fwd(rgb: Vec3A, h: M3) -> Vec3A {
+    let intensity = rgb.x() + rgb.y() + rgb.z();
+    let rgi_in = Vec3A::new(rgb.x(), rgb.y(), intensity);
+    let rgi_out = h.mul_vec(rgi_in);
+    let norm = intensity / (rgi_out.z() + 1.0e-5f32);
+    let o = rgi_out.scale(norm);
+    Vec3A::new(o.x(), o.y(), o.z() - o.x() - o.y())
+}
+
+/// Single-channel CRF toe-shoulder curve on `x` (already clamped to `[0, 1]`).
+#[cube]
+pub(crate) fn crf_channel_fwd(
+    x: f32,
+    toe_raw: f32,
+    shoulder_raw: f32,
+    gamma_raw: f32,
+    center_raw: f32,
+) -> f32 {
+    let toe = 0.3f32 + softplus(toe_raw);
+    let shoulder = 0.3f32 + softplus(shoulder_raw);
+    let gamma = 0.1f32 + softplus(gamma_raw);
+    let center = sigmoid(center_raw);
+
+    let lerp_val = toe + center * (shoulder - toe);
+    let a = shoulder * center / lerp_val;
+    let b = 1.0f32 - a;
+
+    let y_low = a * f32::powf(x / center, toe);
+    let y_high = 1.0f32 - b * f32::powf((1.0f32 - x) / (1.0f32 - center), shoulder);
+    let y = select(x <= center, y_low, y_high);
+    f32::powf(f32::max(y, 0.0f32), gamma)
+}
+
+/// Normalised vignetting UV for a pixel center.
+#[cube]
+pub(crate) fn vig_uv(wi: u32, hi: u32, img_w: u32, img_h: u32) -> (f32, f32) {
+    let wf = f32::cast_from(img_w);
+    let hf = f32::cast_from(img_h);
+    let max_res = f32::max(wf, hf);
+    let px = f32::cast_from(wi) + 0.5f32;
+    let py = f32::cast_from(hi) + 0.5f32;
+    ((px - wf * 0.5f32) / max_res, (py - hf * 0.5f32) / max_res)
+}
+
+// ---------------------------------------------------------------------------
+// Backward helpers (1:1 ports of ppisp_math_bwd.cuh)
+// ---------------------------------------------------------------------------
+
+/// Backward of the homography construction. Adds the latent-color gradients
+/// into `pg[16..24]`.
+#[cube]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn homography_bwd(
+    b0: f32,
+    b1: f32,
+    r0p: f32,
+    r1p: f32,
+    g0: f32,
+    g1: f32,
+    n0: f32,
+    n1: f32,
+    grad_h: M3,
+    pg: &mut Array<f32>,
+    #[comptime] grad_base: u32,
+) {
+    // Recompute forward intermediates.
+    let (t_b, t_r, t_g, t_gray) = color_targets(b0, b1, r0p, r1p, g0, g1, n0, n1);
+    let t = matrix_t(t_b, t_r, t_g);
+    let skew = skew_of(t_gray);
+    let m = skew.mul(t);
+    let lam = nullspace(m);
+    let d = M3::new(
+        lam.x(),
+        0.0f32,
+        0.0f32,
+        0.0f32,
+        lam.y(),
+        0.0f32,
+        0.0f32,
+        0.0f32,
+        lam.z(),
+    );
+    let td = t.mul(d);
+    let h_unnorm = td.mul(s_inv());
+
+    // Normalisation backward: H = H_unnorm / H_unnorm[2][2].
+    let s = h_unnorm.m22;
+    let mut grad_hu = grad_h;
+    if f32::abs(s) > 1.0e-20f32 {
+        let inv_s = 1.0f32 / s;
+        let grad_s = -(grad_h.m00 * h_unnorm.m00
+            + grad_h.m01 * h_unnorm.m01
+            + grad_h.m02 * h_unnorm.m02
+            + grad_h.m10 * h_unnorm.m10
+            + grad_h.m11 * h_unnorm.m11
+            + grad_h.m12 * h_unnorm.m12
+            + grad_h.m20 * h_unnorm.m20
+            + grad_h.m21 * h_unnorm.m21
+            + grad_h.m22 * h_unnorm.m22)
+            * inv_s
+            * inv_s;
+        grad_hu = grad_h.scale(inv_s);
+        grad_hu = M3::new(
+            grad_hu.m00,
+            grad_hu.m01,
+            grad_hu.m02,
+            grad_hu.m10,
+            grad_hu.m11,
+            grad_hu.m12,
+            grad_hu.m20,
+            grad_hu.m21,
+            grad_hu.m22 + grad_s,
+        );
+    }
+
+    // H_unnorm = TD * S_inv → grad_TD = grad_Hu * S_inv^T.
+    let grad_td = grad_hu.mul(s_inv().transpose());
+
+    // TD = T * D → grad_T = grad_TD * D^T, grad_D = T^T * grad_TD.
+    let mut grad_t = grad_td.mul(d.transpose());
+    let grad_d = t.transpose().mul(grad_td);
+
+    // D = diag(lam) → grad_lam = diag(grad_D).
+    let grad_lam = Vec3A::new(grad_d.m00, grad_d.m11, grad_d.m22);
+
+    // lam = nullspace(M) via cross products (replay the forward branch).
+    let r0 = m.row0();
+    let r1 = m.row1();
+    let r2 = m.row2();
+    let mut grad_r0 = Vec3A::new(0.0f32, 0.0f32, 0.0f32);
+    let mut grad_r1 = Vec3A::new(0.0f32, 0.0f32, 0.0f32);
+    let mut grad_r2 = Vec3A::new(0.0f32, 0.0f32, 0.0f32);
+    // cross_bwd(g, a, b): grad_a = cross(b, g), grad_b = cross(g, a).
+    let lam01 = cross3(r0, r1);
+    if lam01.dot(lam01) < 1.0e-20f32 {
+        let lam02 = cross3(r0, r2);
+        if lam02.dot(lam02) < 1.0e-20f32 {
+            grad_r1 = cross3(r2, grad_lam);
+            grad_r2 = cross3(grad_lam, r1);
+        } else {
+            grad_r0 = cross3(r2, grad_lam);
+            grad_r2 = cross3(grad_lam, r0);
+        }
+    } else {
+        grad_r0 = cross3(r1, grad_lam);
+        grad_r1 = cross3(grad_lam, r0);
+    }
+    let grad_m = M3::from_rows(grad_r0, grad_r1, grad_r2);
+
+    // M = skew * T → grad_skew = grad_M * T^T, grad_T += skew^T * grad_M.
+    let grad_skew = grad_m.mul(t.transpose());
+    grad_t = grad_t.add(skew.transpose().mul(grad_m));
+
+    // Skew construction → grad_t_gray.
+    let grad_t_gray = Vec3A::new(
+        -grad_skew.m12 + grad_skew.m21,
+        grad_skew.m02 - grad_skew.m20,
+        -grad_skew.m01 + grad_skew.m10,
+    );
+
+    // T columns are [t_b, t_r, t_g]; only x/y components flow to the latent
+    // offsets (z is the constant 1).
+    let grad_bd_x = grad_t.m00;
+    let grad_bd_y = grad_t.m10;
+    let grad_rd_x = grad_t.m01;
+    let grad_rd_y = grad_t.m11;
+    let grad_gd_x = grad_t.m02;
+    let grad_gd_y = grad_t.m12;
+    let grad_nd_x = grad_t_gray.x();
+    let grad_nd_y = grad_t_gray.y();
+
+    // ZCA backward: grad_latent = zca^T * grad_offset. `grad_base` selects
+    // where the 8 latent gradients land in the caller's accumulator.
+    pg[comptime!(grad_base as usize)] += ZCA_B00 * grad_bd_x + ZCA_B10 * grad_bd_y;
+    pg[comptime!((grad_base + 1) as usize)] += ZCA_B01 * grad_bd_x + ZCA_B11 * grad_bd_y;
+    pg[comptime!((grad_base + 2) as usize)] += ZCA_R00 * grad_rd_x + ZCA_R10 * grad_rd_y;
+    pg[comptime!((grad_base + 3) as usize)] += ZCA_R01 * grad_rd_x + ZCA_R11 * grad_rd_y;
+    pg[comptime!((grad_base + 4) as usize)] += ZCA_G00 * grad_gd_x + ZCA_G10 * grad_gd_y;
+    pg[comptime!((grad_base + 5) as usize)] += ZCA_G01 * grad_gd_x + ZCA_G11 * grad_gd_y;
+    pg[comptime!((grad_base + 6) as usize)] += ZCA_N00 * grad_nd_x + ZCA_N10 * grad_nd_y;
+    pg[comptime!((grad_base + 7) as usize)] += ZCA_N01 * grad_nd_x + ZCA_N11 * grad_nd_y;
+}
+
+/// Backward through the color correction. Returns `dL/drgb_in` and adds the
+/// latent color-param gradients into `pg[16..24]`.
+#[cube]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn color_correct_bwd(
+    rgb_in: Vec3A,
+    b0: f32,
+    b1: f32,
+    r0: f32,
+    r1: f32,
+    g0: f32,
+    g1: f32,
+    n0: f32,
+    n1: f32,
+    grad_out: Vec3A,
+    pg: &mut Array<f32>,
+    #[comptime] grad_base: u32,
+) -> Vec3A {
+    let (h, _) = homography(b0, b1, r0, r1, g0, g1, n0, n1);
+
+    let intensity = rgb_in.x() + rgb_in.y() + rgb_in.z();
+    let rgi_in = Vec3A::new(rgb_in.x(), rgb_in.y(), intensity);
+    let rgi_out = h.mul_vec(rgi_in);
+    let norm = intensity / (rgi_out.z() + 1.0e-5f32);
+
+    // rgb = [o.x, o.y, o.z - o.x - o.y] where o = rgi_out * norm.
+    let grad_o = Vec3A::new(
+        grad_out.x() - grad_out.z(),
+        grad_out.y() - grad_out.z(),
+        grad_out.z(),
+    );
+
+    let mut grad_rgi_out = grad_o.scale(norm);
+    let grad_norm = grad_o.dot(rgi_out);
+    grad_rgi_out = Vec3A::new(
+        grad_rgi_out.x(),
+        grad_rgi_out.y(),
+        grad_rgi_out.z() - grad_norm * norm / (rgi_out.z() + 1.0e-5f32),
+    );
+
+    // rgi_out = H * rgi_in.
+    let grad_h = outer3(grad_rgi_out, rgi_in);
+    let grad_rgi_in = h.tmul_vec(grad_rgi_out);
+
+    let mut grad_intensity = 0.0f32;
+    if intensity > 1.0e-8f32 {
+        grad_intensity = grad_norm * norm / intensity;
+    }
+
+    let grad_in = Vec3A::new(
+        grad_rgi_in.x() + grad_rgi_in.z() + grad_intensity,
+        grad_rgi_in.y() + grad_rgi_in.z() + grad_intensity,
+        grad_rgi_in.z() + grad_intensity,
+    );
+
+    homography_bwd(b0, b1, r0, r1, g0, g1, n0, n1, grad_h, pg, grad_base);
+    grad_in
+}
+
+/// Single-channel CRF backward. Returns `dL/dx` and the four raw-parameter
+/// gradients `(toe, shoulder, gamma, center)`.
+#[cube]
+pub(crate) fn crf_channel_bwd(
+    x: f32,
+    toe_raw: f32,
+    shoulder_raw: f32,
+    gamma_raw: f32,
+    center_raw: f32,
+    grad_out: f32,
+) -> (f32, f32, f32, f32, f32) {
+    let toe = 0.3f32 + softplus(toe_raw);
+    let shoulder = 0.3f32 + softplus(shoulder_raw);
+    let gamma = 0.1f32 + softplus(gamma_raw);
+    let center = sigmoid(center_raw);
+
+    let lerp_val = toe + center * (shoulder - toe);
+    let a = shoulder * center / lerp_val;
+    let b = 1.0f32 - a;
+
+    let low = x <= center;
+    let y_low = a * f32::powf(x / center, toe);
+    let y_high = 1.0f32 - b * f32::powf((1.0f32 - x) / (1.0f32 - center), shoulder);
+    let y = select(low, y_low, y_high);
+    let y_clamped = f32::max(y, 0.0f32);
+    let output = f32::powf(y_clamped, gamma);
+
+    // d(output)/dy through the gamma power.
+    let mut grad_y = 0.0f32;
+    if y_clamped > 0.0f32 {
+        grad_y = grad_out * gamma * f32::powf(y_clamped, gamma - 1.0f32);
+    }
+
+    let mut grad_x = 0.0f32;
+    let mut grad_toe = 0.0f32;
+    let mut grad_shoulder = 0.0f32;
+    let mut grad_center = 0.0f32;
+    let mut grad_a = 0.0f32;
+    let mut grad_b = 0.0f32;
+
+    if low && center > 0.0f32 {
+        let base = x / center;
+        if base > 0.0f32 {
+            let powered = f32::powf(base, toe);
+            grad_x = grad_y * a * toe * f32::powf(base, toe - 1.0f32) / center;
+            grad_a += grad_y * powered;
+            grad_toe += grad_y * a * powered * f32::ln(base + 1.0e-8f32);
+            let grad_base = grad_y * a * toe * f32::powf(base, toe - 1.0f32);
+            grad_center += grad_base * (-x / (center * center));
+        }
+    } else if !low && center < 1.0f32 {
+        let base = (1.0f32 - x) / (1.0f32 - center);
+        if base > 0.0f32 {
+            let powered = f32::powf(base, shoulder);
+            grad_x = grad_y * b * shoulder * f32::powf(base, shoulder - 1.0f32) / (1.0f32 - center);
+            grad_b += -grad_y * powered;
+            grad_shoulder += -grad_y * b * powered * f32::ln(base + 1.0e-8f32);
+            let grad_base = grad_y * (-b * shoulder * f32::powf(base, shoulder - 1.0f32));
+            let dbase_dcenter = (1.0f32 - x) / ((1.0f32 - center) * (1.0f32 - center));
+            grad_center += grad_base * dbase_dcenter;
+        }
+    }
+
+    // b = 1 - a.
+    grad_a += -grad_b;
+
+    if f32::abs(lerp_val) > 1.0e-8f32 {
+        let a_over_lerp = shoulder * center / lerp_val;
+        grad_shoulder += grad_a * center / lerp_val;
+        grad_center += grad_a * shoulder / lerp_val;
+        let grad_lerp_val = -grad_a * a_over_lerp / lerp_val;
+        grad_shoulder += grad_lerp_val * center;
+        grad_toe += grad_lerp_val * (1.0f32 - center);
+        grad_center += grad_lerp_val * (shoulder - toe);
+    }
+
+    // Gradient to gamma from output = y_clamped^gamma.
+    let mut grad_gamma = 0.0f32;
+    if y_clamped > 0.0f32 {
+        grad_gamma = grad_out * output * f32::ln(y_clamped + 1.0e-8f32);
+    }
+
+    // Raw-parameter transforms: softplus'(x) = sigmoid(x); sigmoid' = s(1-s).
+    let grad_toe_raw = grad_toe * sigmoid(toe_raw);
+    let grad_shoulder_raw = grad_shoulder * sigmoid(shoulder_raw);
+    let grad_gamma_raw = grad_gamma * sigmoid(gamma_raw);
+    let grad_center_raw = grad_center * center * (1.0f32 - center);
+
+    (
+        grad_x,
+        grad_toe_raw,
+        grad_shoulder_raw,
+        grad_gamma_raw,
+        grad_center_raw,
+    )
+}

--- a/crates/brush-appearance/src/train_state.rs
+++ b/crates/brush-appearance/src/train_state.rs
@@ -1,0 +1,803 @@
+//! Training-side state for the appearance models: per-step lifting onto the
+//! autodiff graph and Adam updates.
+//!
+//! Two pipelines share this state:
+//!
+//! - **Hybrid** (`ppisp_grid`, the recommended mode): per-camera PPISP
+//!   vignetting → per-view PPISP grid (exposure + optional color/CRF payload)
+//!   → optional per-camera CRF.
+//! - **Legacy** comparison modes: full per-frame PPISP and/or the affine
+//!   bilateral grid.
+//!
+//! The grids deliberately bypass Burn's module/optimizer plumbing: only the
+//! *active view's* `[1, C, L, H, W]` slice is lifted as an autodiff leaf
+//! each step, so the gradient, the regularisers and the optimizer update
+//! all run on one view's grid. A naive full-tensor setup (what the
+//! reference implementations do) allocates an `[N, ...]` gradient and
+//! Adam-updates every view's grid every step, which scales per-step cost
+//! with the dataset size.
+//!
+//! The sparse update is *dense-Adam equivalent*: each visit consolidates
+//! every step a dense Adam would have applied to the slice since the
+//! view's last visit (see `GridTrainState::step`). Plain
+//! `torch.optim.SparseAdam` semantics (per-view bias-correction
+//! timesteps) are deliberately NOT used: their bias correction makes
+//! every visit a `~lr`-sized step, capping a view's total movement at
+//! `visits * lr` — on a large dataset (say 1.5k views / 12k iters, ~8
+//! visits per view) that is ~100x less learning than the references,
+//! whose dense Adam amplifies rare-visit steps by `~1/sqrt(v_hat)` as
+//! the second moment decays toward zero between visits.
+//!
+//! PPISP params are tiny (a few dozen floats per frame/camera), so they get
+//! a plain dense Adam.
+
+use burn::tensor::{Device, Gradients, Tensor, s};
+
+use crate::bilagrid::bilagrid_apply_inner;
+use crate::ppisp::{PpispModel, PpispStages, ppisp_apply_inner};
+use crate::ppisp_grid::{GridPayload, ppisp_grid_apply, ppisp_grid_apply_inner};
+use crate::{AppearanceConfig, BilagridModel, GradSubsample, bilagrid_apply, bilagrid_tv_loss};
+use brush_render::burn_glue::{detach_autodiff, lift_to_autodiff};
+
+const ADAM_EPS: f64 = 1e-15;
+
+/// Warmup steps for the appearance LR schedules (`LichtFeld` / PPISP
+/// reference defaults), with linear warmup from 1% and exponential decay
+/// toward 1% of the base LR at `total_iters`.
+const BILAGRID_LR_WARMUP: u32 = 1000;
+const PPISP_LR_WARMUP: u32 = 500;
+const LR_START_FACTOR: f64 = 0.01;
+const LR_FINAL_FACTOR: f64 = 0.01;
+
+/// EMA decay length (in steps) for the grid mean-to-identity anchor;
+/// roughly one epoch on typical datasets (spirulae uses the same horizon
+/// for its color-shift regulariser).
+const MEAN_EMA_PERIOD: f64 = 750.0;
+
+/// One dense Adam update. `t` is the 1-based timestep for bias correction.
+fn adam_update<const D: usize>(
+    param: Tensor<D>,
+    grad: Tensor<D>,
+    m1: Tensor<D>,
+    m2: Tensor<D>,
+    t: i32,
+    lr: f64,
+    betas: (f64, f64),
+) -> (Tensor<D>, Tensor<D>, Tensor<D>) {
+    let (b1, b2) = betas;
+    let m1 = m1 * b1 + grad.clone() * (1.0 - b1);
+    let m2 = m2 * b2 + grad.powi_scalar(2) * (1.0 - b2);
+    let m1_hat = m1.clone() / (1.0 - b1.powi(t));
+    let m2_hat = m2.clone() / (1.0 - b2.powi(t));
+    let param = param - m1_hat / (m2_hat.sqrt() + ADAM_EPS) * lr;
+    (param, m1, m2)
+}
+
+/// Warmup + exponential decay (see module docs).
+fn scheduled_lr(step: u32, base: f64, warmup: u32, total_iters: u32) -> f64 {
+    crate::warmup_exp_lr(
+        step,
+        base,
+        warmup,
+        LR_START_FACTOR,
+        LR_FINAL_FACTOR,
+        total_iters,
+    )
+}
+
+/// Per-view grids plus sparse-Adam state, all on the inner (non-autodiff)
+/// backend. Tensor fields are `Option` only so updates can take ownership
+/// and write back without cloning the handle (a second live handle would
+/// force `slice_assign` out-of-place over the full tensor).
+struct GridTrainState {
+    grids: Option<Tensor<5>>,
+    m1: Option<Tensor<5>>,
+    m2: Option<Tensor<5>>,
+    /// Global step of each view's last visit (-1 = never), for the
+    /// dense-equivalent moment decay over the gap.
+    last_step: Vec<i64>,
+    betas: (f64, f64),
+    /// EMA of per-view payload-channel means `[C]`, the anchor for the
+    /// mean-to-identity regulariser (zero-identity payloads only).
+    mean_ema: Option<Tensor<1>>,
+}
+
+impl GridTrainState {
+    /// Affine 3x4 grid (identity-initialised diagonal).
+    fn new_affine(
+        num_views: usize,
+        dims: (usize, usize, usize),
+        betas: (f64, f64),
+        device: &Device,
+    ) -> Self {
+        let (gx, gy, guidance) = dims;
+        let grids = BilagridModel::new(num_views, gx, gy, guidance, device)
+            .grids
+            .into_value();
+        let zeros = || Tensor::zeros(grids.dims(), device);
+        Self {
+            m1: Some(zeros()),
+            m2: Some(zeros()),
+            grids: Some(grids),
+            last_step: vec![-1; num_views],
+            betas,
+            mean_ema: None,
+        }
+    }
+
+    /// PPISP-payload grid (all-zeros = identity).
+    fn new_payload(
+        num_views: usize,
+        dims: (usize, usize, usize),
+        payload: GridPayload,
+        betas: (f64, f64),
+        mean_reg: bool,
+        device: &Device,
+    ) -> Self {
+        let (gx, gy, guidance) = dims;
+        let c = payload.channels();
+        let shape = [num_views, c, guidance, gy, gx];
+        Self {
+            grids: Some(Tensor::zeros(shape, device)),
+            m1: Some(Tensor::zeros(shape, device)),
+            m2: Some(Tensor::zeros(shape, device)),
+            last_step: vec![-1; num_views],
+            betas,
+            mean_ema: mean_reg.then(|| Tensor::zeros([c], device)),
+        }
+    }
+
+    fn grids_ref(&self) -> &Tensor<5> {
+        self.grids
+            .as_ref()
+            .expect("grids always present between steps")
+    }
+
+    fn view_grid(&self, view_idx: usize) -> Tensor<5> {
+        self.grids_ref().clone().slice(s![view_idx..view_idx + 1])
+    }
+
+    /// One lazy, dense-Adam-equivalent update for `view_idx`'s slice.
+    ///
+    /// Reproduces exactly what a dense Adam over the full `[N, ...]`
+    /// tensor — the reference implementations' optimizer — would have
+    /// applied since this view's last visit (up to `eps` placement, and
+    /// the LR schedule sampled at visits instead of every step): first
+    /// the momentum tail of zero-gradient steps dense Adam kept taking
+    /// over the gap while `m` decayed (each is bias-corrected
+    /// `m_hat/sqrt(v_hat)`; they share the per-element direction
+    /// `m/sqrt(v)`, so their coefficients fold into one host-side scalar
+    /// sum), then the visit's own Adam step on the gap-decayed moments
+    /// with *global*-timestep bias correction. For consecutive visits
+    /// this reduces to standard Adam. `SparseAdam` semantics (per-view
+    /// bias-correction timesteps) are deliberately NOT used: they turn
+    /// every visit into a `~lr`-sized step, capping a view's total
+    /// movement at `visits * lr` — orders of magnitude too slow on
+    /// many-view datasets, where dense Adam's between-visit second-moment
+    /// decay amplifies each visit's effect instead.
+    fn step(&mut self, view_idx: usize, grad: Tensor<5>, lr: f64, global_step: u32) {
+        let r = s![view_idx..view_idx + 1];
+        let (b1, b2) = self.betas;
+        // 1-based dense-Adam timesteps of the previous visit's update and
+        // this one's (`t_old == 0`: never visited).
+        let t_old = self.last_step[view_idx] + 1;
+        let t_new = i64::from(global_step) + 1;
+        self.last_step[view_idx] = i64::from(global_step);
+        let dt = i32::try_from((t_new - t_old).max(1)).expect("step gap fits i32");
+
+        let grids = self.grids.take().expect("grids present");
+        let m1 = self.m1.take().expect("m1 present");
+        let m2 = self.m2.take().expect("m2 present");
+
+        let mut pv = grids.clone().slice(r);
+        let m1v = m1.clone().slice(r);
+        let m2v = m2.clone().slice(r);
+
+        // Catch up the gap's zero-gradient steps.
+        if t_old > 0 && dt > 1 {
+            let t_old = i32::try_from(t_old).expect("step fits i32");
+            let mut tail = 0.0f64;
+            for k in 1..dt {
+                let decay = b1.powi(k) / b2.powi(k).sqrt();
+                if decay < 1e-14 {
+                    break;
+                }
+                tail += decay * (1.0 - b2.powi(t_old + k)).sqrt() / (1.0 - b1.powi(t_old + k));
+            }
+            if tail > 0.0 {
+                pv = pv - m1v.clone() / (m2v.clone().sqrt() + ADAM_EPS) * (lr * tail);
+            }
+        }
+
+        // The visit's own step, on the gap-decayed moments.
+        let t = i32::try_from(t_new).expect("step fits i32");
+        let m1v = m1v * b1.powi(dt) + grad.clone() * (1.0 - b1);
+        let m2v = m2v * b2.powi(dt) + grad.powi_scalar(2) * (1.0 - b2);
+        let m_hat = m1v.clone() / (1.0 - b1.powi(t));
+        let v_hat = m2v.clone() / (1.0 - b2.powi(t));
+        let pv = pv - m_hat / (v_hat.sqrt() + ADAM_EPS) * lr;
+
+        // Track the dataset-wide payload mean for the identity anchor.
+        if let Some(ema) = self.mean_ema.take() {
+            let c = pv.dims()[1];
+            let cells = pv.dims()[2] * pv.dims()[3] * pv.dims()[4];
+            let view_mean = pv
+                .clone()
+                .reshape([c as i32, cells as i32])
+                .mean_dim(1)
+                .reshape([c]);
+            let beta = 1.0 - 1.0 / MEAN_EMA_PERIOD;
+            self.mean_ema = Some(ema * beta + view_mean * (1.0 - beta));
+        }
+
+        self.grids = Some(grids.slice_assign(r, pv));
+        self.m1 = Some(m1.slice_assign(r, m1v));
+        self.m2 = Some(m2.slice_assign(r, m2v));
+    }
+}
+
+/// Dense Adam state for the four PPISP parameter tensors. In hybrid mode
+/// the per-frame tensors (exposure/color) receive exactly-zero gradients
+/// (the kernel runs with `with_frame = false`) and stay at identity.
+struct PpispTrainState {
+    model: PpispModel,
+    m_exposure: (Tensor<1>, Tensor<1>),
+    m_vignetting: (Tensor<3>, Tensor<3>),
+    m_color: (Tensor<2>, Tensor<2>),
+    m_crf: (Tensor<3>, Tensor<3>),
+    step: i32,
+}
+
+impl PpispTrainState {
+    fn new(
+        num_cameras: usize,
+        num_views: usize,
+        camera_indices: Vec<u32>,
+        device: &Device,
+    ) -> Self {
+        let model = PpispModel::new(num_cameras, num_views, camera_indices, device);
+        let zeros_like1 = |t: &Tensor<1>| {
+            (
+                Tensor::zeros(t.dims(), device),
+                Tensor::zeros(t.dims(), device),
+            )
+        };
+        let zeros_like2 = |t: &Tensor<2>| {
+            (
+                Tensor::zeros(t.dims(), device),
+                Tensor::zeros(t.dims(), device),
+            )
+        };
+        let zeros_like3 = |t: &Tensor<3>| {
+            (
+                Tensor::zeros(t.dims(), device),
+                Tensor::zeros(t.dims(), device),
+            )
+        };
+        Self {
+            m_exposure: zeros_like1(&model.exposure.val()),
+            m_vignetting: zeros_like3(&model.vignetting.val()),
+            m_color: zeros_like2(&model.color.val()),
+            m_crf: zeros_like3(&model.crf.val()),
+            model,
+            step: 0,
+        }
+    }
+
+    /// Lift the stored (inner) params into a fresh tracked model for one
+    /// training step.
+    fn lifted(&self) -> PpispModel {
+        use burn::module::Param;
+        PpispModel {
+            exposure: Param::from_tensor(
+                lift_to_autodiff(self.model.exposure.val()).require_grad(),
+            ),
+            vignetting: Param::from_tensor(
+                lift_to_autodiff(self.model.vignetting.val()).require_grad(),
+            ),
+            color: Param::from_tensor(lift_to_autodiff(self.model.color.val()).require_grad()),
+            crf: Param::from_tensor(lift_to_autodiff(self.model.crf.val()).require_grad()),
+            camera_indices: self.model.camera_indices.clone(),
+        }
+    }
+
+    fn step(&mut self, lifted: &PpispModel, grads: &mut Gradients, lr: f64) {
+        use burn::module::Param;
+        self.step += 1;
+        let t = self.step;
+
+        fn update<const D: usize>(
+            param: &mut Param<Tensor<D>>,
+            moments: &mut (Tensor<D>, Tensor<D>),
+            lifted: &Param<Tensor<D>>,
+            grads: &mut Gradients,
+            t: i32,
+            lr: f64,
+        ) {
+            let Some(grad) = lifted.val().grad_remove(grads) else {
+                return;
+            };
+            let grad = detach_autodiff(grad);
+            let (p, m1, m2) = adam_update(
+                param.val(),
+                grad,
+                moments.0.clone(),
+                moments.1.clone(),
+                t,
+                lr,
+                (0.9, 0.999),
+            );
+            *moments = (m1, m2);
+            *param = Param::from_tensor(p);
+        }
+
+        update(
+            &mut self.model.exposure,
+            &mut self.m_exposure,
+            &lifted.exposure,
+            grads,
+            t,
+            lr,
+        );
+        update(
+            &mut self.model.vignetting,
+            &mut self.m_vignetting,
+            &lifted.vignetting,
+            grads,
+            t,
+            lr,
+        );
+        update(
+            &mut self.model.color,
+            &mut self.m_color,
+            &lifted.color,
+            grads,
+            t,
+            lr,
+        );
+        update(
+            &mut self.model.crf,
+            &mut self.m_crf,
+            &lifted.crf,
+            grads,
+            t,
+            lr,
+        );
+    }
+}
+
+/// Which correction pipeline is active.
+#[derive(Debug, Clone, Copy)]
+enum PipelineMode {
+    /// Comparison modes: optional full per-frame PPISP, then optional
+    /// affine bilateral grid.
+    Legacy,
+    /// Per-camera vignetting → PPISP grid → optional per-camera CRF.
+    Hybrid {
+        payload: GridPayload,
+        crf_per_camera: bool,
+    },
+}
+
+/// Trainer-facing appearance state: holds the params + optimizer state on
+/// the inner backend, and hands out per-step [`ActiveAppearance`] handles
+/// with the lifted (tracked) tensors.
+pub struct AppearanceTrainState {
+    config: AppearanceConfig,
+    mode: PipelineMode,
+    total_iters: u32,
+    grid: Option<GridTrainState>,
+    ppisp: Option<PpispTrainState>,
+}
+
+/// The lifted appearance tensors for one training step. Apply to the
+/// rendered image, add [`Self::reg_loss`] to the training loss, then hand
+/// back to [`AppearanceTrainState::end_step`] after `loss.backward()`.
+pub struct ActiveAppearance {
+    view_idx: usize,
+    mode: PipelineMode,
+    /// Tracked `[1, C, L, H, W]` leaf for the active view.
+    view_grid: Option<Tensor<5>>,
+    ppisp: Option<PpispModel>,
+    /// Detached EMA anchor `[C]` for the mean regulariser.
+    mean_ema: Option<Tensor<1>>,
+    tv_weight: f32,
+    mean_reg_weight: f32,
+    reg_scale: f32,
+    subsample: GradSubsample,
+}
+
+impl AppearanceTrainState {
+    /// Returns `None` when no appearance model is enabled. `device` may be
+    /// the autodiff device; state is kept on its inner counterpart.
+    pub fn new(
+        config: AppearanceConfig,
+        camera_indices: Vec<u32>,
+        total_iters: u32,
+        device: &Device,
+    ) -> Option<Self> {
+        if !config.bilagrid && !config.ppisp && !config.ppisp_grid {
+            return None;
+        }
+        assert!(
+            !(config.ppisp_grid && (config.bilagrid || config.ppisp)),
+            "--ppisp-grid replaces the separate --bilateral-grid / --ppisp modes"
+        );
+        let device = device.clone().inner();
+        let num_views = camera_indices.len();
+        let num_cameras = camera_indices.iter().copied().max().unwrap_or(0) as usize + 1;
+
+        let (mode, grid, ppisp) = if config.ppisp_grid {
+            let payload = GridPayload {
+                color: config.grid_color,
+                crf: config.grid_crf,
+                vignetting: true,
+            };
+            let grid = GridTrainState::new_payload(
+                num_views,
+                config.bilagrid_dims,
+                payload,
+                config.bilagrid_betas,
+                config.bilagrid_mean_reg > 0.0,
+                &device,
+            );
+            // Per-camera vignetting (+ optional CRF); frame params stay at
+            // identity (the grid owns exposure/color).
+            let ppisp = PpispTrainState::new(num_cameras, num_views, camera_indices, &device);
+            (
+                PipelineMode::Hybrid {
+                    payload,
+                    crf_per_camera: config.crf_per_camera,
+                },
+                Some(grid),
+                Some(ppisp),
+            )
+        } else {
+            let grid = config.bilagrid.then(|| {
+                GridTrainState::new_affine(
+                    num_views,
+                    config.bilagrid_dims,
+                    config.bilagrid_betas,
+                    &device,
+                )
+            });
+            let ppisp = config
+                .ppisp
+                .then(|| PpispTrainState::new(num_cameras, num_views, camera_indices, &device));
+            (PipelineMode::Legacy, grid, ppisp)
+        };
+
+        Some(Self {
+            mode,
+            grid,
+            ppisp,
+            config,
+            total_iters,
+        })
+    }
+
+    /// Lift the active view's appearance params onto the autodiff graph.
+    /// `step` rotates the gradient-subsample offset.
+    pub fn begin_step(&self, view_idx: usize, step: u32) -> ActiveAppearance {
+        let every = self.config.grad_subsample.max(1);
+        ActiveAppearance {
+            view_idx,
+            mode: self.mode,
+            view_grid: self
+                .grid
+                .as_ref()
+                .map(|b| lift_to_autodiff(b.view_grid(view_idx)).require_grad()),
+            ppisp: self.ppisp.as_ref().map(PpispTrainState::lifted),
+            mean_ema: self
+                .grid
+                .as_ref()
+                .and_then(|g| g.mean_ema.as_ref())
+                .map(|e| lift_to_autodiff(e.clone())),
+            tv_weight: self.config.bilagrid_tv_weight,
+            mean_reg_weight: self.config.bilagrid_mean_reg,
+            reg_scale: self.config.ppisp_reg_scale,
+            subsample: GradSubsample::for_step(every, step),
+        }
+    }
+
+    /// Consume the step's gradients and run the Adam updates. `step` is the
+    /// global training iteration (for the LR schedules). Takes `active` by
+    /// value: the lifted tensors are stale once the update ran.
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn end_step(&mut self, active: ActiveAppearance, grads: &mut Gradients, step: u32) {
+        if let (Some(state), Some(view_grid)) = (self.grid.as_mut(), &active.view_grid)
+            && let Some(grad) = view_grid.clone().grad_remove(grads)
+        {
+            let lr = scheduled_lr(
+                step,
+                self.config.bilagrid_lr,
+                BILAGRID_LR_WARMUP,
+                self.total_iters,
+            );
+            state.step(active.view_idx, detach_autodiff(grad), lr, step);
+        }
+        if let (Some(state), Some(lifted)) = (self.ppisp.as_mut(), &active.ppisp) {
+            let lr = scheduled_lr(
+                step,
+                self.config.ppisp_lr,
+                PPISP_LR_WARMUP,
+                self.total_iters,
+            );
+            state.step(lifted, grads, lr);
+        }
+    }
+
+    /// Magnitude summary of the learned appearance parameters, for
+    /// periodic logging — the cheapest way to see whether the model is
+    /// actually learning (all-zero payloads mean identity).
+    pub async fn stats(&self) -> Option<String> {
+        let read = |t: Tensor<1>| async move {
+            t.into_scalar_async::<f32>()
+                .await
+                .expect("appearance stats readback")
+        };
+        let mut parts = Vec::new();
+        if let Some(g) = &self.grid {
+            let grids = g.grids_ref().clone();
+            match self.mode {
+                PipelineMode::Hybrid { .. } => {
+                    // Channel 0 is log2 exposure; zero payload = identity.
+                    let exposure = grids.clone().slice(s![.., 0..1]);
+                    let lo = read(exposure.clone().min()).await;
+                    let hi = read(exposure.max()).await;
+                    let payload = read(grids.abs().max()).await;
+                    parts.push(format!(
+                        "grid exposure [{lo:+.3}, {hi:+.3}] stops, payload |max| {payload:.3}"
+                    ));
+                }
+                PipelineMode::Legacy => {
+                    let lo = read(grids.clone().min()).await;
+                    let hi = read(grids.max()).await;
+                    parts.push(format!("grid range [{lo:.3}, {hi:.3}]"));
+                }
+            }
+        }
+        if let Some(p) = &self.ppisp {
+            let vig = read(p.model.vignetting.val().abs().max()).await;
+            parts.push(format!("vignetting |max| {vig:.3}"));
+            if matches!(self.mode, PipelineMode::Legacy) {
+                let e = p.model.exposure.val();
+                let lo = read(e.clone().min()).await;
+                let hi = read(e.max()).await;
+                parts.push(format!("exposure [{lo:+.3}, {hi:+.3}] stops"));
+            }
+        }
+        (!parts.is_empty()).then(|| parts.join(", "))
+    }
+
+    /// Forward-only correction for evaluation renders of *training* views
+    /// (used with `--train-on-eval`, where eval views keep their learned
+    /// per-view parameters). `img` is `[H, W, 3|4]` on the inner backend.
+    pub fn apply_eval(&self, img: Tensor<3>, view_idx: usize) -> Tensor<3> {
+        let p = self.ppisp.as_ref().map(|s| &s.model);
+        let cam = |p: &PpispModel| p.camera_indices[view_idx] as usize;
+        match self.mode {
+            PipelineMode::Legacy => {
+                let img = match p {
+                    Some(p) => ppisp_apply_inner(
+                        p.exposure.val(),
+                        p.vignetting.val(),
+                        p.color.val(),
+                        p.crf.val(),
+                        img,
+                        cam(p),
+                        view_idx,
+                        PpispStages::ALL,
+                    ),
+                    None => img,
+                };
+                match &self.grid {
+                    Some(g) => bilagrid_apply_inner(g.grids_ref().clone(), img, view_idx),
+                    None => img,
+                }
+            }
+            PipelineMode::Hybrid {
+                payload,
+                crf_per_camera,
+            } => {
+                let p = p.expect("hybrid always has ppisp state");
+                let g = self.grid.as_ref().expect("hybrid always has a grid");
+                let img = ppisp_grid_apply_inner(
+                    g.grids_ref().clone(),
+                    p.vignetting.val(),
+                    img,
+                    view_idx,
+                    cam(p),
+                    payload,
+                );
+                if crf_per_camera {
+                    ppisp_apply_inner(
+                        p.exposure.val(),
+                        p.vignetting.val(),
+                        p.color.val(),
+                        p.crf.val(),
+                        img,
+                        cam(p),
+                        view_idx,
+                        PpispStages::CRF_ONLY,
+                    )
+                } else {
+                    img
+                }
+            }
+        }
+    }
+}
+
+impl ActiveAppearance {
+    /// Apply the enabled corrections to a rendered `[H, W, 3|4]` image.
+    /// Alpha passes through untouched.
+    pub fn apply(&self, img: Tensor<3>) -> Tensor<3> {
+        match self.mode {
+            PipelineMode::Legacy => {
+                let img = match &self.ppisp {
+                    Some(p) => p.apply(img, self.view_idx),
+                    None => img,
+                };
+                match &self.view_grid {
+                    Some(g) => bilagrid_apply(g.clone(), img, 0, self.subsample),
+                    None => img,
+                }
+            }
+            PipelineMode::Hybrid {
+                payload,
+                crf_per_camera,
+            } => {
+                // Vignetting is fused into the grid pass; an optional
+                // per-camera CRF runs as a separate pass after it.
+                let p = self.ppisp.as_ref().expect("hybrid always has ppisp");
+                let camera_idx = p.camera_indices[self.view_idx] as usize;
+                let g = self.view_grid.as_ref().expect("hybrid always has a grid");
+                let img = ppisp_grid_apply(
+                    g.clone(),
+                    p.vignetting.val(),
+                    img,
+                    0,
+                    camera_idx,
+                    payload,
+                    self.subsample,
+                );
+                if crf_per_camera {
+                    p.apply_stages(img, self.view_idx, PpispStages::CRF_ONLY)
+                } else {
+                    img
+                }
+            }
+        }
+    }
+
+    /// Regularisation for this step: TV on the active view's grid, the
+    /// EMA-anchored mean-to-identity term (hybrid payloads), plus the PPISP
+    /// parameter priors.
+    ///
+    /// The TV/mean terms cover only the sampled view (the references
+    /// regularise all `N` grids every step with an extra `1/N` factor —
+    /// per-epoch that applies the same total pressure per view as these
+    /// per-step single-view terms, while keeping step cost independent of
+    /// the dataset size).
+    pub fn reg_loss(&self) -> Option<Tensor<1>> {
+        let mut loss: Option<Tensor<1>> = None;
+        let add = |loss: &mut Option<Tensor<1>>, term: Tensor<1>| {
+            *loss = Some(match loss.take() {
+                Some(l) => l + term,
+                None => term,
+            });
+        };
+        if let Some(g) = &self.view_grid {
+            if self.tv_weight > 0.0 {
+                add(&mut loss, bilagrid_tv_loss(g.clone()) * self.tv_weight);
+            }
+            // Mean anchor: gradient of `w * mse(EMA, 0)` w.r.t. this view's
+            // contribution, with the EMA itself held constant — drives the
+            // dataset-mean transform toward identity without touching the
+            // other views' grids. Channel-mean (not sum) normalization so
+            // the weight is directly comparable to spirulae's
+            // `bilagrid_mean_reg_weight` (both default 10).
+            if let Some(ema) = &self.mean_ema
+                && self.mean_reg_weight > 0.0
+            {
+                let dims = g.dims();
+                let c = dims[1];
+                let cells = dims[2] * dims[3] * dims[4];
+                let view_mean = g
+                    .clone()
+                    .reshape([c as i32, cells as i32])
+                    .mean_dim(1)
+                    .reshape([c]);
+                let term =
+                    (ema.clone() * view_mean).sum() * (2.0 * self.mean_reg_weight / c as f32);
+                add(&mut loss, term);
+            }
+        }
+        if let Some(p) = &self.ppisp
+            && self.reg_scale > 0.0
+        {
+            add(&mut loss, p.reg_loss() * self.reg_scale);
+        }
+        loss
+    }
+}
+
+#[cfg(all(test, not(target_family = "wasm")))]
+mod tests {
+    use super::*;
+    use crate::ppisp_grid::GridPayload;
+
+    /// The consolidated per-visit update must reproduce what a dense Adam
+    /// over the full `[N, ...]` grid tensor (the reference implementations'
+    /// optimizer) applies in total. `SparseAdam` semantics would end this
+    /// schedule at `visits * lr ~ 0.02` — dense Adam's between-visit
+    /// second-moment decay reaches several times that.
+    #[tokio::test]
+    async fn sparse_step_matches_dense_adam() {
+        let device = Device::from(brush_cube::test_helpers::test_device().await);
+        let payload = GridPayload {
+            color: false,
+            crf: false,
+            vignetting: true,
+        };
+        let betas = (0.9f64, 0.999f64);
+        let mut state = GridTrainState::new_payload(3, (1, 1, 1), payload, betas, false, &device);
+
+        let lr = 2e-3;
+        let gap = 40u32;
+        let visits = 10;
+        // Dense Adam reference for view 0's single cell, in host f64. The
+        // view sees a gradient every `gap` steps and zeros in between, but
+        // dense Adam still applies an update every step. The lazy update
+        // defers each gap's zero-gradient tail to the next visit, so
+        // parity holds right after a visit — stop both at the last one.
+        let (mut p, mut m, mut v) = (0.0f64, 0.0f64, 0.0f64);
+        for step in 0..=gap * (visits - 1) {
+            let g = if step % gap == 0 {
+                let g = 1.0 + 0.5 * f64::sin(f64::from(step));
+                let grad = Tensor::<5>::full([1, 1, 1, 1, 1], g as f32, &device);
+                state.step(0, grad, lr, step);
+                g
+            } else {
+                0.0
+            };
+            m = betas.0 * m + (1.0 - betas.0) * g;
+            v = betas.1 * v + (1.0 - betas.1) * g * g;
+            let t = f64::from(step + 1);
+            let m_hat = m / (1.0 - betas.0.powf(t));
+            let v_hat = v / (1.0 - betas.1.powf(t));
+            p -= lr * m_hat / (v_hat.sqrt() + ADAM_EPS);
+        }
+
+        let got = f64::from(
+            state
+                .view_grid(0)
+                .into_data_async()
+                .await
+                .expect("readback")
+                .to_vec::<f32>()
+                .expect("vec")[0],
+        );
+        // Prove we're in the amplification regime SparseAdam can't reach...
+        assert!(
+            p.abs() > 3.0 * f64::from(visits) * lr,
+            "dense reference moved only {p:.4}; test schedule too easy"
+        );
+        // ...and that the lazy update tracks it.
+        let rel = (got - p).abs() / p.abs();
+        assert!(
+            rel < 0.02,
+            "lazy update {got:.5} vs dense Adam {p:.5} (rel err {rel:.3})"
+        );
+        // Untouched views must stay at identity.
+        let other = state
+            .view_grid(1)
+            .abs()
+            .max()
+            .into_scalar_async::<f32>()
+            .await
+            .expect("readback");
+        assert_eq!(other, 0.0);
+    }
+}

--- a/crates/brush-appearance/tests/reference.rs
+++ b/crates/brush-appearance/tests/reference.rs
@@ -1,0 +1,1475 @@
+//! Correctness tests for the appearance kernels.
+//!
+//! Each fused kernel is checked against a plain-Rust CPU reference (ported
+//! from the same CUDA/PyTorch sources the kernels were ported from), and
+//! gradients are verified with central finite differences through the
+//! forward-only paths.
+
+use brush_appearance::GradSubsample;
+use brush_appearance::bilagrid::{BilagridModel, bilagrid_apply, bilagrid_tv_loss};
+use brush_appearance::ppisp::{PpispModel, PpispStages, ppisp_apply};
+use burn::tensor::{Device, Tensor, TensorData};
+use wasm_bindgen_test::wasm_bindgen_test;
+
+#[cfg(target_family = "wasm")]
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+async fn ad_device() -> Device {
+    burn::tensor::Device::from(brush_cube::test_helpers::test_device().await).autodiff()
+}
+
+/// Deterministic pseudo-random floats in [lo, hi).
+fn pattern(n: usize, seed: u32, lo: f32, hi: f32) -> Vec<f32> {
+    let mut state = seed.wrapping_mul(747796405).wrapping_add(2891336453);
+    (0..n)
+        .map(|_| {
+            // PCG-ish hash; deterministic across platforms.
+            state = state.wrapping_mul(747796405).wrapping_add(2891336453);
+            let word = ((state >> ((state >> 28) + 4)) ^ state).wrapping_mul(277803737);
+            let h = (word >> 22) ^ word;
+            lo + (hi - lo) * (h as f32 / u32::MAX as f32)
+        })
+        .collect()
+}
+
+async fn read_vec(t: Tensor<3>) -> Vec<f32> {
+    t.into_data_async()
+        .await
+        .expect("readback")
+        .to_vec()
+        .expect("vec")
+}
+
+// ---------------------------------------------------------------------------
+// CPU references
+// ---------------------------------------------------------------------------
+
+const C2G: [f32; 3] = [0.299, 0.587, 0.114];
+
+/// CPU port of the fused bilateral-grid slice (`LichtFeld` HWC forward).
+#[allow(clippy::too_many_arguments)]
+fn bilagrid_slice_cpu(
+    grid: &[f32], // [12, L, H, W] (single view)
+    rgb: &[f32],  // [h, w, 3]
+    gl: usize,
+    gh: usize,
+    gw: usize,
+    h: usize,
+    w: usize,
+) -> Vec<f32> {
+    let mut out = vec![0.0f32; h * w * 3];
+    let cell = gl * gh * gw;
+    for hi in 0..h {
+        for wi in 0..w {
+            let base = (hi * w + wi) * 3;
+            let (sr, sg, sb) = (rgb[base], rgb[base + 1], rgb[base + 2]);
+            let x = wi as f32 / (w - 1).max(1) as f32 * (gw - 1) as f32;
+            let y = hi as f32 / (h - 1).max(1) as f32 * (gh - 1) as f32;
+            let z = (C2G[0] * sr + C2G[1] * sg + C2G[2] * sb) * (gl - 1) as f32;
+
+            let x0 = x.floor() as usize;
+            let y0 = y.floor() as usize;
+            let x1 = (x0 + 1).min(gw - 1);
+            let y1 = (y0 + 1).min(gh - 1);
+            let z0i = z.floor() as i64;
+            let z0 = z0i.clamp(0, gl as i64 - 1) as usize;
+            let z1 = (z0i + 1).clamp(0, gl as i64 - 1) as usize;
+            let fx = x - x.floor();
+            let fy = y - y.floor();
+            let fz = z - z0 as f32;
+
+            let mut acc = [0.0f32; 3];
+            for ci in 0..12 {
+                let g =
+                    |zz: usize, yy: usize, xx: usize| grid[ci * cell + (zz * gh + yy) * gw + xx];
+                let c00 = g(z0, y0, x0) * (1.0 - fx) + g(z0, y0, x1) * fx;
+                let c01 = g(z0, y1, x0) * (1.0 - fx) + g(z0, y1, x1) * fx;
+                let c10 = g(z1, y0, x0) * (1.0 - fx) + g(z1, y0, x1) * fx;
+                let c11 = g(z1, y1, x0) * (1.0 - fx) + g(z1, y1, x1) * fx;
+                let c0 = c00 * (1.0 - fy) + c01 * fy;
+                let c1 = c10 * (1.0 - fy) + c11 * fy;
+                let val = c0 * (1.0 - fz) + c1 * fz;
+                let si = ci % 4;
+                let di = ci / 4;
+                let coeff = match si {
+                    0 => sr,
+                    1 => sg,
+                    2 => sb,
+                    _ => 1.0,
+                };
+                acc[di] += val * coeff;
+            }
+            out[base] = acc[0];
+            out[base + 1] = acc[1];
+            out[base + 2] = acc[2];
+        }
+    }
+    out
+}
+
+/// CPU total-variation loss matching gsplat's `total_variation_loss`.
+fn bilagrid_tv_cpu(grids: &[f32], n: usize, gl: usize, gh: usize, gw: usize) -> f32 {
+    let cell = gl * gh * gw;
+    let mut tv = 0.0f64;
+    let at = |ni: usize, ci: usize, li: usize, hi: usize, wi: usize| {
+        grids[((ni * 12 + ci) * gl + li) * gh * gw + hi * gw + wi] as f64
+    };
+    for ni in 0..n {
+        for ci in 0..12 {
+            for li in 0..gl {
+                for hi in 0..gh {
+                    for wi in 0..gw {
+                        let v = at(ni, ci, li, hi, wi);
+                        if wi > 0 {
+                            let d = v - at(ni, ci, li, hi, wi - 1);
+                            tv += d * d / (gl * gh * (gw - 1)) as f64;
+                        }
+                        if hi > 0 {
+                            let d = v - at(ni, ci, li, hi - 1, wi);
+                            tv += d * d / (gl * (gh - 1) * gw) as f64;
+                        }
+                        if li > 0 {
+                            let d = v - at(ni, ci, li - 1, hi, wi);
+                            tv += d * d / ((gl - 1) * gh * gw) as f64;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    let _ = cell;
+    (tv / (12 * n) as f64) as f32
+}
+
+/// CPU port of the PPISP reference pipeline (`torch_reference.py`).
+#[allow(clippy::too_many_arguments)]
+fn ppisp_cpu(
+    exposure: f32,
+    vignetting: &[f32], // [3, 5] for the active camera
+    color: &[f32],      // [8] for the active frame
+    crf: &[f32],        // [3, 4] for the active camera
+    rgb: &[f32],        // [h, w, 3]
+    h: usize,
+    w: usize,
+    apply_crf: bool,
+) -> Vec<f32> {
+    let mut out = vec![0.0f32; h * w * 3];
+
+    // Homography from latent color params.
+    let zca: [[f32; 4]; 4] = [
+        [0.0480542, -0.0043631, -0.0043631, 0.0481283],
+        [0.0580570, -0.0179872, -0.0179872, 0.0431061],
+        [0.0433336, -0.0180537, -0.0180537, 0.0580500],
+        [0.0128369, -0.0034654, -0.0034654, 0.0128158],
+    ];
+    let off = |i: usize| {
+        let (l0, l1) = (color[i * 2], color[i * 2 + 1]);
+        [
+            zca[i][0] * l0 + zca[i][1] * l1,
+            zca[i][2] * l0 + zca[i][3] * l1,
+        ]
+    };
+    let (bd, rd, gd, nd) = (off(0), off(1), off(2), off(3));
+    let t_b = [bd[0], bd[1], 1.0];
+    let t_r = [1.0 + rd[0], rd[1], 1.0];
+    let t_g = [gd[0], 1.0 + gd[1], 1.0];
+    let t_n = [1.0 / 3.0 + nd[0], 1.0 / 3.0 + nd[1], 1.0];
+
+    // Row-major matrices.
+    let t = [
+        [t_b[0], t_r[0], t_g[0]],
+        [t_b[1], t_r[1], t_g[1]],
+        [t_b[2], t_r[2], t_g[2]],
+    ];
+    let skew = [
+        [0.0, -t_n[2], t_n[1]],
+        [t_n[2], 0.0, -t_n[0]],
+        [-t_n[1], t_n[0], 0.0],
+    ];
+    let matmul = |a: &[[f32; 3]; 3], b: &[[f32; 3]; 3]| {
+        let mut c = [[0.0f32; 3]; 3];
+        for i in 0..3 {
+            for j in 0..3 {
+                for (k, bk) in b.iter().enumerate() {
+                    c[i][j] += a[i][k] * bk[j];
+                }
+            }
+        }
+        c
+    };
+    let m = matmul(&skew, &t);
+    let cross = |a: [f32; 3], b: [f32; 3]| {
+        [
+            a[1] * b[2] - a[2] * b[1],
+            a[2] * b[0] - a[0] * b[2],
+            a[0] * b[1] - a[1] * b[0],
+        ]
+    };
+    let dot3 = |a: [f32; 3], b: [f32; 3]| a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+    let mut lam = cross(m[0], m[1]);
+    if dot3(lam, lam) < 1.0e-20 {
+        lam = cross(m[0], m[2]);
+        if dot3(lam, lam) < 1.0e-20 {
+            lam = cross(m[1], m[2]);
+        }
+    }
+    let d = [[lam[0], 0.0, 0.0], [0.0, lam[1], 0.0], [0.0, 0.0, lam[2]]];
+    let s_inv = [[-1.0, -1.0, 1.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]];
+    let mut hmat = matmul(&matmul(&t, &d), &s_inv);
+    let s = hmat[2][2];
+    if s.abs() > 1.0e-20 {
+        for row in &mut hmat {
+            for v in row.iter_mut() {
+                *v /= s;
+            }
+        }
+    }
+
+    let softplus = |x: f32| x.exp().ln_1p();
+    let sigmoid = |x: f32| 1.0 / (1.0 + (-x).exp());
+
+    for hi in 0..h {
+        for wi in 0..w {
+            let base = (hi * w + wi) * 3;
+            let mut c = [rgb[base], rgb[base + 1], rgb[base + 2]];
+
+            // Exposure.
+            let factor = 2.0f32.powf(exposure);
+            for v in &mut c {
+                *v *= factor;
+            }
+
+            // Vignetting.
+            let max_res = (w as f32).max(h as f32);
+            let uvx = (wi as f32 + 0.5 - w as f32 * 0.5) / max_res;
+            let uvy = (hi as f32 + 0.5 - h as f32 * 0.5) / max_res;
+            for ch in 0..3 {
+                let p = &vignetting[ch * 5..ch * 5 + 5];
+                let dx = uvx - p[0];
+                let dy = uvy - p[1];
+                let r2 = dx * dx + dy * dy;
+                let falloff =
+                    (1.0 + p[2] * r2 + p[3] * r2 * r2 + p[4] * r2 * r2 * r2).clamp(0.0, 1.0);
+                c[ch] *= falloff;
+            }
+
+            // Color homography in RGI space.
+            let intensity = c[0] + c[1] + c[2];
+            let rgi_in = [c[0], c[1], intensity];
+            let mut rgi = [0.0f32; 3];
+            for i in 0..3 {
+                rgi[i] = dot3(hmat[i], rgi_in);
+            }
+            let norm = intensity / (rgi[2] + 1.0e-5);
+            for v in &mut rgi {
+                *v *= norm;
+            }
+            c = [rgi[0], rgi[1], rgi[2] - rgi[0] - rgi[1]];
+
+            // CRF.
+            for ch in 0..3 {
+                if !apply_crf {
+                    continue;
+                }
+                let p = &crf[ch * 4..ch * 4 + 4];
+                let toe = 0.3 + softplus(p[0]);
+                let shoulder = 0.3 + softplus(p[1]);
+                let gamma = 0.1 + softplus(p[2]);
+                let center = sigmoid(p[3]);
+                let x = c[ch].clamp(0.0, 1.0);
+                let lerp_val = toe + center * (shoulder - toe);
+                let a = shoulder * center / lerp_val;
+                let b = 1.0 - a;
+                let y = if x <= center {
+                    a * (x / center).powf(toe)
+                } else {
+                    1.0 - b * ((1.0 - x) / (1.0 - center)).powf(shoulder)
+                };
+                c[ch] = y.max(0.0).powf(gamma);
+            }
+
+            out[base] = c[0];
+            out[base + 1] = c[1];
+            out[base + 2] = c[2];
+        }
+    }
+    out
+}
+
+fn assert_close(actual: &[f32], expected: &[f32], tol: f32, what: &str) {
+    assert_eq!(actual.len(), expected.len(), "{what}: length mismatch");
+    let mut max_err = 0.0f32;
+    let mut max_at = 0;
+    for (i, (a, e)) in actual.iter().zip(expected).enumerate() {
+        let err = (a - e).abs();
+        if err > max_err {
+            max_err = err;
+            max_at = i;
+        }
+    }
+    assert!(
+        max_err <= tol,
+        "{what}: max err {max_err} at {max_at} (got {}, want {}), tol {tol}",
+        actual[max_at],
+        expected[max_at]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Bilateral grid tests
+// ---------------------------------------------------------------------------
+
+#[wasm_bindgen_test(unsupported = tokio::test)]
+async fn bilagrid_identity_grid_is_noop() {
+    let device = ad_device().await;
+    let (h, w) = (17, 23);
+    let model = BilagridModel::new(3, 8, 8, 4, &device);
+    let rgb_data = pattern(h * w * 3, 7, 0.0, 1.0);
+    let rgb = Tensor::<1>::from_floats(rgb_data.as_slice(), &device).reshape([h, w, 3]);
+
+    let out = model.apply(rgb.clone(), 1);
+    let out_v = read_vec(out).await;
+    assert_close(&out_v, &rgb_data, 1e-5, "identity bilagrid");
+}
+
+#[wasm_bindgen_test(unsupported = tokio::test)]
+async fn bilagrid_slice_matches_cpu_reference() {
+    let device = ad_device().await;
+    let (h, w) = (15, 21);
+    let (gx, gy, gl) = (6, 5, 4);
+    let n = 2;
+    let view = 1;
+
+    let grids_data = pattern(n * 12 * gl * gy * gx, 3, -0.6, 1.2);
+    let rgb_data = pattern(h * w * 3, 11, 0.0, 1.0);
+
+    let grids =
+        Tensor::<1>::from_floats(grids_data.as_slice(), &device).reshape([n, 12, gl, gy, gx]);
+    let rgb = Tensor::<1>::from_floats(rgb_data.as_slice(), &device).reshape([h, w, 3]);
+
+    let out = bilagrid_apply(grids, rgb, view, GradSubsample::default());
+    let out_v = read_vec(out).await;
+
+    let view_grid = &grids_data[view * 12 * gl * gy * gx..(view + 1) * 12 * gl * gy * gx];
+    let expected = bilagrid_slice_cpu(view_grid, &rgb_data, gl, gy, gx, h, w);
+    assert_close(&out_v, &expected, 1e-4, "bilagrid slice vs cpu");
+}
+
+#[wasm_bindgen_test(unsupported = tokio::test)]
+async fn bilagrid_alpha_passthrough() {
+    let device = ad_device().await;
+    let (h, w) = (9, 13);
+    let model = BilagridModel::new(1, 4, 4, 2, &device);
+    let rgba_data = pattern(h * w * 4, 5, 0.0, 1.0);
+    let rgba = Tensor::<1>::from_floats(rgba_data.as_slice(), &device).reshape([h, w, 4]);
+
+    let out = model.apply(rgba, 0);
+    let out_v = read_vec(out).await;
+    for i in 0..h * w {
+        let a_in = rgba_data[i * 4 + 3];
+        let a_out = out_v[i * 4 + 3];
+        assert!(
+            (a_in - a_out).abs() < 1e-6,
+            "alpha not passed through at {i}: {a_in} vs {a_out}"
+        );
+    }
+}
+
+#[wasm_bindgen_test(unsupported = tokio::test)]
+async fn bilagrid_tv_matches_cpu_reference() {
+    let device = ad_device().await;
+    let (gx, gy, gl) = (5, 4, 3);
+    let n = 3;
+    let grids_data = pattern(n * 12 * gl * gy * gx, 13, -1.0, 1.0);
+    let grids =
+        Tensor::<1>::from_floats(grids_data.as_slice(), &device).reshape([n, 12, gl, gy, gx]);
+
+    let tv = bilagrid_tv_loss(grids)
+        .into_data_async()
+        .await
+        .expect("readback")
+        .to_vec::<f32>()
+        .expect("vec")[0];
+    let expected = bilagrid_tv_cpu(&grids_data, n, gl, gy, gx);
+    assert!(
+        (tv - expected).abs() < 1e-4 * expected.abs().max(1.0),
+        "tv {tv} vs cpu {expected}"
+    );
+}
+
+#[wasm_bindgen_test(unsupported = tokio::test)]
+async fn bilagrid_gradients_match_finite_differences() {
+    let device = ad_device().await;
+    let (h, w) = (9, 11);
+    let (gx, gy, gl) = (4, 4, 3);
+    let n = 2;
+    let view = 0;
+
+    let grids_data = pattern(n * 12 * gl * gy * gx, 17, -0.4, 1.1);
+    let rgb_data = pattern(h * w * 3, 19, 0.05, 0.95);
+    // Loss weights make dL/dout vary per pixel.
+    let wts_data = pattern(h * w * 3, 23, -1.0, 1.0);
+
+    let make_grids = |d: &[f32]| Tensor::<1>::from_floats(d, &device).reshape([n, 12, gl, gy, gx]);
+    let make_rgb = |d: &[f32]| Tensor::<1>::from_floats(d, &device).reshape([h, w, 3]);
+    let wts = Tensor::<1>::from_floats(wts_data.as_slice(), &device).reshape([h, w, 3]);
+
+    // Analytic gradients.
+    let grids = make_grids(&grids_data).require_grad();
+    let rgb = make_rgb(&rgb_data).require_grad();
+    let out = bilagrid_apply(grids.clone(), rgb.clone(), view, GradSubsample::default());
+    let loss = (out * wts.clone()).sum();
+    let grads = loss.backward();
+    let g_grids: Vec<f32> = grids
+        .grad(&grads)
+        .expect("grids grad")
+        .into_data_async()
+        .await
+        .expect("rb")
+        .to_vec()
+        .expect("vec");
+    let g_rgb: Vec<f32> = rgb
+        .grad(&grads)
+        .expect("rgb grad")
+        .into_data_async()
+        .await
+        .expect("rb")
+        .to_vec()
+        .expect("vec");
+
+    // Finite differences on a scattering of indices.
+    let loss_for = |gd: &[f32], rd: &[f32]| {
+        let out = bilagrid_apply(make_grids(gd), make_rgb(rd), view, GradSubsample::default());
+        (out * wts.clone()).sum()
+    };
+    let eps = 2e-3;
+    for idx in [0usize, 7, 101, 333, 12 * gl * gy * gx - 5] {
+        let mut plus = grids_data.clone();
+        plus[idx] += eps;
+        let mut minus = grids_data.clone();
+        minus[idx] -= eps;
+        let lp = loss_for(&plus, &rgb_data)
+            .into_scalar_async::<f32>()
+            .await
+            .expect("lp");
+        let lm = loss_for(&minus, &rgb_data)
+            .into_scalar_async::<f32>()
+            .await
+            .expect("lm");
+        let fd = (lp - lm) / (2.0 * eps);
+        assert!(
+            (fd - g_grids[idx]).abs() < 2e-2 * fd.abs().max(1.0),
+            "grid grad mismatch at {idx}: analytic {} vs fd {fd}",
+            g_grids[idx]
+        );
+    }
+    for idx in [4usize, 50, 151] {
+        let mut plus = rgb_data.clone();
+        plus[idx] += eps;
+        let mut minus = rgb_data.clone();
+        minus[idx] -= eps;
+        let lp = loss_for(&grids_data, &plus)
+            .into_scalar_async::<f32>()
+            .await
+            .expect("lp");
+        let lm = loss_for(&grids_data, &minus)
+            .into_scalar_async::<f32>()
+            .await
+            .expect("lm");
+        let fd = (lp - lm) / (2.0 * eps);
+        assert!(
+            (fd - g_rgb[idx]).abs() < 2e-2 * fd.abs().max(1.0),
+            "rgb grad mismatch at {idx}: analytic {} vs fd {fd}",
+            g_rgb[idx]
+        );
+    }
+}
+
+#[wasm_bindgen_test(unsupported = tokio::test)]
+async fn bilagrid_tv_gradients_match_finite_differences() {
+    let device = ad_device().await;
+    let (gx, gy, gl) = (4, 3, 3);
+    let n = 2;
+    let grids_data = pattern(n * 12 * gl * gy * gx, 29, -0.8, 0.8);
+    let make_grids = |d: &[f32]| Tensor::<1>::from_floats(d, &device).reshape([n, 12, gl, gy, gx]);
+
+    let grids = make_grids(&grids_data).require_grad();
+    let loss = bilagrid_tv_loss(grids.clone());
+    let grads = loss.backward();
+    let g: Vec<f32> = grids
+        .grad(&grads)
+        .expect("grad")
+        .into_data_async()
+        .await
+        .expect("rb")
+        .to_vec()
+        .expect("vec");
+
+    let eps = 1e-2;
+    for idx in [0usize, 13, 200, n * 12 * gl * gy * gx - 1] {
+        let mut plus = grids_data.clone();
+        plus[idx] += eps;
+        let mut minus = grids_data.clone();
+        minus[idx] -= eps;
+        let lp = bilagrid_tv_loss(make_grids(&plus))
+            .into_scalar_async::<f32>()
+            .await
+            .expect("lp");
+        let lm = bilagrid_tv_loss(make_grids(&minus))
+            .into_scalar_async::<f32>()
+            .await
+            .expect("lm");
+        let fd = (lp - lm) / (2.0 * eps);
+        assert!(
+            (fd - g[idx]).abs() < 2e-2 * fd.abs().max(0.1),
+            "tv grad mismatch at {idx}: analytic {} vs fd {fd}",
+            g[idx]
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PPISP tests
+// ---------------------------------------------------------------------------
+
+struct PpispTestData {
+    exposure: Vec<f32>,
+    vignetting: Vec<f32>,
+    color: Vec<f32>,
+    crf: Vec<f32>,
+    rgb: Vec<f32>,
+    num_frames: usize,
+    num_cameras: usize,
+    h: usize,
+    w: usize,
+}
+
+fn ppisp_test_data(h: usize, w: usize) -> PpispTestData {
+    let num_frames = 3;
+    let num_cameras = 2;
+    let mut crf = pattern(num_cameras * 12, 41, -0.3, 0.3);
+    // Bias CRF toward the identity-ish init region.
+    for (i, v) in crf.iter_mut().enumerate() {
+        match i % 4 {
+            0 | 1 => *v += 0.0137,
+            2 => *v += 0.3781,
+            _ => {}
+        }
+    }
+    // Vignetting: small centers, clearly-negative alphas. Keeps the falloff
+    // strictly inside the (0, 1) clamp so finite differences don't straddle
+    // the clamp's gradient gate (the subgradient there matches the CUDA
+    // reference but is not FD-measurable).
+    let centers = pattern(num_cameras * 6, 36, -0.1, 0.1);
+    let alphas = pattern(num_cameras * 9, 37, -0.5, -0.05);
+    let mut vignetting = Vec::with_capacity(num_cameras * 15);
+    for i in 0..num_cameras * 3 {
+        vignetting.extend_from_slice(&centers[i * 2..i * 2 + 2]);
+        vignetting.extend_from_slice(&alphas[i * 3..i * 3 + 3]);
+    }
+    PpispTestData {
+        exposure: pattern(num_frames, 31, -0.3, 0.3),
+        vignetting,
+        color: pattern(num_frames * 8, 39, -0.5, 0.5),
+        crf,
+        rgb: pattern(h * w * 3, 43, 0.05, 0.95),
+        num_frames,
+        num_cameras,
+        h,
+        w,
+    }
+}
+
+#[allow(clippy::type_complexity)]
+fn ppisp_tensors(
+    d: &PpispTestData,
+    device: &Device,
+) -> (Tensor<1>, Tensor<3>, Tensor<2>, Tensor<3>, Tensor<3>) {
+    (
+        Tensor::<1>::from_floats(d.exposure.as_slice(), device),
+        Tensor::<1>::from_floats(d.vignetting.as_slice(), device).reshape([d.num_cameras, 3, 5]),
+        Tensor::<1>::from_floats(d.color.as_slice(), device).reshape([d.num_frames, 8]),
+        Tensor::<1>::from_floats(d.crf.as_slice(), device).reshape([d.num_cameras, 3, 4]),
+        Tensor::<1>::from_floats(d.rgb.as_slice(), device).reshape([d.h, d.w, 3]),
+    )
+}
+
+#[wasm_bindgen_test(unsupported = tokio::test)]
+async fn ppisp_identity_init_is_near_noop() {
+    let device = ad_device().await;
+    let (h, w) = (12, 16);
+    let model = PpispModel::new(1, 2, vec![0, 0], &device);
+    let rgb_data = pattern(h * w * 3, 47, 0.05, 0.95);
+    let rgb = Tensor::<1>::from_floats(rgb_data.as_slice(), &device).reshape([h, w, 3]);
+
+    let out = model.apply(rgb, 1);
+    let out_v = read_vec(out).await;
+    // Zero-init exposure/vignetting/color and identity CRF — output should
+    // match the input closely (CRF identity init is exact: toe=shoulder=
+    // gamma=1, center=0.5 gives y = x).
+    assert_close(&out_v, &rgb_data, 1e-4, "ppisp identity");
+}
+
+#[wasm_bindgen_test(unsupported = tokio::test)]
+async fn ppisp_matches_cpu_reference() {
+    let device = ad_device().await;
+    let (h, w) = (13, 19);
+    let d = ppisp_test_data(h, w);
+    let (exposure, vignetting, color, crf, rgb) = ppisp_tensors(&d, &device);
+    let (camera_idx, frame_idx) = (1usize, 2usize);
+
+    let out = ppisp_apply(
+        exposure,
+        vignetting,
+        color,
+        crf,
+        rgb,
+        camera_idx,
+        frame_idx,
+        PpispStages::ALL,
+    );
+    let out_v = read_vec(out).await;
+
+    let expected = ppisp_cpu(
+        d.exposure[frame_idx],
+        &d.vignetting[camera_idx * 15..camera_idx * 15 + 15],
+        &d.color[frame_idx * 8..frame_idx * 8 + 8],
+        &d.crf[camera_idx * 12..camera_idx * 12 + 12],
+        &d.rgb,
+        h,
+        w,
+        true,
+    );
+    assert_close(&out_v, &expected, 1e-4, "ppisp vs cpu");
+}
+
+#[wasm_bindgen_test(unsupported = tokio::test)]
+async fn ppisp_gradients_match_finite_differences() {
+    let device = ad_device().await;
+    let (h, w) = (11, 14);
+    let d = ppisp_test_data(h, w);
+    let (camera_idx, frame_idx) = (0usize, 1usize);
+    let wts_data = pattern(h * w * 3, 53, -1.0, 1.0);
+    let wts = Tensor::<1>::from_floats(wts_data.as_slice(), &device).reshape([h, w, 3]);
+
+    // Analytic gradients.
+    let (exposure, vignetting, color, crf, rgb) = ppisp_tensors(&d, &device);
+    let exposure = exposure.require_grad();
+    let vignetting = vignetting.require_grad();
+    let color = color.require_grad();
+    let crf = crf.require_grad();
+    let rgb = rgb.require_grad();
+    let out = ppisp_apply(
+        exposure.clone(),
+        vignetting.clone(),
+        color.clone(),
+        crf.clone(),
+        rgb.clone(),
+        camera_idx,
+        frame_idx,
+        PpispStages::ALL,
+    );
+    let loss = (out * wts.clone()).sum();
+    let grads = loss.backward();
+
+    let read1 = |t: Option<Tensor<1>>| t.expect("grad");
+    let g_exp: Vec<f32> = read1(exposure.grad(&grads))
+        .into_data_async()
+        .await
+        .expect("rb")
+        .to_vec()
+        .expect("v");
+    let g_vig: Vec<f32> = vignetting
+        .grad(&grads)
+        .expect("grad")
+        .into_data_async()
+        .await
+        .expect("rb")
+        .to_vec()
+        .expect("v");
+    let g_color: Vec<f32> = color
+        .grad(&grads)
+        .expect("grad")
+        .into_data_async()
+        .await
+        .expect("rb")
+        .to_vec()
+        .expect("v");
+    let g_crf: Vec<f32> = crf
+        .grad(&grads)
+        .expect("grad")
+        .into_data_async()
+        .await
+        .expect("rb")
+        .to_vec()
+        .expect("v");
+    let g_rgb: Vec<f32> = rgb
+        .grad(&grads)
+        .expect("grad")
+        .into_data_async()
+        .await
+        .expect("rb")
+        .to_vec()
+        .expect("v");
+
+    // Gradients for non-active frames/cameras must be zero.
+    for f in 0..d.num_frames {
+        if f != frame_idx {
+            assert_eq!(g_exp[f], 0.0, "inactive frame {f} exposure grad");
+            for k in 0..8 {
+                assert_eq!(g_color[f * 8 + k], 0.0, "inactive frame color grad");
+            }
+        }
+    }
+    for c in 0..d.num_cameras {
+        if c != camera_idx {
+            for k in 0..15 {
+                assert_eq!(g_vig[c * 15 + k], 0.0, "inactive camera vig grad");
+            }
+            for k in 0..12 {
+                assert_eq!(g_crf[c * 12 + k], 0.0, "inactive camera crf grad");
+            }
+        }
+    }
+
+    // Finite differences through the forward (f64-accumulated CPU loss for
+    // stability of the comparison would be ideal; GPU forward is enough at
+    // these sizes).
+    let loss_for = |e: &[f32], v: &[f32], co: &[f32], cr: &[f32], r: &[f32]| {
+        let exposure = Tensor::<1>::from_floats(e, &device);
+        let vignetting = Tensor::<1>::from_floats(v, &device).reshape([d.num_cameras, 3, 5]);
+        let color = Tensor::<1>::from_floats(co, &device).reshape([d.num_frames, 8]);
+        let crf = Tensor::<1>::from_floats(cr, &device).reshape([d.num_cameras, 3, 4]);
+        let rgb = Tensor::<1>::from_floats(r, &device).reshape([h, w, 3]);
+        let out = ppisp_apply(
+            exposure,
+            vignetting,
+            color,
+            crf,
+            rgb,
+            camera_idx,
+            frame_idx,
+            PpispStages::ALL,
+        );
+        (out * wts.clone()).sum()
+    };
+
+    let eps = 1e-3;
+    let check = |name: &str, analytic: f32, fd: f32| {
+        assert!(
+            (fd - analytic).abs() < 3e-2 * fd.abs().max(0.5),
+            "{name}: analytic {analytic} vs fd {fd}"
+        );
+    };
+
+    // Exposure (active frame).
+    {
+        let mut p = d.exposure.clone();
+        p[frame_idx] += eps;
+        let mut m = d.exposure.clone();
+        m[frame_idx] -= eps;
+        let lp = loss_for(&p, &d.vignetting, &d.color, &d.crf, &d.rgb)
+            .into_scalar_async::<f32>()
+            .await
+            .expect("lp");
+        let lm = loss_for(&m, &d.vignetting, &d.color, &d.crf, &d.rgb)
+            .into_scalar_async::<f32>()
+            .await
+            .expect("lm");
+        check("exposure", g_exp[frame_idx], (lp - lm) / (2.0 * eps));
+    }
+    // Vignetting (every param of the active camera).
+    for k in 0..15 {
+        let idx = camera_idx * 15 + k;
+        let mut p = d.vignetting.clone();
+        p[idx] += eps;
+        let mut m = d.vignetting.clone();
+        m[idx] -= eps;
+        let lp = loss_for(&d.exposure, &p, &d.color, &d.crf, &d.rgb)
+            .into_scalar_async::<f32>()
+            .await
+            .expect("lp");
+        let lm = loss_for(&d.exposure, &m, &d.color, &d.crf, &d.rgb)
+            .into_scalar_async::<f32>()
+            .await
+            .expect("lm");
+        check(&format!("vig[{k}]"), g_vig[idx], (lp - lm) / (2.0 * eps));
+    }
+    // Color (every latent of the active frame).
+    for k in 0..8 {
+        let idx = frame_idx * 8 + k;
+        let mut p = d.color.clone();
+        p[idx] += eps;
+        let mut m = d.color.clone();
+        m[idx] -= eps;
+        let lp = loss_for(&d.exposure, &d.vignetting, &p, &d.crf, &d.rgb)
+            .into_scalar_async::<f32>()
+            .await
+            .expect("lp");
+        let lm = loss_for(&d.exposure, &d.vignetting, &m, &d.crf, &d.rgb)
+            .into_scalar_async::<f32>()
+            .await
+            .expect("lm");
+        check(
+            &format!("color[{k}]"),
+            g_color[idx],
+            (lp - lm) / (2.0 * eps),
+        );
+    }
+    // CRF (every raw param of the active camera).
+    for k in 0..12 {
+        let idx = camera_idx * 12 + k;
+        let mut p = d.crf.clone();
+        p[idx] += eps;
+        let mut m = d.crf.clone();
+        m[idx] -= eps;
+        let lp = loss_for(&d.exposure, &d.vignetting, &d.color, &p, &d.rgb)
+            .into_scalar_async::<f32>()
+            .await
+            .expect("lp");
+        let lm = loss_for(&d.exposure, &d.vignetting, &d.color, &m, &d.rgb)
+            .into_scalar_async::<f32>()
+            .await
+            .expect("lm");
+        check(&format!("crf[{k}]"), g_crf[idx], (lp - lm) / (2.0 * eps));
+    }
+    // RGB (a few pixels).
+    for idx in [0usize, 77, 311] {
+        let mut p = d.rgb.clone();
+        p[idx] += eps;
+        let mut m = d.rgb.clone();
+        m[idx] -= eps;
+        let lp = loss_for(&d.exposure, &d.vignetting, &d.color, &d.crf, &p)
+            .into_scalar_async::<f32>()
+            .await
+            .expect("lp");
+        let lm = loss_for(&d.exposure, &d.vignetting, &d.color, &d.crf, &m)
+            .into_scalar_async::<f32>()
+            .await
+            .expect("lm");
+        check(&format!("rgb[{idx}]"), g_rgb[idx], (lp - lm) / (2.0 * eps));
+    }
+}
+
+#[wasm_bindgen_test(unsupported = tokio::test)]
+async fn ppisp_reg_loss_zero_at_init_and_positive_off_init() {
+    let device = ad_device().await;
+    let model = PpispModel::new(2, 4, vec![0, 0, 1, 1], &device);
+    let loss = model
+        .reg_loss()
+        .into_scalar_async::<f32>()
+        .await
+        .expect("loss");
+    // At init: exposure/color/vignetting are zero and CRF is identical
+    // across channels → every term vanishes.
+    assert!(
+        loss.abs() < 1e-6,
+        "reg loss at init should be 0, got {loss}"
+    );
+
+    // Perturbed params produce a positive loss.
+    let mut model = model;
+    model.exposure =
+        burn::module::Param::from_tensor(Tensor::<1>::from_floats([0.5, 0.4, 0.3, 0.2], &device));
+    let loss = model
+        .reg_loss()
+        .into_scalar_async::<f32>()
+        .await
+        .expect("loss");
+    assert!(
+        loss > 1e-4,
+        "reg loss should penalise exposure mean, got {loss}"
+    );
+}
+
+#[wasm_bindgen_test(unsupported = tokio::test)]
+async fn ppisp_module_keeps_camera_mapping() {
+    let device = ad_device().await;
+    let model = PpispModel::new(2, 3, vec![0, 1, 1], &device);
+    let _ = TensorData::new(vec![0.0f32], [1]);
+    assert_eq!(model.camera_indices, vec![0, 1, 1]);
+}
+
+/// Rough kernel timing split (run with --nocapture --ignored).
+#[tokio::test]
+#[ignore = "manual benchmark"]
+async fn bench_bilagrid_kernels() {
+    let device = ad_device().await;
+    let (h, w) = (1080, 1080);
+    let (gx, gy, gl) = (16, 16, 8);
+    let n = 1;
+    let grids_data = pattern(n * 12 * gl * gy * gx, 3, -0.5, 1.0);
+    let rgb_data = pattern(h * w * 4, 11, 0.0, 1.0);
+    let grids =
+        Tensor::<1>::from_floats(grids_data.as_slice(), &device).reshape([n, 12, gl, gy, gx]);
+    let rgb = Tensor::<1>::from_floats(rgb_data.as_slice(), &device).reshape([h, w, 4]);
+
+    let sync = |t: Tensor<3>| async move {
+        let _ = t
+            .slice(burn::tensor::s![0..1, 0..1])
+            .into_data_async()
+            .await;
+    };
+
+    // Warmup.
+    for _ in 0..10 {
+        let out = bilagrid_apply(grids.clone(), rgb.clone(), 0, GradSubsample::default());
+        sync(out).await;
+    }
+    let iters = 100;
+
+    // Forward only.
+    let start = std::time::Instant::now();
+    for _ in 0..iters {
+        let out = bilagrid_apply(grids.clone(), rgb.clone(), 0, GradSubsample::default());
+        std::hint::black_box(&out);
+    }
+    let out = bilagrid_apply(grids.clone(), rgb.clone(), 0, GradSubsample::default());
+    sync(out).await;
+    println!(
+        "fwd: {:.3} ms/iter",
+        start.elapsed().as_secs_f64() * 1000.0 / (iters + 1) as f64
+    );
+
+    // Forward + backward.
+    let start = std::time::Instant::now();
+    for _ in 0..iters {
+        let g = grids.clone().require_grad();
+        let r = rgb.clone().require_grad();
+        let out = bilagrid_apply(g, r, 0, GradSubsample::default());
+        let loss = out.sum();
+        let _grads = loss.backward();
+    }
+    let g = grids.clone().require_grad();
+    let out = bilagrid_apply(g.clone(), rgb.clone(), 0, GradSubsample::default());
+    let loss = out.sum();
+    let grads = loss.backward();
+    let _ = g.grad(&grads).unwrap().into_data_async().await;
+    println!(
+        "fwd+bwd: {:.3} ms/iter",
+        start.elapsed().as_secs_f64() * 1000.0 / (iters + 1) as f64
+    );
+
+    // Raw backward kernel only (no autodiff plumbing).
+    let rgb_smooth_data: Vec<f32> = (0..h * w * 4)
+        .map(|i| {
+            let px = (i / 4) % w;
+            let py = (i / 4) / w;
+            (px + py) as f32 / (w + h) as f32
+        })
+        .collect();
+    let rgb_smooth =
+        Tensor::<1>::from_floats(rgb_smooth_data.as_slice(), &device).reshape([h, w, 4]);
+    for (name, img) in [("noise", rgb.clone()), ("smooth", rgb_smooth)] {
+        use brush_appearance::bilagrid::BilagridOps;
+        use brush_cube::MainBackend;
+        use brush_render::burn_glue::{unwrap_ad_wgpu_float, wrap_wgpu_float};
+        let grids_p = unwrap_ad_wgpu_float(grids.clone()).primitive;
+        let rgb_p = unwrap_ad_wgpu_float(img.clone()).primitive;
+        let v_out_p = unwrap_ad_wgpu_float(img.clone()).primitive;
+        // Warmup
+        for _ in 0..5 {
+            let (gg, _gr) = <MainBackend as BilagridOps<MainBackend>>::bilagrid_slice_bwd(
+                grids_p.clone(),
+                rgb_p.clone(),
+                v_out_p.clone(),
+                0,
+                GradSubsample::default(),
+            );
+            let t: Tensor<5> = wrap_wgpu_float(gg);
+            let _ = t
+                .slice(burn::tensor::s![0..1, 0..1, 0..1, 0..1, 0..1])
+                .into_data_async()
+                .await;
+        }
+        let start = std::time::Instant::now();
+        for _ in 0..iters {
+            let (gg, _gr) = <MainBackend as BilagridOps<MainBackend>>::bilagrid_slice_bwd(
+                grids_p.clone(),
+                rgb_p.clone(),
+                v_out_p.clone(),
+                0,
+                GradSubsample::default(),
+            );
+            std::hint::black_box(&gg);
+        }
+        let (gg, _gr) = <MainBackend as BilagridOps<MainBackend>>::bilagrid_slice_bwd(
+            grids_p.clone(),
+            rgb_p.clone(),
+            v_out_p.clone(),
+            0,
+            GradSubsample::default(),
+        );
+        let t: Tensor<5> = wrap_wgpu_float(gg);
+        let _ = t
+            .slice(burn::tensor::s![0..1, 0..1, 0..1, 0..1, 0..1])
+            .into_data_async()
+            .await;
+        println!(
+            "raw bwd kernel ({name}): {:.3} ms/iter",
+            start.elapsed().as_secs_f64() * 1000.0 / (iters + 1) as f64
+        );
+    }
+
+    // TV fwd+bwd on a 200-view grid.
+    let big = Tensor::<5>::zeros([200, 12, gl, gy, gx], &device);
+    let start = std::time::Instant::now();
+    for _ in 0..iters {
+        let g = big.clone().require_grad();
+        let loss = bilagrid_tv_loss(g);
+        let _grads = loss.backward();
+    }
+    let g = big.clone().require_grad();
+    let loss = bilagrid_tv_loss(g.clone());
+    let grads = loss.backward();
+    let _ = g.grad(&grads).unwrap().into_data_async().await;
+    println!(
+        "tv (200 views) fwd+bwd: {:.3} ms/iter",
+        start.elapsed().as_secs_f64() * 1000.0 / (iters + 1) as f64
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Hybrid PPISP-grid tests
+// ---------------------------------------------------------------------------
+
+use brush_appearance::ppisp_grid::{GridPayload, ppisp_grid_apply};
+
+const CRF_IDENT: [f32; 4] = [0.013_658_988, 0.013_658_988, 0.378_164_53, 0.0];
+
+/// CPU reference: per-camera vignetting, then slice a C-channel payload
+/// grid at the vignetted color's guidance, then exposure → color → CRF
+/// (per the payload flags).
+// tuple_array_conversions: clippy 1.93 false-positives on `[sr, sg, sb]`.
+#[allow(clippy::too_many_arguments, clippy::tuple_array_conversions)]
+fn ppisp_grid_cpu(
+    grid: &[f32],       // [C, L, H, W] single view
+    vignetting: &[f32], // [3, 5] for the active camera
+    rgb: &[f32],        // [h, w, 3]
+    payload: GridPayload,
+    gl: usize,
+    gh: usize,
+    gw: usize,
+    h: usize,
+    w: usize,
+) -> Vec<f32> {
+    let pc = payload.channels();
+    let cell = gl * gh * gw;
+    let mut out = vec![0.0f32; h * w * 3];
+    for hi in 0..h {
+        for wi in 0..w {
+            let base = (hi * w + wi) * 3;
+            let (mut sr, mut sg, mut sb) = (rgb[base], rgb[base + 1], rgb[base + 2]);
+            if payload.vignetting {
+                let max_res = (w as f32).max(h as f32);
+                let uvx = (wi as f32 + 0.5 - w as f32 * 0.5) / max_res;
+                let uvy = (hi as f32 + 0.5 - h as f32 * 0.5) / max_res;
+                let mut c = [sr, sg, sb];
+                for (ch, v) in c.iter_mut().enumerate() {
+                    let p = &vignetting[ch * 5..ch * 5 + 5];
+                    let dx = uvx - p[0];
+                    let dy = uvy - p[1];
+                    let r2 = dx * dx + dy * dy;
+                    let falloff =
+                        (1.0 + p[2] * r2 + p[3] * r2 * r2 + p[4] * r2 * r2 * r2).clamp(0.0, 1.0);
+                    *v *= falloff;
+                }
+                sr = c[0];
+                sg = c[1];
+                sb = c[2];
+            }
+            let x = wi as f32 / (w - 1).max(1) as f32 * (gw - 1) as f32;
+            let y = hi as f32 / (h - 1).max(1) as f32 * (gh - 1) as f32;
+            let z = (C2G[0] * sr + C2G[1] * sg + C2G[2] * sb) * (gl - 1) as f32;
+            let x0 = x.floor() as usize;
+            let y0 = y.floor() as usize;
+            let x1 = (x0 + 1).min(gw - 1);
+            let y1 = (y0 + 1).min(gh - 1);
+            let z0i = z.floor() as i64;
+            let z0 = z0i.clamp(0, gl as i64 - 1) as usize;
+            let z1 = (z0i + 1).clamp(0, gl as i64 - 1) as usize;
+            let fx = x - x.floor();
+            let fy = y - y.floor();
+            let fz = z - z0 as f32;
+
+            let mut p = vec![0.0f32; pc];
+            for (ci, pv) in p.iter_mut().enumerate() {
+                let g =
+                    |zz: usize, yy: usize, xx: usize| grid[ci * cell + (zz * gh + yy) * gw + xx];
+                let c00 = g(z0, y0, x0) * (1.0 - fx) + g(z0, y0, x1) * fx;
+                let c01 = g(z0, y1, x0) * (1.0 - fx) + g(z0, y1, x1) * fx;
+                let c10 = g(z1, y0, x0) * (1.0 - fx) + g(z1, y0, x1) * fx;
+                let c11 = g(z1, y1, x0) * (1.0 - fx) + g(z1, y1, x1) * fx;
+                let c0 = c00 * (1.0 - fy) + c01 * fy;
+                let c1 = c10 * (1.0 - fy) + c11 * fy;
+                *pv = c0 * (1.0 - fz) + c1 * fz;
+            }
+
+            // Build a full PPISP param set: exposure + (color) + (CRF with
+            // identity offsets), reuse the full-pipeline CPU reference with
+            // vignetting zeroed via cx=cy=alphas=0 (falloff = 1).
+            let exposure = p[0];
+            let mut color = [0.0f32; 8];
+            if payload.color {
+                color.copy_from_slice(&p[1..9]);
+            }
+            let kb = if payload.color { 9 } else { 1 };
+            let mut crf = [0.0f32; 12];
+            for ch in 0..3 {
+                for k in 0..4 {
+                    crf[ch * 4 + k] =
+                        CRF_IDENT[k] + if payload.crf { p[kb + ch * 4 + k] } else { 0.0 };
+                }
+            }
+            // Vignetting was applied above (before slicing); the pipeline
+            // here starts at the exposure stage. Without the CRF stage the
+            // kernel does not clamp the output.
+            let zero_vig = [0.0f32; 15];
+            let sliced_rgb = [sr, sg, sb];
+            let px = ppisp_cpu(
+                exposure,
+                &zero_vig,
+                &color,
+                &crf,
+                &sliced_rgb,
+                1,
+                1,
+                payload.crf,
+            );
+            out[base] = px[0];
+            out[base + 1] = px[1];
+            out[base + 2] = px[2];
+        }
+    }
+    out
+}
+
+#[wasm_bindgen_test(unsupported = tokio::test)]
+async fn ppisp_grid_zero_is_identity() {
+    let device = ad_device().await;
+    let (h, w) = (14, 18);
+    let (gx, gy, gl) = (6, 5, 4);
+    let rgb_data = pattern(h * w * 3, 61, 0.05, 0.95);
+    let rgb = Tensor::<1>::from_floats(rgb_data.as_slice(), &device).reshape([h, w, 3]);
+
+    for payload in [
+        GridPayload {
+            color: false,
+            crf: false,
+            vignetting: false,
+        },
+        GridPayload {
+            color: true,
+            crf: false,
+            vignetting: false,
+        },
+        GridPayload {
+            color: true,
+            crf: true,
+            vignetting: true,
+        },
+    ] {
+        let grids = Tensor::zeros([2, payload.channels(), gl, gy, gx], &device);
+        // Zero vignetting params are an identity falloff.
+        let vig = Tensor::zeros([1, 3, 5], &device);
+        let out = ppisp_grid_apply(
+            grids,
+            vig,
+            rgb.clone(),
+            1,
+            0,
+            payload,
+            GradSubsample::default(),
+        );
+        let out_v = read_vec(out).await;
+        assert_close(&out_v, &rgb_data, 2e-4, &format!("identity {payload:?}"));
+    }
+}
+
+#[wasm_bindgen_test(unsupported = tokio::test)]
+async fn ppisp_grid_matches_cpu_reference() {
+    let device = ad_device().await;
+    let (h, w) = (13, 17);
+    let (gx, gy, gl) = (5, 4, 3);
+    let n = 2;
+    let view = 1;
+    let rgb_data = pattern(h * w * 3, 67, 0.05, 0.95);
+    let rgb = Tensor::<1>::from_floats(rgb_data.as_slice(), &device).reshape([h, w, 3]);
+
+    // Vignetting data shared by the vignetting-enabled payloads: small
+    // centers, clearly-negative alphas (away from the falloff clamp).
+    let centers = pattern(6, 36, -0.1, 0.1);
+    let alphas = pattern(9, 37, -0.5, -0.05);
+    let mut vig_data = vec![0.0f32; 15];
+    for ch in 0..3 {
+        vig_data[ch * 5] = centers[ch * 2];
+        vig_data[ch * 5 + 1] = centers[ch * 2 + 1];
+        vig_data[ch * 5 + 2..ch * 5 + 5].copy_from_slice(&alphas[ch * 3..ch * 3 + 3]);
+    }
+
+    for payload in [
+        GridPayload {
+            color: false,
+            crf: false,
+            vignetting: false,
+        },
+        GridPayload {
+            color: true,
+            crf: false,
+            vignetting: false,
+        },
+        GridPayload {
+            color: true,
+            crf: false,
+            vignetting: true,
+        },
+        GridPayload {
+            color: true,
+            crf: true,
+            vignetting: true,
+        },
+    ] {
+        let pc = payload.channels();
+        // Small payload values keep the homography/CRF well-conditioned.
+        let grids_data = pattern(n * pc * gl * gy * gx, 71, -0.25, 0.25);
+        let grids =
+            Tensor::<1>::from_floats(grids_data.as_slice(), &device).reshape([n, pc, gl, gy, gx]);
+        let vig = Tensor::<1>::from_floats(vig_data.as_slice(), &device).reshape([1, 3, 5]);
+        let out = ppisp_grid_apply(
+            grids,
+            vig,
+            rgb.clone(),
+            view,
+            0,
+            payload,
+            GradSubsample::default(),
+        );
+        let out_v = read_vec(out).await;
+
+        let view_grid = &grids_data[view * pc * gl * gy * gx..(view + 1) * pc * gl * gy * gx];
+        let expected = ppisp_grid_cpu(view_grid, &vig_data, &rgb_data, payload, gl, gy, gx, h, w);
+        assert_close(&out_v, &expected, 3e-4, &format!("grid vs cpu {payload:?}"));
+    }
+}
+
+#[wasm_bindgen_test(unsupported = tokio::test)]
+async fn ppisp_grid_gradients_match_finite_differences() {
+    let device = ad_device().await;
+    let (h, w) = (9, 11);
+    let (gx, gy, gl) = (4, 3, 3);
+    let n = 1;
+    let view = 0;
+    let payload = GridPayload {
+        color: true,
+        crf: true,
+        vignetting: true,
+    };
+    let pc = payload.channels();
+
+    let grids_data = pattern(n * pc * gl * gy * gx, 73, -0.2, 0.2);
+    let rgb_data = pattern(h * w * 3, 79, 0.1, 0.9);
+    let wts_data = pattern(h * w * 3, 83, -1.0, 1.0);
+    let wts = Tensor::<1>::from_floats(wts_data.as_slice(), &device).reshape([h, w, 3]);
+    // Two cameras; camera 1 is active. Clearly-negative alphas keep the
+    // falloff away from its clamp (where FD can't measure the subgradient).
+    let cam = 1usize;
+    let centers = pattern(12, 101, -0.1, 0.1);
+    let alphas = pattern(18, 103, -0.5, -0.05);
+    let mut vig_data = vec![0.0f32; 30];
+    for k in 0..6 {
+        vig_data[k * 5] = centers[k * 2];
+        vig_data[k * 5 + 1] = centers[k * 2 + 1];
+        vig_data[k * 5 + 2..k * 5 + 5].copy_from_slice(&alphas[k * 3..k * 3 + 3]);
+    }
+
+    let make_grids = |d: &[f32]| Tensor::<1>::from_floats(d, &device).reshape([n, pc, gl, gy, gx]);
+    let make_rgb = |d: &[f32]| Tensor::<1>::from_floats(d, &device).reshape([h, w, 3]);
+    let make_vig = |d: &[f32]| Tensor::<1>::from_floats(d, &device).reshape([2, 3, 5]);
+
+    let grids = make_grids(&grids_data).require_grad();
+    let rgb = make_rgb(&rgb_data).require_grad();
+    let vig = make_vig(&vig_data).require_grad();
+    let out = ppisp_grid_apply(
+        grids.clone(),
+        vig.clone(),
+        rgb.clone(),
+        view,
+        cam,
+        payload,
+        GradSubsample::default(),
+    );
+    let loss = (out * wts.clone()).sum();
+    let grads = loss.backward();
+    let g_grids: Vec<f32> = grids
+        .grad(&grads)
+        .expect("grids grad")
+        .into_data_async()
+        .await
+        .expect("rb")
+        .to_vec()
+        .expect("v");
+    let g_rgb: Vec<f32> = rgb
+        .grad(&grads)
+        .expect("rgb grad")
+        .into_data_async()
+        .await
+        .expect("rb")
+        .to_vec()
+        .expect("v");
+    let g_vig: Vec<f32> = vig
+        .grad(&grads)
+        .expect("vig grad")
+        .into_data_async()
+        .await
+        .expect("rb")
+        .to_vec()
+        .expect("v");
+
+    // The inactive camera's vignetting rows must have exactly zero grads.
+    for k in 0..15 {
+        assert_eq!(g_vig[k], 0.0, "inactive camera vig grad at {k}");
+    }
+
+    let loss_for = |gd: &[f32], vd: &[f32], rd: &[f32]| {
+        let out = ppisp_grid_apply(
+            make_grids(gd),
+            make_vig(vd),
+            make_rgb(rd),
+            view,
+            cam,
+            payload,
+            GradSubsample::default(),
+        );
+        (out * wts.clone()).sum()
+    };
+    let eps = 1e-3;
+    // Sample indices across all payload sections: exposure (ch 0), color
+    // (ch 1..9), CRF (ch 9..21).
+    let cell = gl * gy * gx;
+    for idx in [
+        0usize,
+        3 * cell + 5,
+        10 * cell + 7,
+        15 * cell + 2,
+        20 * cell + 9,
+    ] {
+        let mut plus = grids_data.clone();
+        plus[idx] += eps;
+        let mut minus = grids_data.clone();
+        minus[idx] -= eps;
+        let lp = loss_for(&plus, &vig_data, &rgb_data)
+            .into_scalar_async::<f32>()
+            .await
+            .expect("lp");
+        let lm = loss_for(&minus, &vig_data, &rgb_data)
+            .into_scalar_async::<f32>()
+            .await
+            .expect("lm");
+        let fd = (lp - lm) / (2.0 * eps);
+        assert!(
+            (fd - g_grids[idx]).abs() < 3e-2 * fd.abs().max(0.5),
+            "grid grad mismatch at {idx}: analytic {} vs fd {fd}",
+            g_grids[idx]
+        );
+    }
+    // Every vignetting param of the active camera.
+    for k in 0..15 {
+        let idx = cam * 15 + k;
+        let mut plus = vig_data.clone();
+        plus[idx] += eps;
+        let mut minus = vig_data.clone();
+        minus[idx] -= eps;
+        let lp = loss_for(&grids_data, &plus, &rgb_data)
+            .into_scalar_async::<f32>()
+            .await
+            .expect("lp");
+        let lm = loss_for(&grids_data, &minus, &rgb_data)
+            .into_scalar_async::<f32>()
+            .await
+            .expect("lm");
+        let fd = (lp - lm) / (2.0 * eps);
+        assert!(
+            (fd - g_vig[idx]).abs() < 3e-2 * fd.abs().max(0.5),
+            "vig grad mismatch at {k}: analytic {} vs fd {fd}",
+            g_vig[idx]
+        );
+    }
+    for idx in [4usize, 50, 151] {
+        let mut plus = rgb_data.clone();
+        plus[idx] += eps;
+        let mut minus = rgb_data.clone();
+        minus[idx] -= eps;
+        let lp = loss_for(&grids_data, &vig_data, &plus)
+            .into_scalar_async::<f32>()
+            .await
+            .expect("lp");
+        let lm = loss_for(&grids_data, &vig_data, &minus)
+            .into_scalar_async::<f32>()
+            .await
+            .expect("lm");
+        let fd = (lp - lm) / (2.0 * eps);
+        assert!(
+            (fd - g_rgb[idx]).abs() < 3e-2 * fd.abs().max(0.5),
+            "rgb grad mismatch at {idx}: analytic {} vs fd {fd}",
+            g_rgb[idx]
+        );
+    }
+}
+
+#[wasm_bindgen_test(unsupported = tokio::test)]
+async fn ppisp_grid_subsampled_gradients_are_unbiased() {
+    // Planes elect themselves independently per seed (Bernoulli, p = 1/N,
+    // scaled by N), so the mean over many seeds must converge to the
+    // unsubsampled gradient. Deterministic: fixed seed list.
+    let device = ad_device().await;
+    let (h, w) = (32, 48);
+    let (gx, gy, gl) = (4, 4, 3);
+    let payload = GridPayload {
+        color: true,
+        crf: false,
+        vignetting: false,
+    };
+    let pc = payload.channels();
+    let grids_data = pattern(pc * gl * gy * gx, 89, -0.3, 0.3);
+    let rgb_data = pattern(h * w * 3, 97, 0.05, 0.95);
+
+    let grad_for = |sub: GradSubsample| {
+        let grids = Tensor::<1>::from_floats(grids_data.as_slice(), &device)
+            .reshape([1, pc, gl, gy, gx])
+            .require_grad();
+        let vig = Tensor::zeros([1, 3, 5], &device);
+        let rgb = Tensor::<1>::from_floats(rgb_data.as_slice(), &device).reshape([h, w, 3]);
+        let out = ppisp_grid_apply(grids.clone(), vig, rgb, 0, 0, payload, sub);
+        let grads = out.sum().backward();
+        grids.grad(&grads).expect("grad")
+    };
+
+    let full: Vec<f32> = grad_for(GradSubsample::default())
+        .into_data_async()
+        .await
+        .expect("rb")
+        .to_vec()
+        .expect("v");
+    let every = 4u32;
+    let mut acc = vec![0.0f32; full.len()];
+    let seeds = 64u32;
+    for seed in 0..seeds {
+        let g: Vec<f32> = grad_for(GradSubsample { every, seed })
+            .into_data_async()
+            .await
+            .expect("rb")
+            .to_vec()
+            .expect("v");
+        for (a, b) in acc.iter_mut().zip(&g) {
+            *a += b / seeds as f32;
+        }
+    }
+    // Relative L2 error of the seed-averaged gradient against dense.
+    let num: f32 = acc.iter().zip(&full).map(|(a, b)| (a - b) * (a - b)).sum();
+    let den: f32 = full.iter().map(|b| b * b).sum();
+    let rel = (num / den.max(1e-12)).sqrt();
+    assert!(
+        rel < 0.1,
+        "subsampled gradient biased: rel L2 err {rel:.4} over {seeds} seeds"
+    );
+}

--- a/crates/brush-bench-test/src/benches.rs
+++ b/crates/brush-bench-test/src/benches.rs
@@ -137,6 +137,7 @@ fn generate_training_batch(resolution: (u32, u32), camera_pos: Vec3) -> SceneBat
         has_alpha: false,
         alpha_mode: AlphaMode::Transparent,
         camera,
+        view_index: 0,
     }
 }
 

--- a/crates/brush-bench-test/tests/integration.rs
+++ b/crates/brush-bench-test/tests/integration.rs
@@ -127,6 +127,7 @@ fn generate_test_batch(resolution: (u32, u32)) -> SceneBatch {
         has_alpha: false,
         alpha_mode: AlphaMode::Transparent,
         camera,
+        view_index: 0,
     }
 }
 
@@ -253,6 +254,7 @@ async fn train_with_zero_visible_does_not_crash() {
         has_alpha: false,
         alpha_mode: AlphaMode::Transparent,
         camera,
+        view_index: 0,
     };
 
     let config = TrainConfig::default();

--- a/crates/brush-cube/src/lib.rs
+++ b/crates/brush-cube/src/lib.rs
@@ -562,6 +562,61 @@ pub struct PixelRect {
     pub max_y: f32,
 }
 
+/// f32-atomic-add abstraction: a single kernel covers both the native
+/// `Atomic<f32>::fetch_add` path and the `Atomic<u32>` CAS-over-bit-pattern
+/// fallback. Hosts pick the impl from [`supports_float_atomics`]. Shared by
+/// the rasterizer backward and the appearance-grid backward.
+#[cube]
+pub trait AtomicAddF32: Send + Sync + 'static {
+    type Storage: Numeric;
+    fn add(target: &Atomic<Self::Storage>, val: f32);
+}
+
+#[derive(CubeType)]
+pub struct HfAtomicAdd;
+
+#[derive(CubeType)]
+pub struct CasAtomicAdd;
+
+#[cube]
+impl AtomicAddF32 for HfAtomicAdd {
+    type Storage = f32;
+    fn add(target: &Atomic<f32>, val: f32) {
+        Atomic::fetch_add(target, val);
+    }
+}
+
+#[cube]
+impl AtomicAddF32 for CasAtomicAdd {
+    type Storage = u32;
+    fn add(target: &Atomic<u32>, val: f32) {
+        let mut old_value = Atomic::load(target);
+        let mut done = false;
+        while !done {
+            let new_bits = u32::reinterpret(f32::reinterpret(old_value) + val);
+            let actual = Atomic::compare_exchange_weak(target, old_value, new_bits);
+            if actual == old_value {
+                done = true;
+            } else {
+                old_value = actual;
+            }
+        }
+    }
+}
+
+/// Whether the device supports native f32 atomic add (`HfAtomicAdd`) or
+/// needs the CAS fallback (`CasAtomicAdd`).
+pub fn supports_float_atomics<R: burn_cubecl::CubeRuntime>(
+    client: &burn_cubecl::cubecl::client::ComputeClient<R>,
+) -> bool {
+    use burn_cubecl::cubecl::features::AtomicUsage;
+    use burn_cubecl::cubecl::ir::{ElemType, FloatKind, Type};
+    client
+        .properties()
+        .atomic_type_usage(Type::atomic(Type::scalar(ElemType::Float(FloatKind::F32))))
+        .contains(AtomicUsage::Add)
+}
+
 #[cube]
 pub fn sigmoid(x: f32) -> f32 {
     1.0f32 / (1.0f32 + f32::exp(-x))

--- a/crates/brush-dataset/src/config.rs
+++ b/crates/brush-dataset/src/config.rs
@@ -27,6 +27,13 @@ pub struct LoadDataseConfig {
     /// Create an eval dataset by selecting every nth image
     #[arg(long, help_heading = "Dataset Options")]
     pub eval_split_every: Option<usize>,
+    /// Keep the eval views in the training set instead of holding them out.
+    /// Useful with appearance compensation, where held-out views have no
+    /// learned per-view corrections and eval scores mostly measure the
+    /// splat <-> average-appearance drift.
+    #[arg(long, help_heading = "Dataset Options")]
+    #[serde(default)]
+    pub train_on_eval: bool,
     /// Load only every nth frame
     #[arg(long, help_heading = "Dataset Options")]
     pub subsample_frames: Option<u32>,

--- a/crates/brush-dataset/src/formats/colmap.rs
+++ b/crates/brush-dataset/src/formats/colmap.rs
@@ -220,7 +220,8 @@ async fn load_dataset_inner(
             views.push(SceneView { camera, image });
         }
 
-        let (train_views, eval_views) = split_eval_every(views, load_args.eval_split_every);
+        let (train_views, eval_views) =
+            split_eval_every(views, load_args.eval_split_every, load_args.train_on_eval);
 
         Result::<_, FormatError>::Ok((Dataset::from_views(train_views, eval_views), warnings))
     });

--- a/crates/brush-dataset/src/formats/mod.rs
+++ b/crates/brush-dataset/src/formats/mod.rs
@@ -131,11 +131,23 @@ fn opengl_c2w_to_pose(mut c2w: glam::Mat4) -> (glam::Vec3, glam::Quat) {
 }
 
 /// Split views into (train, eval) by selecting every `eval_split_every`-th view
-/// for eval. With `None`, every view is a train view.
+/// for eval. With `None`, every view is a train view. With `train_on_eval`,
+/// eval views are additionally kept in the training set (so per-view
+/// appearance corrections exist for them).
 fn split_eval_every(
     views: Vec<SceneView>,
     eval_split_every: Option<usize>,
+    train_on_eval: bool,
 ) -> (Vec<SceneView>, Vec<SceneView>) {
+    if train_on_eval {
+        let eval = views
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| eval_split_every.is_some_and(|split| i % split == 0))
+            .map(|(_, v)| v.clone())
+            .collect();
+        return (views, eval);
+    }
     views.into_iter().enumerate().partition_map(|(i, v)| {
         if let Some(split) = eval_split_every
             && i % split == 0

--- a/crates/brush-dataset/src/formats/nerfstudio.rs
+++ b/crates/brush-dataset/src/formats/nerfstudio.rs
@@ -347,6 +347,9 @@ async fn read_dataset_inner(
         if let Some(eval_period) = load_args.eval_split_every {
             // Include extra eval images only when the dataset doesn't have them.
             if i % eval_period == 0 && val_views.is_none() {
+                if load_args.train_on_eval {
+                    train_views.push(view.clone());
+                }
                 eval_views.push(view);
             } else {
                 train_views.push(view);

--- a/crates/brush-dataset/src/formats/realitycapture.rs
+++ b/crates/brush-dataset/src/formats/realitycapture.rs
@@ -152,7 +152,8 @@ async fn read_dataset_inner(
         views.push(SceneView { camera, image });
     }
 
-    let (train_views, eval_views) = split_eval_every(views, load_args.eval_split_every);
+    let (train_views, eval_views) =
+        split_eval_every(views, load_args.eval_split_every, load_args.train_on_eval);
 
     Ok(DatasetLoadResult {
         init_splat: None,

--- a/crates/brush-dataset/src/scene.rs
+++ b/crates/brush-dataset/src/scene.rs
@@ -148,6 +148,9 @@ pub struct SceneBatch {
     pub has_alpha: bool,
     pub alpha_mode: AlphaMode,
     pub camera: Camera,
+    /// Index of this view in the training scene's view list. Used by
+    /// per-view appearance models (bilateral grid / PPISP).
+    pub view_index: usize,
 }
 
 impl SceneBatch {

--- a/crates/brush-dataset/src/scene_loader.rs
+++ b/crates/brush-dataset/src/scene_loader.rs
@@ -145,6 +145,7 @@ async fn run_loader(
             has_alpha,
             alpha_mode: view.image.alpha_mode(),
             camera: view.camera,
+            view_index: index,
         };
 
         if tx.send(batch).await.is_err() {

--- a/crates/brush-process/src/train_stream.rs
+++ b/crates/brush-process/src/train_stream.rs
@@ -170,6 +170,25 @@ pub(crate) async fn train_stream(
 
     let mut eval_scene = dataset.eval;
 
+    // With `--train-on-eval`, eval views are also training views and carry
+    // learned per-view appearance corrections — map each eval view to its
+    // train index (by image path) so eval can apply them.
+    let eval_train_indices: Vec<Option<usize>> = eval_scene
+        .as_ref()
+        .map(|eval| {
+            eval.views
+                .iter()
+                .map(|ev| {
+                    dataset
+                        .train
+                        .views
+                        .iter()
+                        .position(|tv| tv.image.path() == ev.image.path())
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
     let mut train_duration = Duration::from_secs(0);
     let mut dataloader = SceneLoader::new(&dataset.train, 42);
     let bounds = get_splat_bounds(init_splats.clone(), BOUND_PERCENTILE).await;
@@ -185,6 +204,19 @@ pub(crate) async fn train_stream(
 
     let mut trainer = SplatTrainer::new(&train_stream_config.train_config, &device, bounds);
     trainer.set_view_cams(view_cams.clone());
+
+    // Per-view appearance compensation (bilateral grid / PPISP). PPISP's
+    // per-camera params (vignetting, tone curve) are shared across views
+    // taken by the same physical camera, so group views by intrinsics.
+    let camera_indices = camera_groups(&dataset.train);
+    trainer.init_appearance(camera_indices.clone(), &device);
+    if trainer.has_appearance() {
+        let num_cams = camera_indices.iter().copied().max().unwrap_or(0) + 1;
+        log::info!(
+            "Appearance compensation enabled ({} views, {num_cams} camera group(s))",
+            camera_indices.len()
+        );
+    }
 
     // Get the dataset name from the base path (if available) for interpolation.
     let dataset_name = vfs
@@ -276,6 +308,7 @@ pub(crate) async fn train_stream(
             let bounds = get_splat_bounds(splats.clone(), BOUND_PERCENTILE).await;
             trainer = SplatTrainer::new(&train_stream_config.train_config, &device, bounds);
             trainer.set_view_cams(view_cams.clone());
+            trainer.init_appearance(camera_groups(&dataset.train), &device);
 
             log::info!(
                 "LOD {current_lod}/{lod_levels}: Training for {lod_refine_steps} steps (image scale {:.0}%)",
@@ -352,6 +385,8 @@ pub(crate) async fn train_stream(
                 &device,
                 emitter,
                 &visualize,
+                &trainer,
+                &eval_train_indices,
                 splats.clone(),
                 iter,
                 eval_scene,
@@ -363,6 +398,10 @@ pub(crate) async fn train_stream(
 
             if let Err(error) = eval {
                 emitter.emit(ProcessMessage::Warning { error }).await;
+            }
+
+            if let Some(stats) = trainer.appearance_stats().await {
+                log::info!("Appearance at iter {iter}: {stats}");
             }
         }
 
@@ -480,10 +519,40 @@ pub(crate) async fn train_stream(
     Ok(())
 }
 
+/// Group training views by camera intrinsics (fov + principal point +
+/// camera model). Views shot by the same physical camera share PPISP's
+/// per-camera vignetting and tone-curve parameters.
+fn camera_groups(scene: &Scene) -> Vec<u32> {
+    let mut keys: Vec<(u64, u64, u32, u32, std::mem::Discriminant<_>)> = Vec::new();
+    scene
+        .views
+        .iter()
+        .map(|view| {
+            let cam = &view.camera;
+            let key = (
+                cam.fov_x.to_bits(),
+                cam.fov_y.to_bits(),
+                cam.center_uv.x.to_bits(),
+                cam.center_uv.y.to_bits(),
+                std::mem::discriminant(&cam.camera_model),
+            );
+            if let Some(idx) = keys.iter().position(|k| *k == key) {
+                idx as u32
+            } else {
+                keys.push(key);
+                (keys.len() - 1) as u32
+            }
+        })
+        .collect()
+}
+
+#[allow(clippy::too_many_arguments)]
 async fn run_eval(
     device: &burn::tensor::Device,
     emitter: &Emitter,
     visualize: &VisualizeTools,
+    trainer: &SplatTrainer,
+    eval_train_indices: &[Option<usize>],
     splats: Splats,
     iter: u32,
     eval_scene: &Scene,
@@ -503,12 +572,21 @@ async fn run_eval(
         brush_async::yield_now().await;
 
         let eval_img = view.image.load().await?;
+        // Only views that exist in the training set have learned per-view
+        // corrections to apply.
+        let train_idx = eval_train_indices.get(i).copied().flatten();
+        let correction = train_idx.filter(|_| trainer.has_appearance()).map(|idx| {
+            move |img: burn::tensor::Tensor<3>| trainer.appearance_eval_correction(img, idx)
+        });
         let sample = eval_stats(
             splats.clone(),
             &view.camera,
             eval_img,
             view.image.alpha_mode(),
             device,
+            correction
+                .as_ref()
+                .map(|f| f as &(dyn Fn(burn::tensor::Tensor<3>) -> burn::tensor::Tensor<3> + Sync)),
         )
         .await
         .context("Failed to run eval for sample.")?;

--- a/crates/brush-render-bwd/src/kernels/rasterize_backwards.rs
+++ b/crates/brush-render-bwd/src/kernels/rasterize_backwards.rs
@@ -57,45 +57,9 @@ fn zero_grad() -> SplatGrad {
     }
 }
 
-/// f32-atomic-add abstraction so a single kernel covers both the native
-/// `Atomic<f32>::fetch_add` path and the `Atomic<u32>` CAS fallback.
-#[cube]
-pub trait AtomicAddF32: Send + Sync + 'static {
-    type Storage: Numeric;
-    fn add(target: &Atomic<Self::Storage>, val: f32);
-}
-
-#[derive(CubeType)]
-pub struct HfAtomicAdd;
-
-#[derive(CubeType)]
-pub struct CasAtomicAdd;
-
-#[cube]
-impl AtomicAddF32 for HfAtomicAdd {
-    type Storage = f32;
-    fn add(target: &Atomic<f32>, val: f32) {
-        Atomic::fetch_add(target, val);
-    }
-}
-
-#[cube]
-impl AtomicAddF32 for CasAtomicAdd {
-    type Storage = u32;
-    fn add(target: &Atomic<u32>, val: f32) {
-        let mut old_value = Atomic::load(target);
-        let mut done = false;
-        while !done {
-            let new_bits = u32::reinterpret(f32::reinterpret(old_value) + val);
-            let actual = Atomic::compare_exchange_weak(target, old_value, new_bits);
-            if actual == old_value {
-                done = true;
-            } else {
-                old_value = actual;
-            }
-        }
-    }
-}
+// f32-atomic-add abstraction lives in `brush-cube` (shared with the
+// appearance-grid backward); re-exported here for the host launch code.
+pub use brush_cube::{AtomicAddF32, CasAtomicAdd, HfAtomicAdd};
 
 #[cube(launch)]
 pub fn rasterize_backwards_kernel<A: AtomicAddF32>(

--- a/crates/brush-train/Cargo.toml
+++ b/crates/brush-train/Cargo.toml
@@ -10,6 +10,7 @@ debug-validation = ["brush-render-bwd/debug-validation"]
 
 [dependencies]
 brush-render.path = "../brush-render"
+brush-appearance.path = "../brush-appearance"
 brush-dataset.path = "../brush-dataset"
 brush-render-bwd.path = "../brush-render-bwd"
 brush-loss.path = "../brush-loss"

--- a/crates/brush-train/src/config.rs
+++ b/crates/brush-train/src/config.rs
@@ -76,6 +76,13 @@ pub struct TrainConfig {
     #[arg(long, help_heading = "Refine options", default_value = "0.5")]
     pub kill_at_screen_size: f32,
 
+    /// Mip-Splatting 3D-filter strength: each splat gets a frozen world-space
+    /// scale floor of `sqrt(factor)` pixels at its nearest observing camera,
+    /// folded into derived scales/opacity (and baked at export). 0 disables.
+    #[arg(long, help_heading = "Refine options", default_value = "0.1")]
+    #[serde(default = "default_min_scale_factor")]
+    pub min_scale_factor: f32,
+
     /// Weight of the per-splat screen-area loss. Works as a nudge toward small on-screen
     /// footprints.
     #[arg(long, help_heading = "Training options", default_value = "0.05")]
@@ -133,6 +140,113 @@ pub struct TrainConfig {
     /// estimated from the camera spacing (with a 1m minimum).
     #[arg(long, help_heading = "Training options")]
     pub random_init_scene_scale: Option<f32>,
+
+    /// Enable hybrid appearance compensation (recommended): per-camera
+    /// PPISP vignetting plus a per-view bilateral grid of PPISP exposure +
+    /// color parameters, applied to the render before the loss so exposure /
+    /// white-balance variation isn't baked into the splats.
+    #[arg(long, help_heading = "Appearance options", default_value = "false")]
+    #[serde(default)]
+    pub ppisp_grid: bool,
+
+    /// Hybrid grid holds one log2-exposure scalar per cell instead of
+    /// exposure + color.
+    #[arg(long, help_heading = "Appearance options", default_value = "false")]
+    #[serde(default)]
+    pub ppisp_grid_expose_only: bool,
+
+    /// Hybrid grid additionally holds per-cell CRF (tone curve) offsets.
+    /// On by default: without tone-curve freedom the grid can only apply
+    /// display-space gain, which under-fits tone-mapped exposure changes
+    /// and leaves floaters. `--ppisp-grid-crf=false` disables.
+    #[arg(
+        long,
+        help_heading = "Appearance options",
+        default_value = "true",
+        default_missing_value = "true",
+        num_args = 0..=1,
+        action = clap::ArgAction::Set
+    )]
+    #[serde(default = "default_ppisp_grid_crf")]
+    pub ppisp_grid_crf: bool,
+
+    /// Learn a per-camera CRF (tone curve) applied after the hybrid grid.
+    #[arg(long, help_heading = "Appearance options", default_value = "false")]
+    #[serde(default)]
+    pub ppisp_crf_per_camera: bool,
+
+    /// Comparison mode: per-view affine bilateral grids (BilaRF-style).
+    #[arg(long, help_heading = "Appearance options", default_value = "false")]
+    #[serde(default)]
+    pub bilateral_grid: bool,
+
+    /// Bilateral grid dimensions as `x,y,guidance`.
+    #[arg(
+        long,
+        help_heading = "Appearance options",
+        default_value = "16,16,8",
+        value_delimiter = ','
+    )]
+    #[serde(default = "default_bilagrid_dims")]
+    pub bilagrid_dims: Vec<u32>,
+
+    /// Weight of the bilateral grid's total-variation regularizer.
+    #[arg(long, help_heading = "Appearance options", default_value = "10.0")]
+    #[serde(default = "default_bilagrid_tv_weight")]
+    pub bilagrid_tv_weight: f32,
+
+    /// Weight of the grid's EMA-anchored mean-to-identity regularizer
+    /// (hybrid mode; keeps the dataset-mean correction at identity).
+    /// Channel-mean normalized, directly comparable to spirulae's
+    /// `bilagrid_mean_reg_weight`. Too high caps how much exposure the
+    /// grid can absorb, pushing it into floaters instead.
+    #[arg(long, help_heading = "Appearance options", default_value = "10.0")]
+    #[serde(default = "default_bilagrid_mean_reg")]
+    pub bilagrid_mean_reg: f32,
+
+    /// Learning rate for the bilateral grids.
+    #[arg(long, help_heading = "Appearance options", default_value = "2e-3")]
+    #[serde(default = "default_bilagrid_lr")]
+    pub bilagrid_lr: f64,
+
+    /// Adam betas for the per-view grid updates as `b1,b2`. The sparse
+    /// updates are dense-Adam equivalent (moments decay over the gap
+    /// between a view's visits), so the horizons are in global steps and
+    /// the defaults match the reference implementations.
+    #[arg(
+        long,
+        help_heading = "Appearance options",
+        default_value = "0.9,0.999",
+        value_delimiter = ','
+    )]
+    #[serde(default = "default_bilagrid_betas")]
+    pub bilagrid_betas: Vec<f64>,
+
+    /// Grid-gradient subsampling: only every Nth subgroup scatters
+    /// gradients into the grid (scaled to stay unbiased; offset rotates per
+    /// step). 1 disables. Cuts the dominant atomic cost of the grid
+    /// backward; measured quality-neutral at the default for the heavily
+    /// regularized grids.
+    #[arg(long, help_heading = "Appearance options", default_value = "4")]
+    #[serde(default = "default_bilagrid_grad_subsample")]
+    pub bilagrid_grad_subsample: u32,
+
+    /// Enable PPISP appearance compensation: per-frame exposure + color
+    /// homography and per-camera vignetting + tone curve (physically
+    /// plausible ISP model), applied to the render before the loss.
+    #[arg(long, help_heading = "Appearance options", default_value = "false")]
+    #[serde(default)]
+    pub ppisp: bool,
+
+    /// Learning rate for the PPISP parameters.
+    #[arg(long, help_heading = "Appearance options", default_value = "2e-3")]
+    #[serde(default = "default_ppisp_lr")]
+    pub ppisp_lr: f64,
+
+    /// Scale on all PPISP parameter-regularization terms.
+    #[arg(long, help_heading = "Appearance options", default_value = "1.0")]
+    #[serde(default = "default_ppisp_reg_scale")]
+    pub ppisp_reg_scale: f32,
 }
 
 impl Default for TrainConfig {
@@ -145,4 +259,44 @@ impl TrainConfig {
     pub fn total_iters(&self) -> u32 {
         self.total_train_iters + self.lod_levels * self.lod_refine_steps
     }
+}
+
+fn default_min_scale_factor() -> f32 {
+    0.1
+}
+
+fn default_bilagrid_dims() -> Vec<u32> {
+    vec![16, 16, 8]
+}
+
+fn default_ppisp_grid_crf() -> bool {
+    true
+}
+
+fn default_bilagrid_tv_weight() -> f32 {
+    10.0
+}
+
+fn default_bilagrid_lr() -> f64 {
+    2e-3
+}
+
+fn default_bilagrid_mean_reg() -> f32 {
+    10.0
+}
+
+fn default_bilagrid_betas() -> Vec<f64> {
+    vec![0.9, 0.999]
+}
+
+fn default_bilagrid_grad_subsample() -> u32 {
+    4
+}
+
+fn default_ppisp_lr() -> f64 {
+    2e-3
+}
+
+fn default_ppisp_reg_scale() -> f32 {
+    1.0
 }

--- a/crates/brush-train/src/eval.rs
+++ b/crates/brush-train/src/eval.rs
@@ -25,6 +25,7 @@ pub async fn eval_stats(
     gt_img: DynamicImage,
     alpha_mode: AlphaMode,
     device: &Device,
+    correction: Option<&(dyn Fn(Tensor<3>) -> Tensor<3> + Sync)>,
 ) -> Result<EvalSample> {
     let res = glam::uvec2(gt_img.width(), gt_img.height());
 
@@ -36,6 +37,15 @@ pub async fn eval_stats(
     let (img, render_aux) =
         render_splats(splats, gt_cam, res, Vec3::ZERO, None, TextureMode::Float).await;
     let render_rgb = img.slice(s![.., .., 0..3]);
+
+    // Apply the learned per-view appearance correction when scoring a
+    // training view (`--train-on-eval`): without it, scores on
+    // appearance-varying datasets mostly measure the splat <-> average
+    // appearance offset rather than reconstruction quality.
+    let render_rgb = match correction {
+        Some(f) => f(render_rgb),
+        None => render_rgb,
+    };
 
     // Simulate an 8-bit roundtrip for fair comparison.
     let render_rgb = (render_rgb * 255.0).round() / 255.0;

--- a/crates/brush-train/src/train.rs
+++ b/crates/brush-train/src/train.rs
@@ -9,6 +9,7 @@ use crate::{
     splat_init::bounds_from_pos,
     stats::RefineRecord,
 };
+use brush_appearance::{AppearanceConfig, AppearanceTrainState};
 use brush_dataset::scene::SceneBatch;
 use brush_loss::{ImageLossConfig, image_loss};
 use brush_render::gaussian_splats::Splats;
@@ -41,13 +42,6 @@ const MIN_OPACITY: f32 = 1.0 / 255.0;
 /// against a fixed target instead of chasing a moving floor.
 const MIN_SCALE_FREEZE_FRAC: f32 = 0.9;
 
-/// Mip-Splatting 3D-filter strength (the paper's `s`): each splat gets a frozen
-/// per-splat world-space scale floor `f = sqrt(MIN_SCALE_FACTOR) · pixel size at
-/// the nearest observing camera`, i.e. a ~0.32px std-dev floor. Folded into
-/// scales/opacity at render (and baked at export), never optimized. Fundamental
-/// to well-behaved splats, so not a tunable.
-const MIN_SCALE_FACTOR: f32 = 0.1;
-
 type OptimizerType = OptimizerAdaptor<AdamScaled, Splats>;
 
 pub struct SplatTrainer {
@@ -55,6 +49,9 @@ pub struct SplatTrainer {
     sched_mean: ExponentialLrScheduler,
     refine_record: Option<RefineRecord>,
     optim: Option<OptimizerType>,
+    /// Optional per-view appearance compensation (bilateral grid / PPISP).
+    /// Lives on the inner backend between steps, like the splats.
+    appearance: Option<AppearanceTrainState>,
     ssim_enabled: bool,
     bounds: BoundingBox,
     step_count: u32,
@@ -137,6 +134,7 @@ impl SplatTrainer {
             config,
             sched_mean: lr_mean.init().expect("Mean lr schedule must be valid."),
             optim: None,
+            appearance: None,
             refine_record: None,
             ssim_enabled,
             bounds,
@@ -152,6 +150,67 @@ impl SplatTrainer {
     /// the Mip-Splatting 3D filter (gated on `config.min_scale_factor > 0`).
     pub fn set_view_cams(&mut self, view_cams: Vec<(glam::Vec3, f32)>) {
         self.view_cams = view_cams;
+    }
+
+    /// Set up per-view appearance compensation (bilateral grid and/or PPISP,
+    /// gated on the train config). `camera_indices` maps each training view
+    /// to a physical-camera group for PPISP's per-camera params; same length
+    /// and order as the scene's view list.
+    pub fn init_appearance(&mut self, camera_indices: Vec<u32>, device: &Device) {
+        let dims = &self.config.bilagrid_dims;
+        assert_eq!(dims.len(), 3, "bilagrid-dims must be `x,y,guidance`");
+        assert!(
+            dims.iter().all(|d| *d >= 2),
+            "bilagrid-dims must each be >= 2"
+        );
+        let betas = &self.config.bilagrid_betas;
+        assert_eq!(betas.len(), 2, "bilagrid-betas must be `b1,b2`");
+        let config = AppearanceConfig {
+            ppisp_grid: self.config.ppisp_grid,
+            grid_color: !self.config.ppisp_grid_expose_only,
+            grid_crf: self.config.ppisp_grid_crf,
+            crf_per_camera: self.config.ppisp_crf_per_camera,
+            bilagrid: self.config.bilateral_grid,
+            bilagrid_dims: (dims[0] as usize, dims[1] as usize, dims[2] as usize),
+            bilagrid_tv_weight: self.config.bilagrid_tv_weight,
+            bilagrid_mean_reg: self.config.bilagrid_mean_reg,
+            bilagrid_lr: self.config.bilagrid_lr,
+            bilagrid_betas: (betas[0], betas[1]),
+            grad_subsample: self.config.bilagrid_grad_subsample,
+            ppisp: self.config.ppisp,
+            ppisp_lr: self.config.ppisp_lr,
+            ppisp_reg_scale: self.config.ppisp_reg_scale,
+        };
+        self.appearance = AppearanceTrainState::new(
+            config,
+            camera_indices,
+            self.config.total_train_iters,
+            device,
+        );
+    }
+
+    /// Whether appearance compensation is active.
+    pub fn has_appearance(&self) -> bool {
+        self.appearance.is_some()
+    }
+
+    /// Magnitude summary of the learned appearance parameters (`None` when
+    /// appearance compensation is disabled).
+    pub async fn appearance_stats(&self) -> Option<String> {
+        match &self.appearance {
+            Some(state) => state.stats().await,
+            None => None,
+        }
+    }
+
+    /// Forward-only appearance correction for an eval render of *training*
+    /// view `view_idx` (`--train-on-eval`). `img` is `[H, W, 3|4]` on the
+    /// inner backend; returns it unchanged when appearance is disabled.
+    pub fn appearance_eval_correction(&self, img: Tensor<3>, view_idx: usize) -> Tensor<3> {
+        match &self.appearance {
+            Some(state) => state.apply_eval(img, view_idx),
+            None => img,
+        }
     }
 
     pub async fn step(&mut self, batch: SceneBatch, splats: Splats) -> (Splats, TrainStepStats) {
@@ -184,6 +243,13 @@ impl SplatTrainer {
 
         let median_scale = self.bounds.median_size();
 
+        // Lift the active view's appearance params onto the autodiff graph
+        // for this step.
+        let active_appearance = self
+            .appearance
+            .as_ref()
+            .map(|s| s.begin_step(batch.view_index, self.step_count.saturating_sub(1)));
+
         let (mut grads, visible, num_visible, loss_inner) = {
             // The splats already carry their 3D-filter floor (set at refine);
             // the render path folds it in. Optimizer/refine work on raw params.
@@ -198,7 +264,14 @@ impl SplatTrainer {
             .instrument(trace_span!("Forward"))
             .await;
 
-            let pred_image = diff_out.img;
+            // Per-view appearance compensation (PPISP then bilateral grid)
+            // happens on the rendered image, before any loss term sees it —
+            // the splats themselves learn appearance-free colors. Alpha
+            // passes through untouched.
+            let pred_image = match &active_appearance {
+                Some(active) => active.apply(diff_out.img),
+                None => diff_out.img,
+            };
             let refine_weight_holder = diff_out.refine_weight_holder;
             let visible = diff_out.visible;
             let max_radius = diff_out.max_radius;
@@ -257,6 +330,13 @@ impl SplatTrainer {
                         pred_image.clone().slice(s![.., .., 0..3]).unsqueeze_dim(0),
                         gt_rgb_diff.unsqueeze_dim(0),
                     ) * self.config.lpips_loss_weight;
+            }
+
+            // Appearance regularisers (bilagrid TV, PPISP param priors).
+            if let Some(active) = &active_appearance
+                && let Some(reg) = active.reg_loss()
+            {
+                loss = loss + reg;
             }
 
             // Strip the autodiff graph off the loss so consumers can read the
@@ -369,6 +449,15 @@ impl SplatTrainer {
             splats
         });
 
+        // Appearance optimizer step: the active view's bilateral grid gets a
+        // sparse Adam update and the PPISP params a dense one, each on its
+        // own warmup + exp-decay LR schedule.
+        if let (Some(state), Some(active)) = (self.appearance.as_mut(), active_appearance) {
+            trace_span!("Appearance step").in_scope(|| {
+                state.end_step(active, &mut grads, self.step_count.saturating_sub(1));
+            });
+        }
+
         // Add random noise. Only do this in the growth phase, otherwise
         // let the splats settle in without noise, not much point in exploring regions anymore.
         // The noise gate is non-differentiable bookkeeping. Read opacity from
@@ -469,6 +558,13 @@ impl SplatTrainer {
                 n_area_gt_005 as f64 / n_total,
                 n_area_gt_010 as f64 / n_total,
             );
+        }
+
+        // Surface the learned appearance magnitudes with the same cadence:
+        // runs without an eval split (e.g. GUI) otherwise never see whether
+        // the grids are training.
+        if let Some(stats) = self.appearance_stats().await {
+            log::info!("appearance iter={iter}: {stats}");
         }
 
         let max_allowed_bounds = self.bounds.extent.max_element() * 100.0;
@@ -619,7 +715,9 @@ impl SplatTrainer {
             // `splats` is already on the inner backend here, so `means()` is too.
             // No-op when there are no view cameras (e.g. unit tests).
             let means = splats.means();
-            if let Some(f) = compute_min_scale(&means, &self.view_cams, MIN_SCALE_FACTOR) {
+            if let Some(f) =
+                compute_min_scale(&means, &self.view_cams, self.config.min_scale_factor)
+            {
                 splats = splats.with_min_scale(f);
             }
         }


### PR DESCRIPTION
New brush-appearance crate: fused CubeCL kernels with custom autodiff for a vanilla per-view bilateral grid (--bilateral-grid), full per-frame PPISP (--ppisp), and a spirulae-style hybrid PPISP grid (--ppisp-grid) with per-cell exposure/color/CRF payloads and per-camera vignetting. Corrections apply to the rendered image before the loss; exported splats keep canonical colors. Per-view grid slices train with a lazy dense-Adam-equivalent sparse optimizer (O(1) step cost, parity-tested against dense Adam), Bernoulli per-warp gradient subsampling, and an EMA mean-to-identity anchor. Also: --train-on-eval + corrected eval, --min-scale-factor flag for the previously hardcoded 3D filter floor, shared f32 atomics in brush-cube.

Modes:
- `--bilateral-grid` — per-view bilateral grid of affine color transforms (the gsplat formulation)
- `--ppisp-grid` — spirulae-splat style hybrid: per-view grid of PPISP exposure/color/CRF payloads, plus per-camera vignetting
- `--ppisp` — full per-frame PPISP (everything global per frame; comparison mode)

Tested on a large dataset with strong exposure variation: both grid modes remove the
exposure-driven floaters, the bilateral grid most effectively.

Known limitations: checkpoint resume resets appearance state (not yet serialized), and
the PPISP controller CNN is not implemented (novel views get identity corrections).