### PR TITLE
Configurable scene batch cache (max size)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -988,6 +988,7 @@ dependencies = [
  "itertools 0.14.0",
  "jpeg-decoder",
  "log",
+ "parse-size",
  "rand 0.10.1",
  "serde",
  "serde_json",
@@ -6338,6 +6339,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "parse-size"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "487f2ccd1e17ce8c1bfab3a65c89525af41cfad4c8659021a1e9a2aacd73b89b"
 
 [[package]]
 name = "password-hash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ reqwest = { version = "0.13", default-features = false, features = [
 indicatif = "0.18"
 env_logger = "0.11"
 clap = { version = "4.5.23", features = ["derive"] }
+parse-size = "1.1"
 
 web-time = "1.1.0"
 humantime = "2.1.0"

--- a/crates/brush-dataset/Cargo.toml
+++ b/crates/brush-dataset/Cargo.toml
@@ -27,6 +27,7 @@ rand.workspace = true
 
 brush-async.path = "../brush-async"
 clap.workspace = true
+parse-size.workspace = true
 itertools = "0.14"
 
 [target.'cfg(target_family = "wasm")'.dependencies]

--- a/crates/brush-dataset/src/config.rs
+++ b/crates/brush-dataset/src/config.rs
@@ -2,6 +2,13 @@ use brush_render::AlphaMode;
 use clap::Args;
 use serde::{Deserialize, Serialize};
 
+/// Default Cache budget for packed scene batches. 6 GB on native; less on
+/// wasm since the whole heap is bounded by browser limits.
+#[cfg(not(target_family = "wasm"))]
+const DEFAULT_MAX_SCENE_BATCH_CACHE_SIZE: &str = "6GiB";
+#[cfg(target_family = "wasm")]
+const DEFAULT_MAX_SCENE_BATCH_CACHE_SIZE: &str = "2GiB";
+
 #[derive(Clone, Debug, Args, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct ModelConfig {
@@ -36,4 +43,11 @@ pub struct LoadDatasetConfig {
     /// Whether to interpret an alpha channel (or masks) as transparency or masking.
     #[arg(long, help_heading = "Dataset Options")]
     pub alpha_mode: Option<AlphaMode>,
+    /// Max size of the cache for frames of the dataset, larger values usually improve performance for large datasets at the cost of more memory usage, can be e.g. 6G, 6000M, 6000MiB, 6000MB
+    #[arg(long, help_heading = "Dataset Options", default_value = DEFAULT_MAX_SCENE_BATCH_CACHE_SIZE, value_parser = parse_size)]
+    pub max_scene_batch_cache_size: u64,
+}
+
+fn parse_size(s: &str) -> Result<u64, parse_size::Error> {
+    parse_size::parse_size(s)
 }

--- a/crates/brush-dataset/src/config.rs
+++ b/crates/brush-dataset/src/config.rs
@@ -17,7 +17,7 @@ pub struct ModelConfig {
 
 #[derive(Clone, Debug, Args, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
-pub struct LoadDataseConfig {
+pub struct LoadDatasetConfig {
     /// Max nr. of frames of dataset to load
     #[arg(long, help_heading = "Dataset Options")]
     pub max_frames: Option<usize>,

--- a/crates/brush-dataset/src/formats/colmap.rs
+++ b/crates/brush-dataset/src/formats/colmap.rs
@@ -7,7 +7,7 @@ use std::{
 use super::{DatasetLoadResult, FormatError};
 use crate::{
     Dataset,
-    config::LoadDataseConfig,
+    config::LoadDatasetConfig,
     formats::{find_image_by_name, find_mask_path, split_eval_every},
     scene::{LoadImage, SceneView},
 };
@@ -101,7 +101,7 @@ async fn count_registered_images(
 
 pub(crate) async fn load_dataset(
     vfs: Arc<BrushVfs>,
-    load_args: &LoadDataseConfig,
+    load_args: &LoadDatasetConfig,
 ) -> Option<Result<DatasetLoadResult, FormatError>> {
     log::info!("Loading colmap dataset");
 
@@ -121,7 +121,7 @@ pub(crate) async fn load_dataset(
 
 async fn load_dataset_inner(
     vfs: Arc<BrushVfs>,
-    load_args: &LoadDataseConfig,
+    load_args: &LoadDatasetConfig,
     cam_path: PathBuf,
     img_path: PathBuf,
 ) -> Result<DatasetLoadResult, FormatError> {

--- a/crates/brush-dataset/src/formats/mod.rs
+++ b/crates/brush-dataset/src/formats/mod.rs
@@ -1,4 +1,4 @@
-use crate::{Dataset, config::LoadDataseConfig, scene::SceneView};
+use crate::{Dataset, config::LoadDatasetConfig, scene::SceneView};
 use brush_serde::{DeserializeError, SplatMessage, load_splat_from_ply};
 
 use brush_vfs::BrushVfs;
@@ -55,7 +55,7 @@ pub enum DatasetError {
 
 pub async fn load_dataset(
     vfs: Arc<BrushVfs>,
-    load_args: &LoadDataseConfig,
+    load_args: &LoadDatasetConfig,
 ) -> Result<DatasetLoadResult, DatasetError> {
     let mut dataset = colmap::load_dataset(vfs.clone(), load_args).await;
 

--- a/crates/brush-dataset/src/formats/nerfstudio.rs
+++ b/crates/brush-dataset/src/formats/nerfstudio.rs
@@ -1,7 +1,7 @@
 use super::{DatasetLoadResult, FormatError, find_mask_path, opengl_c2w_to_pose};
 use crate::{
     Dataset,
-    config::LoadDataseConfig,
+    config::LoadDatasetConfig,
     scene::{LoadImage, SceneView},
 };
 use brush_render::camera::fov_to_focal;
@@ -141,7 +141,7 @@ async fn read_transforms_file(
     scene: JsonScene,
     transforms_path: &Path,
     vfs: Arc<BrushVfs>,
-    load_args: &LoadDataseConfig,
+    load_args: &LoadDatasetConfig,
     warnings: &mut Vec<String>,
 ) -> Result<Vec<SceneView>, FormatError> {
     let mut results = vec![];
@@ -268,7 +268,7 @@ async fn read_transforms_file(
 
 pub async fn read_dataset(
     vfs: Arc<BrushVfs>,
-    load_args: &LoadDataseConfig,
+    load_args: &LoadDatasetConfig,
 ) -> Option<Result<DatasetLoadResult, FormatError>> {
     log::info!("Loading nerfstudio dataset");
 
@@ -289,7 +289,7 @@ pub async fn read_dataset(
 
 async fn read_dataset_inner(
     vfs: Arc<BrushVfs>,
-    load_args: &LoadDataseConfig,
+    load_args: &LoadDatasetConfig,
     json_files: Vec<std::path::PathBuf>,
     transforms_path: std::path::PathBuf,
 ) -> Result<DatasetLoadResult, FormatError> {

--- a/crates/brush-dataset/src/formats/realitycapture.rs
+++ b/crates/brush-dataset/src/formats/realitycapture.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::{
     Dataset,
-    config::LoadDataseConfig,
+    config::LoadDatasetConfig,
     scene::{LoadImage, SceneView},
 };
 use brush_render::camera::{Camera, focal_to_fov};
@@ -60,7 +60,7 @@ fn col_f64(fields: &[&str], header: &HashMap<String, usize>, name: &str) -> f64 
 
 pub async fn read_dataset(
     vfs: Arc<BrushVfs>,
-    load_args: &LoadDataseConfig,
+    load_args: &LoadDatasetConfig,
 ) -> Option<Result<DatasetLoadResult, FormatError>> {
     let csv_paths: Vec<_> = vfs.files_with_extension("csv").collect();
 
@@ -87,7 +87,7 @@ pub async fn read_dataset(
 
 async fn read_dataset_inner(
     vfs: Arc<BrushVfs>,
-    load_args: &LoadDataseConfig,
+    load_args: &LoadDatasetConfig,
     contents: String,
 ) -> Result<DatasetLoadResult, FormatError> {
     let mut lines = contents.lines().filter(|l| !l.trim().is_empty());

--- a/crates/brush-dataset/src/scene_loader.rs
+++ b/crates/brush-dataset/src/scene_loader.rs
@@ -4,14 +4,10 @@ use brush_async::Actor;
 use rand::{SeedableRng, seq::SliceRandom};
 use tokio::sync::{Mutex, mpsc};
 
-use crate::scene::{Scene, SceneBatch, sample_to_packed_data, view_to_sample_image};
-
-/// Cache budget for packed scene batches. 6 GB on native; less on
-/// wasm since the whole heap is bounded by browser limits.
-#[cfg(not(target_family = "wasm"))]
-const CACHE_BUDGET_BYTES: usize = 6 * 1024 * 1024 * 1024;
-#[cfg(target_family = "wasm")]
-const CACHE_BUDGET_BYTES: usize = 2 * 1024 * 1024 * 1024;
+use crate::{
+    config::LoadDatasetConfig,
+    scene::{Scene, SceneBatch, sample_to_packed_data, view_to_sample_image},
+};
 
 /// Shared cache of GPU-ready scene batches. Each slot holds at most one
 /// batch; once the running total passes `budget_bytes`, new batches bypass
@@ -22,16 +18,16 @@ const CACHE_BUDGET_BYTES: usize = 2 * 1024 * 1024 * 1024;
 /// single copy of the already-packed `[H, W]` u32 buffer.
 struct BatchCache {
     slots: Vec<Option<Arc<SceneBatch>>>,
-    used_bytes: usize,
-    budget_bytes: usize,
+    used_bytes: u64,
+    budget_bytes: u64,
 }
 
 impl BatchCache {
-    fn new(n_views: usize) -> Self {
+    fn new(n_views: usize, budget_bytes: u64) -> Self {
         Self {
             slots: vec![None; n_views],
             used_bytes: 0,
-            budget_bytes: CACHE_BUDGET_BYTES,
+            budget_bytes,
         }
     }
 
@@ -45,7 +41,12 @@ impl BatchCache {
         }
         // Track exact bytes: rounding to whole MB let sub-MB images slip in
         // for free and bypass the budget entirely.
-        let size_bytes = batch.img_packed.as_bytes().len();
+        let size_bytes: u64 = batch
+            .img_packed
+            .as_bytes()
+            .len()
+            .try_into()
+            .expect("shouldn't exceed ~18 Exabytes...");
         if self.used_bytes + size_bytes < self.budget_bytes {
             self.slots[index] = Some(batch);
             self.used_bytes += size_bytes;
@@ -61,7 +62,7 @@ pub struct SceneLoader {
 }
 
 impl SceneLoader {
-    pub fn new(scene: &Scene, seed: u64) -> Self {
+    pub fn new(scene: &Scene, seed: u64, config: &LoadDatasetConfig) -> Self {
         // Prefetch buffer: at most 4 batches ahead of the trainer.
         // Two tasks per actor share this buffer so one task's I/O can
         // overlap with the other's decode + GPU upload.
@@ -78,7 +79,10 @@ impl SceneLoader {
         const TASKS_PER_ACTOR: usize = 2;
 
         let views = scene.views.clone();
-        let cache = Arc::new(Mutex::new(BatchCache::new(views.len())));
+        let cache = Arc::new(Mutex::new(BatchCache::new(
+            views.len(),
+            config.max_scene_batch_cache_size,
+        )));
 
         let mut task_idx: u64 = 0;
         let actors: Vec<Actor> = (0..n_actors)

--- a/crates/brush-process/src/config.rs
+++ b/crates/brush-process/src/config.rs
@@ -58,7 +58,7 @@ pub struct TrainStreamConfig {
     pub model_config: brush_dataset::config::ModelConfig,
     #[clap(flatten)]
     #[serde(flatten)]
-    pub load_config: brush_dataset::config::LoadDataseConfig,
+    pub load_config: brush_dataset::config::LoadDatasetConfig,
     #[clap(flatten)]
     #[serde(flatten)]
     pub process_config: ProcessConfig,

--- a/crates/brush-process/src/train_stream.rs
+++ b/crates/brush-process/src/train_stream.rs
@@ -171,7 +171,7 @@ pub(crate) async fn train_stream(
     let mut eval_scene = dataset.eval;
 
     let mut train_duration = Duration::from_secs(0);
-    let mut dataloader = SceneLoader::new(&dataset.train, 42);
+    let mut dataloader = SceneLoader::new(&dataset.train, 42, &train_stream_config.load_config);
     let bounds = get_splat_bounds(init_splats.clone(), BOUND_PERCENTILE).await;
 
     // Per-train-view (world center, focal-px at native res) for the
@@ -268,9 +268,9 @@ pub(crate) async fn train_stream(
             let cumulative_scale = (lod_img_pct as f32 / 100.0).powi(current_lod as i32);
             dataloader = if lod_img_pct < 100 {
                 let lod_scene = dataset.train.clone().with_image_scale(cumulative_scale);
-                SceneLoader::new(&lod_scene, 42)
+                SceneLoader::new(&lod_scene, 42, &train_stream_config.load_config)
             } else {
-                SceneLoader::new(&dataset.train, 42)
+                SceneLoader::new(&dataset.train, 42, &train_stream_config.load_config)
             };
 
             let bounds = get_splat_bounds(splats.clone(), BOUND_PERCENTILE).await;


### PR DESCRIPTION
I noticed that the cache is quickly saturated when training with bigger datasets and can slow down significantly then (when IO is slow, like harddisk or streaming over network), thus when RAM is available I think it makes sense to make this configurable.

Not sure yet about the name of the cli argument, something like `--max-frame-cache-size` might be more user-friendly...

I've deliberately used the `train_stream_config.load_config` directly for the `SceneLoader` as I think with other planned contributions this reduces code-churn, since other parameters might be added like e.g. whether to use compression (when this should even be configurable), but of course we can just pass the size directly.