### PR TITLE
Only query GPU memory stats when rerun is recording

### DIFF
--- a/crates/brush-process/src/train_stream.rs
+++ b/crates/brush-process/src/train_stream.rs
@@ -414,10 +414,17 @@ pub(crate) async fn train_stream(
                     .unwrap();
             }
 
-            visualize.log_memory(
-                iter,
-                &WgpuRuntime::<AutoCompiler>::client(wgpu_device).memory_usage_total()?,
-            )?;
+            // The memory query goes through the compute server and stalls
+            // behind all queued GPU work — keep it off the hot path unless
+            // rerun is actually recording, and then only on the stats cadence.
+            if rerun_config.rerun_enabled
+                && (iter.is_multiple_of(rerun_config.rerun_log_train_stats_every) || is_last_step)
+            {
+                visualize.log_memory(
+                    iter,
+                    &WgpuRuntime::<AutoCompiler>::client(wgpu_device).memory_usage_total()?,
+                )?;
+            }
             if refine.num_added > 0 {
                 visualize
                     .log_refine_stats(iter, &refine, refine_dur)


### PR DESCRIPTION
memory_usage_total() was evaluated every training iteration even with rerun disabled (it's the argument to log_memory, which only no-ops internally). The query goes through the compute server, so it stalls behind whatever GPU work is queued. Skip it unless rerun is recording, and then sample it on the train-stats cadence.