### PR TITLE
Fix flaky training NaN from broken moment reset

### DIFF
--- a/crates/brush-bench-test/tests/burn_scatter_repro.rs
+++ b/crates/brush-bench-test/tests/burn_scatter_repro.rs
@@ -1,0 +1,86 @@
+//! Repro for an upstream burn bug: `split_strides` (burn-std/src/tensor)
+//! anchors its stride walk on unit dims, so reshaping a `repeat_dim`
+//! broadcast view like `[k, 1]` strides `[1, 0]` to `[k, 1, 1]` yields
+//! strides `[0, 0, 0]` — every row of the index tensor aliases row 0. A
+//! `scatter(Add)` fed such indices piles all k updates onto `inds[0]` and
+//! applies none to the other rows.
+//!
+//! This bit brush as a flaky `tensor 'sh_coeffs' has 48 NaNs` failure in
+//! brush-c's `test_train_and_save_ffi_short`: refine reset the Adam moments
+//! of split parents with `x.scatter(0, inds, -x.select(0, inds), Add)`; for
+//! the `[n,1,1]` reduced `moment_2` the broken index view left `inds[0]`'s
+//! moment slightly *negative* — then `sqrt(-ε)` is NaN (bits 0x7fffffff on
+//! NVIDIA), and the reduced-moment broadcast smears it across the splat's
+//! whole SH row. Whether the index chain reached the scatter as a view
+//! (broken) or materialized (fine) depended on fusion flush timing — hence
+//! suite-only flakiness. Refine now resets moments with a mask multiply, and
+//! the Adam update clamps `moment_2` before the sqrt.
+//!
+//! Fix: `split_strides` must skip unit dims when anchoring (branch
+//! `fix/split-strides-unit-dims` in the burn repo). Un-ignore this test once
+//! the burn pin includes it.
+
+#![cfg(not(target_family = "wasm"))]
+
+use burn::tensor::{Device, IndexingUpdateOp, Int, Tensor, TensorData};
+
+/// `x + (-x)` must be exactly 0.0 at the scattered rows, and every other row
+/// must be bit-identical. Mirrors the shapes refine used: `[n,1,1]` (reduced
+/// moment_2) and `[n,16,3]` (moment_1), n around post-refine splat counts,
+/// ~26 unique indices.
+#[tokio::test]
+#[ignore = "exposes the upstream burn split_strides unit-dim bug; un-ignore once the burn pin has the fix"]
+async fn scatter_zeroing_is_exact() {
+    use rand::SeedableRng;
+    use rand::seq::SliceRandom;
+
+    let device: Device = burn::tensor::Device::from(brush_cube::test_helpers::test_device().await);
+    let mut rng = rand::rngs::StdRng::seed_from_u64(4242);
+
+    for &n in &[95usize, 96, 97, 100, 121, 122, 123] {
+        for rep in 0..20 {
+            // ~26 unique indices like a real refine split set.
+            let mut inds: Vec<i32> = (0..n as i32).collect();
+            inds.shuffle(&mut rng);
+            inds.truncate(26);
+            let k = inds.len();
+
+            for &(d1, d2) in &[(1usize, 1usize), (16, 3)] {
+                let base: Vec<f32> = (0..n * d1 * d2).map(|i| 1e-8 + (i as f32) * 1e-9).collect();
+                let x = Tensor::<3>::from_data(TensorData::new(base.clone(), [n, d1, d2]), &device);
+                let inds_t =
+                    Tensor::<1, Int>::from_data(TensorData::new(inds.clone(), [k]), &device);
+                let neg_parent = -x.clone().select(0, inds_t.clone());
+                let inds_2: Tensor<2, Int> = inds_t.clone().unsqueeze_dim(1).repeat_dim(1, d1);
+                let inds_3: Tensor<3, Int> = inds_2.unsqueeze_dim(2).repeat_dim(2, d2);
+                let out = x.scatter(0, inds_3, neg_parent, IndexingUpdateOp::Add);
+
+                let vals = out
+                    .into_data_async()
+                    .await
+                    .expect("scatter read")
+                    .into_vec::<f32>()
+                    .expect("scatter vec");
+                let selected: std::collections::HashSet<usize> =
+                    inds.iter().map(|i| *i as usize).collect();
+                for (i, v) in vals.iter().enumerate() {
+                    let row = i / (d1 * d2);
+                    if selected.contains(&row) {
+                        assert!(
+                            *v == 0.0,
+                            "zeroing not exact at n={n} d=({d1},{d2}) rep {rep} row {row} flat {i}: {v:e} ({:#010x})",
+                            v.to_bits(),
+                        );
+                    } else {
+                        assert!(
+                            *v == base[i],
+                            "untouched row changed at n={n} d=({d1},{d2}) rep {rep} row {row} flat {i}: {v:e} ({:#010x}) want {:e}",
+                            v.to_bits(),
+                            base[i],
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/brush-render/src/validation.rs
+++ b/crates/brush-render/src/validation.rs
@@ -9,7 +9,9 @@ pub async fn validate_tensor_val<const D: usize>(
     min_val: Option<f32>,
     max_val: Option<f32>,
 ) {
+    let dims = tensor.dims();
     let data = tensor
+        .clone()
         .into_data_async()
         .await
         .expect("Failed to read tensor data");
@@ -47,7 +49,7 @@ pub async fn validate_tensor_val<const D: usize>(
 
     if nan_count > 0 || inf_count > 0 {
         log::error!(
-            "tensor '{name}': {nan_count} NaN (first @ {first_nan_idx:?}), \
+            "tensor '{name}' shape {dims:?}: {nan_count} NaN (first @ {first_nan_idx:?}), \
              {inf_count} Inf (first @ {first_inf_idx:?}) of {} total",
             values.len(),
         );
@@ -69,13 +71,86 @@ pub async fn validate_tensor_val<const D: usize>(
 
     #[cfg(any(test, feature = "debug-validation"))]
     {
+        // Map a flat index to per-dim coordinates, to tell "one whole row"
+        // from "scattered elements" at a glance in the failure output.
+        let coords = move |idx: usize| -> Vec<usize> {
+            let mut rem = idx;
+            let mut out = vec![0; D];
+            for d in (0..D).rev() {
+                out[d] = rem % dims[d];
+                rem /= dims[d];
+            }
+            out
+        };
+        let values_ref = &values;
+        let bad_rows = move |pred: fn(f32) -> bool| -> Vec<usize> {
+            let row_len: usize = dims[1..].iter().product();
+            let mut rows: Vec<usize> = values_ref
+                .iter()
+                .enumerate()
+                .filter(|(_, v)| pred(**v))
+                .map(|(i, _)| i / row_len)
+                .collect();
+            rows.dedup();
+            rows
+        };
+
+        // Bit patterns of the bad values discriminate failure modes: all
+        // 0x7FC00000 (canonical quiet NaN) points at arithmetic; diverse
+        // garbage mantissas point at memory corruption / OOB writes.
+        let bad_bits = || -> Vec<String> {
+            values
+                .iter()
+                .filter(|v| !v.is_finite())
+                .take(8)
+                .map(|v| format!("{:#010x}", v.to_bits()))
+                .collect()
+        };
+
+        // On a hit, read the SAME tensor a second time. If the re-read is
+        // clean, the buffer was fine and the first readback returned phantom
+        // bytes (staging/copy race); if it still shows the same garbage, the
+        // buffer itself is corrupted.
+        let reread_verdict = if nan_count > 0 || inf_count > 0 {
+            let values2 = tensor
+                .into_data_async()
+                .await
+                .expect("Failed to re-read tensor data")
+                .into_vec::<f32>()
+                .expect("Failed to convert re-read to f32 vec");
+            let bad2 = values2.iter().filter(|v| !v.is_finite()).count();
+            let first_bad = values
+                .iter()
+                .position(|v| !v.is_finite())
+                .unwrap_or_default();
+            format!(
+                "reread: {} non-finite (was {}), same idx bits {:#010x} -> {:#010x}",
+                bad2,
+                nan_count + inf_count,
+                values[first_bad].to_bits(),
+                values2.get(first_bad).copied().unwrap_or(0.0).to_bits(),
+            )
+        } else {
+            String::new()
+        };
+
         assert_eq!(
-            nan_count, 0,
-            "tensor '{name}' has {nan_count} NaNs (first @ {first_nan_idx:?})"
+            nan_count,
+            0,
+            "tensor '{name}' shape {dims:?} has {nan_count} NaNs (first @ {first_nan_idx:?} = {:?}, rows {:?}, bits {:?}; {})",
+            first_nan_idx.map(coords),
+            bad_rows(f32::is_nan),
+            bad_bits(),
+            reread_verdict,
         );
         assert_eq!(
-            inf_count, 0,
-            "tensor '{name}' has {inf_count} Infs (first @ {first_inf_idx:?})"
+            inf_count,
+            0,
+            "tensor '{name}' shape {dims:?} has {inf_count} Infs (first @ {first_inf_idx:?} = {:?}, rows {:?}, bits {:?}; {})",
+            first_inf_idx.map(coords),
+            bad_rows(f32::is_infinite),
+            bad_bits(),
+            reread_verdict,
         );
     }
 }

--- a/crates/brush-train/src/adam_scaled.rs
+++ b/crates/brush-train/src/adam_scaled.rs
@@ -206,8 +206,21 @@ impl AdaptiveMomentum {
             .moment_2
             .clone()
             .div_scalar(1f32 - self.beta_2.powi(time));
-        // moment_2_corrected broadcasts when it has reduced trailing dims
-        let grad = moment_1_corrected.div(moment_2_corrected.sqrt().add_scalar(self.epsilon));
+        // moment_2_corrected broadcasts when it has reduced trailing dims.
+        //
+        // The clamp guards the sqrt: a second moment is non-negative by
+        // construction, but a tiny negative residue can sneak in GPU-side
+        // (refine's old scatter-add moment reset did exactly that, see
+        // `scatter_zeroing_is_exact`), and sqrt(-ε) is NaN — which the
+        // reduced-moment broadcast then smears across the whole row. A
+        // negative state self-heals within a few steps via the
+        // (1-β₂)·mean(g²) term, so clamping only at the read is enough.
+        let grad = moment_1_corrected.div(
+            moment_2_corrected
+                .clamp_min(0.0)
+                .sqrt()
+                .add_scalar(self.epsilon),
+        );
         (grad, state)
     }
 }

--- a/crates/brush-train/src/train.rs
+++ b/crates/brush-train/src/train.rs
@@ -649,10 +649,9 @@ impl SplatTrainer {
         let refine_count = split_inds.len();
 
         if refine_count > 0 {
-            let refine_inds = Tensor::from_data(
-                TensorData::new(split_inds.into_iter().collect::<Vec<_>>(), [refine_count]),
-                device,
-            );
+            let split_inds: Vec<i32> = split_inds.into_iter().collect();
+            let refine_inds =
+                Tensor::from_data(TensorData::new(split_inds.clone(), [refine_count]), device);
 
             let cur_transforms = splats.transforms.val().select(0, refine_inds.clone());
             let cur_means = cur_transforms.clone().slice(s![.., 0..3]);
@@ -719,13 +718,30 @@ impl SplatTrainer {
 
             // Optimizer state lives on the inner (non-autodiff) device.
             let opt_device = device.clone().inner();
-            let refine_inds_opt = refine_inds.to_device(&opt_device);
 
-            // Both halves of a split start with zero Adam moments.
+            // Both halves of a split start with zero Adam moments: multiply
+            // the parent rows by a 0/1 mask built on the CPU (the indices are
+            // already host-side).
             //
-            // Burn's scatter bridge
-            // only implements Add, so we add the negated parent value to zero
-            // it out instead of using Assign.
+            // This deliberately avoids `scatter(Add)` of the negated parent
+            // value: under load, burn's scatter can drop or misroute single
+            // row updates (see `scatter_zeroing_is_exact`), which left
+            // moment_2 slightly NEGATIVE — and `sqrt(-ε)` is NaN, which the
+            // reduced-moment broadcast then smeared over a whole SH row. A
+            // mask multiply is elementwise (fusable) and exact.
+            let mut keep = vec![1.0f32; splats.num_splats() as usize];
+            for i in &split_inds {
+                keep[*i as usize] = 0.0;
+            }
+            let keep_mask = Tensor::<1>::from_data(
+                TensorData::new(keep, [splats.num_splats() as usize]),
+                &opt_device,
+            );
+
+            let mask1 = keep_mask.clone();
+            let mask2 = keep_mask.clone().unsqueeze_dim::<2>(1);
+            let mask3 = keep_mask.unsqueeze_dim::<2>(1).unsqueeze_dim::<3>(2);
+
             splats = map_splats_and_opt(
                 splats,
                 &mut record,
@@ -734,32 +750,19 @@ impl SplatTrainer {
                 |x| Tensor::cat(vec![x, new_raw_opac], 0),
                 |x: Tensor<2>| {
                     let d1 = x.dims()[1];
-                    let neg_parent = -x.clone().select(0, refine_inds_opt.clone());
-                    let inds: Tensor<2, Int> =
-                        refine_inds_opt.clone().unsqueeze_dim(1).repeat_dim(1, d1);
-                    let x = x.scatter(0, inds, neg_parent, IndexingUpdateOp::Add);
+                    let x = x * mask2.clone();
                     Tensor::cat(vec![x, Tensor::zeros([refine_count, d1], &opt_device)], 0)
                 },
                 |x: Tensor<3>| {
                     let [_, d1, d2] = x.dims();
-                    let neg_parent = -x.clone().select(0, refine_inds_opt.clone());
-                    let inds_2: Tensor<2, Int> =
-                        refine_inds_opt.clone().unsqueeze_dim(1).repeat_dim(1, d1);
-                    let inds: Tensor<3, Int> = inds_2.unsqueeze_dim(2).repeat_dim(2, d2);
-                    let x = x.scatter(0, inds, neg_parent, IndexingUpdateOp::Add);
+                    let x = x * mask3.clone();
                     Tensor::cat(
                         vec![x, Tensor::zeros([refine_count, d1, d2], &opt_device)],
                         0,
                     )
                 },
                 |x: Tensor<1>| {
-                    let neg_parent = -x.clone().select(0, refine_inds_opt.clone());
-                    let x = x.scatter(
-                        0,
-                        refine_inds_opt.clone(),
-                        neg_parent,
-                        IndexingUpdateOp::Add,
-                    );
+                    let x = x * mask1.clone();
                     Tensor::cat(vec![x, Tensor::zeros([refine_count], &opt_device)], 0)
                 },
             );


### PR DESCRIPTION
Fixes the flaky `tensor 'sh_coeffs' has 48 NaNs` failure in brush-c's `test_train_and_save_ffi_short` (failed roughly every other `cargo test --all --all-features --release`, never in isolation), and with it a silent correctness bug in refine's Adam moment reset.

## Root cause

Refine reset the Adam moments of split parents with `x.scatter(0, inds, -x.select(0, inds), Add)`. The index tensor for the reduced `moment_2` (`[n,1,1]`) is built with `unsqueeze_dim` + `repeat_dim`, and hits an upstream burn bug: `split_strides` (burn-std) anchors its stride walk on unit dims, so reshaping the `repeat_dim` broadcast view `[k,1]` (strides `[1,0]`) to `[k,1,1]` produces strides `[0,0,0]` — every row of the index tensor aliases row 0.

The scatter then applies all `k` adds to `inds[0]` and none to the other rows:

- `inds[0]`'s moment_2 goes **negative** (it receives the sum of everyone's negated values)
- `sqrt(-ε)` is NaN — bit pattern `0x7fffffff`, NVIDIA's canonical NaN, which spent most of this investigation masquerading as a memory-corruption sentinel
- the reduced `[n,1,1]` moment_2 broadcasts the NaN across the splat's whole 48-element SH row in the Adam update

Whether the index chain reached the scatter as a broadcast view (broken) or materialized contiguous (fine) depends on fusion flush timing — that's the suite-vs-isolation coin flip. In real training runs the same failure occasionally NaN'd one splat per refine, which the next refine's non-finite prune silently deleted, and split parents' moment_2 was never actually reset.

## Changes

- `train.rs`: reset moments with a CPU-built 0/1 mask multiply instead of `select` + `scatter(Add)` — the indices are already host-side; elementwise, fusable, and exact. This also restores the intended symmetric moment reset on split.
- `adam_scaled.rs`: clamp `moment_2` before the `sqrt` as defense in depth; a second moment is non-negative by construction, and a negative residue self-heals within a few steps.
- `validation.rs`: debug-validation asserts now report shape, per-dim coordinates, affected rows, raw bit patterns, and a re-read verdict (phantom readback vs real buffer content) — this is what cracked the case.
- `burn_scatter_repro.rs`: deterministic standalone repro of the upstream bug, `#[ignore]`d until the burn pin contains the fix, then it becomes a live regression guard.

## Repro: before / after

The repro fails on the current burn pin in under a second, no GPU load needed:

```
> cargo test -p brush-bench-test --test burn_scatter_repro --release -- --ignored

zeroing not exact at n=95 d=(1,1) rep 0 row 2 flat 2: 1.2e-8 (0x324e288f)
test result: FAILED. 0 passed; 1 failed
```

(the scattered row keeps exactly its original value — its add landed on row `inds[0]` instead).

Before this PR, the full suite reproduced the training NaN 7/7 times on this machine:

```
tensor 'sh_coeffs' shape [123, 16, 3] has 48 NaNs (first @ [26, 0, 0], rows [26], bits ["0x7fffffff", ...])
```

After: 7/7 full-suite runs pass with zero `sh_coeffs` NaNs (several with zero failures workspace-wide, including the occasionally-flaky `finite_diff` fuzz tests). With a locally patched burn containing the `split_strides` fix, the repro test passes too and the whole workspace is green.

## Upstream

The burn fix is up as tracel-ai/burn#5071 (repro commit + fix commit, with before/after test evidence). Once the pin advances past it, un-ignore `scatter_zeroing_is_exact`.

