### PR TITLE
Gsplat like depth loss + depth map viewer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,6 +992,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tiff",
  "tokio",
  "tracing",
  "wasm-bindgen-test",

--- a/apps/brush-app/src/ui/app.rs
+++ b/apps/brush-app/src/ui/app.rs
@@ -149,6 +149,7 @@ pub struct CameraSettings {
     pub splat_scale: Option<f32>,
     pub background: Option<Vec3>,
     pub grid_enabled: Option<bool>,
+    pub depth_view: bool,
     pub clamping: CameraClamping,
 }
 

--- a/apps/brush-app/src/ui/scene.rs
+++ b/apps/brush-app/src/ui/scene.rs
@@ -451,6 +451,83 @@ impl ScenePanel {
         }
     }
 
+    /// Google's "Turbo" colormap, matching the polynomial in the backbuffer shader.
+    fn turbo_color(t: f32) -> Color32 {
+        let x = t.clamp(0.0, 1.0);
+        let c0 = [0.114_089_01, 0.062_883_41, 0.224_833_72];
+        let c1 = [6.716_419_5, 3.182_286_8, 7.571_581_6];
+        let c2 = [-66.094_02, -4.927_983, -10.094_394];
+        let c3 = [228.766_08, 25.049_868, -91.541_05];
+        let c4 = [-334.835_15, -69.317_5, 288.585_88];
+        let c5 = [218.763_72, 67.521_51, -305.204_6];
+        let c6 = [-52.889_034, -21.545_273, 110.517_46];
+        let mut rgb = [0.0f32; 3];
+        for i in 0..3 {
+            let v = c0[i]
+                + x * (c1[i] + x * (c2[i] + x * (c3[i] + x * (c4[i] + x * (c5[i] + x * c6[i])))));
+            rgb[i] = v.clamp(0.0, 1.0);
+        }
+        Color32::from_rgb(
+            (rgb[0] * 255.0) as u8,
+            (rgb[1] * 255.0) as u8,
+            (rgb[2] * 255.0) as u8,
+        )
+    }
+
+    /// Draw a vertical depth colorbar in the top-right of `rect` with min/max labels.
+    fn draw_depth_colorbar(ui: &egui::Ui, rect: Rect, depth_min: f32, depth_max: f32) {
+        let painter = ui.painter_at(rect);
+
+        let bar_w = 16.0;
+        let bar_h = (rect.height() * 0.4).clamp(80.0, 240.0);
+        let bar_rect = Rect::from_min_size(
+            egui::pos2(rect.max.x - 24.0 - bar_w, rect.min.y + 36.0),
+            egui::vec2(bar_w, bar_h),
+        );
+
+        let bg_rect = Rect::from_min_max(
+            egui::pos2(bar_rect.min.x - 40.0, bar_rect.min.y - 12.0),
+            egui::pos2(bar_rect.max.x + 12.0, bar_rect.max.y + 12.0),
+        );
+        painter.rect_filled(
+            bg_rect,
+            6.0,
+            Color32::from_rgba_unmultiplied(20, 20, 25, 180),
+        );
+
+        let steps = 64;
+        for i in 0..steps {
+            let f = i as f32 / (steps - 1) as f32;
+            let seg_top = bar_rect.max.y - (i as f32 + 1.0) / steps as f32 * bar_h;
+            let color = Self::turbo_color(f);
+            painter.rect_filled(
+                Rect::from_min_size(
+                    egui::pos2(bar_rect.min.x, seg_top),
+                    egui::vec2(bar_w, bar_h / steps as f32 + 1.0),
+                ),
+                0.0,
+                color,
+            );
+        }
+
+        let text_color = Color32::WHITE;
+        let font = egui::FontId::new(11.0, egui::FontFamily::Proportional);
+        painter.text(
+            egui::pos2(bar_rect.min.x - 6.0, bar_rect.min.y),
+            Align2::RIGHT_CENTER,
+            format!("{depth_max:.2}"),
+            font.clone(),
+            text_color,
+        );
+        painter.text(
+            egui::pos2(bar_rect.min.x - 6.0, bar_rect.max.y),
+            Align2::RIGHT_CENTER,
+            format!("{depth_min:.2}"),
+            font,
+            text_color,
+        );
+    }
+
     fn draw_controls_help(ui: &mut egui::Ui, min_width: Option<f32>) {
         let key_color = Color32::from_rgb(140, 180, 220);
         let action_color = Color32::from_rgb(140, 140, 140);
@@ -557,6 +634,16 @@ impl ScenePanel {
         let mut enabled = settings.grid_enabled.unwrap_or(false);
         if ui.checkbox(&mut enabled, "Show Grid").changed() {
             settings.grid_enabled = Some(enabled);
+            process.set_cam_settings(&settings);
+        }
+
+        // Depth map view toggle
+        let mut settings = process.get_cam_settings();
+        if ui
+            .checkbox(&mut settings.depth_view, "Depth map view")
+            .on_hover_text("Render the depth instead of color")
+            .changed()
+        {
             process.set_cam_settings(&settings);
         }
 
@@ -1039,6 +1126,9 @@ impl AppPane for ScenePanel {
                 camera.fov_y = focal_to_fov(focal_x, size.y, &camera.camera_model);
             }
 
+            // Depth range of the last rendered depth map, for the colorbar.
+            let mut depth_range = None;
+
             // Render the splats and grid
             ui.scope(|ui| {
                 // if training views have alpha, show a background checker. Masked images
@@ -1059,7 +1149,7 @@ impl AppPane for ScenePanel {
                 }
 
                 if let Some(backbuffer) = &mut self.backbuffer {
-                    backbuffer.paint(
+                    depth_range = backbuffer.paint(
                         rect,
                         ui,
                         &process.current_splats(),
@@ -1067,6 +1157,7 @@ impl AppPane for ScenePanel {
                         self.frame as usize,
                         settings.background.unwrap_or(Vec3::ZERO),
                         settings.splat_scale,
+                        settings.depth_view,
                         self.splats_dirty,
                     );
                     self.splats_dirty = false;
@@ -1080,6 +1171,10 @@ impl AppPane for ScenePanel {
             });
 
             self.update_and_draw_reference_pose_bars(ui, rect, &camera, delta_time);
+
+            if let Some((depth_min, depth_max)) = depth_range {
+                Self::draw_depth_colorbar(ui, rect, depth_min, depth_max);
+            }
 
             if interactive {
                 self.draw_play_pause(ui, rect);

--- a/apps/brush-app/src/ui/settings_popup.rs
+++ b/apps/brush-app/src/ui/settings_popup.rs
@@ -193,7 +193,7 @@ pub(crate) fn draw_settings(ui: &mut Ui, args: &mut TrainStreamConfig, enabled: 
         slider(
             ui,
             &mut tc.depth_loss_weight,
-            0.0..=10.0,
+            0.0..=1.0,
             "Depth loss weight (0 disables)",
             false,
             enabled,

--- a/apps/brush-app/src/ui/settings_popup.rs
+++ b/apps/brush-app/src/ui/settings_popup.rs
@@ -190,6 +190,14 @@ pub(crate) fn draw_settings(ui: &mut Ui, args: &mut TrainStreamConfig, enabled: 
             false,
             enabled,
         );
+        slider(
+            ui,
+            &mut tc.depth_loss_weight,
+            0.0..=10.0,
+            "Depth loss weight (0 disables)",
+            false,
+            enabled,
+        );
     });
 
     ui.collapsing("Background", |ui| {
@@ -387,6 +395,14 @@ pub(crate) fn draw_settings(ui: &mut Ui, args: &mut TrainStreamConfig, enabled: 
             args.load_config.alpha_mode = Some(alpha_mode);
         }
     }
+
+    ui.add_enabled(
+        enabled,
+        egui::Checkbox::new(
+            &mut args.load_config.estimate_metric_scale,
+            "Estimate metric scale",
+        ),
+    );
 
     ui.add_space(16.0);
 

--- a/apps/brush-app/src/ui/shaders/splat_backbuffer.wgsl
+++ b/apps/brush-app/src/ui/shaders/splat_backbuffer.wgsl
@@ -1,6 +1,11 @@
 struct Uniforms {
     img_width: u32,
     img_height: u32,
+    mode: u32,
+    _pad: u32,
+    depth_min: f32,
+    depth_max: f32,
+    _pad2: vec2<f32>,
 }
 
 @group(0) @binding(0) var<uniform> uniforms: Uniforms;
@@ -22,6 +27,19 @@ fn vs_main(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
     return out;
 }
 
+fn turbo(t: f32) -> vec3<f32> {
+    let x = clamp(t, 0.0, 1.0);
+    let c0 = vec3<f32>(0.1140890109226559, 0.06288340699912215, 0.2248337216805064);
+    let c1 = vec3<f32>(6.716419496985708, 3.182286745507602, 7.571581586103393);
+    let c2 = vec3<f32>(-66.09402360453038, -4.9279827041226, -10.09439367561635);
+    let c3 = vec3<f32>(228.7660791526501, 25.04986699771574, -91.54105330182436);
+    let c4 = vec3<f32>(-334.8351565777451, -69.31749712757485, 288.5858850615712);
+    let c5 = vec3<f32>(218.7637218434795, 67.52150567819112, -305.2045772184957);
+    let c6 = vec3<f32>(-52.88903478218835, -21.54527364654712, 110.5174647748972);
+    let rgb = c0 + x * (c1 + x * (c2 + x * (c3 + x * (c4 + x * (c5 + x * c6)))));
+    return clamp(rgb, vec3<f32>(0.0), vec3<f32>(1.0));
+}
+
 @fragment
 fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     let pixel_x = u32(in.uv.x * f32(uniforms.img_width));
@@ -32,12 +50,22 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     }
 
     let idx = pixel_y * uniforms.img_width + pixel_x;
-    let packed = image_data[idx];
+    let raw = image_data[idx];
+
+    if (uniforms.mode == 1u) {
+        let depth = bitcast<f32>(raw);
+        if (depth <= 0.0) {
+            return vec4<f32>(0.0, 0.0, 0.0, 0.0);
+        }
+        let range = max(uniforms.depth_max - uniforms.depth_min, 1e-6);
+        let t = (depth - uniforms.depth_min) / range;
+        return vec4<f32>(turbo(t), 1.0);
+    }
 
     // Unpack RGBA8: R|(G<<8)|(B<<16)|(A<<24)
-    let r = f32(packed & 0xFFu) / 255.0;
-    let g = f32((packed >> 8u) & 0xFFu) / 255.0;
-    let b = f32((packed >> 16u) & 0xFFu) / 255.0;
-    let a = f32((packed >> 24u) & 0xFFu) / 255.0;
+    let r = f32(raw & 0xFFu) / 255.0;
+    let g = f32((raw >> 8u) & 0xFFu) / 255.0;
+    let b = f32((raw >> 16u) & 0xFFu) / 255.0;
+    let a = f32((raw >> 24u) & 0xFFu) / 255.0;
     return vec4<f32>(r, g, b, a);
 }

--- a/apps/brush-app/src/ui/splat_backbuffer.rs
+++ b/apps/brush-app/src/ui/splat_backbuffer.rs
@@ -2,9 +2,9 @@ use brush_async::{Actor, AsyncMap};
 use brush_process::slot::Slot;
 use brush_render::{
     TextureMode, burn_glue::resolve_to_cube_float, camera::Camera, gaussian_splats::Splats,
-    render_splats,
+    render_splats, render_splats_depth,
 };
-use burn::tensor::Tensor;
+use burn::tensor::{Tensor, s};
 use egui::Rect;
 use glam::{UVec2, Vec3};
 
@@ -23,11 +23,20 @@ struct LastRenderState {
     camera: Camera,
     background: Vec3,
     splat_scale: Option<f32>,
+    depth_view: bool,
     img_size: UVec2,
 }
 
+#[derive(Clone)]
+struct RenderResult {
+    /// In RGBA mode, a `[H, W, 1]` tensor holding packed RGBA8 values.
+    /// In depth mode, a `[H, W, 1]` tensor of depths.
+    image: Tensor<3>,
+    depth_range: Option<(f32, f32)>,
+}
+
 pub struct SplatBackbuffer {
-    pipe: AsyncMap<RenderRequest, Tensor<3>>,
+    pipe: AsyncMap<RenderRequest, RenderResult>,
 }
 
 impl SplatBackbuffer {
@@ -45,16 +54,12 @@ impl SplatBackbuffer {
         let pipe = AsyncMap::new(
             actor,
             async move |req: &RenderRequest| {
-                let (image, _) = render_splats(
-                    req.splats.get(req.state.frame).unwrap(),
-                    &req.state.camera,
-                    req.state.img_size,
-                    req.state.background,
-                    req.state.splat_scale,
-                    TextureMode::Packed,
-                )
-                .await;
-                image
+                let splats = req.splats.get(req.state.frame).unwrap();
+                if req.state.depth_view {
+                    render_depth(splats, req).await
+                } else {
+                    render_rgba(splats, req).await
+                }
             },
             |req: &RenderRequest| req.ctx.request_repaint(),
         );
@@ -71,8 +76,9 @@ impl SplatBackbuffer {
         frame: usize,
         background: Vec3,
         splat_scale: Option<f32>,
+        depth_view: bool,
         splats_dirty: bool,
-    ) {
+    ) -> Option<(f32, f32)> {
         // Calculate pixel size for rendering
         let ppp = ui.ctx().pixels_per_point();
         let img_size = UVec2::new(
@@ -86,6 +92,7 @@ impl SplatBackbuffer {
             camera: *camera,
             background,
             splat_scale,
+            depth_view,
             img_size,
         };
 
@@ -100,7 +107,8 @@ impl SplatBackbuffer {
             });
         }
 
-        if let Some(image) = self.pipe.latest() {
+        if let Some(result) = self.pipe.latest() {
+            let image = result.image;
             let shape = image.shape();
             let img_height = shape[0] as u32;
             let img_width = shape[1] as u32;
@@ -112,8 +120,13 @@ impl SplatBackbuffer {
                         last_img: image,
                         img_width,
                         img_height,
+                        depth_range: result.depth_range,
                     },
                 ));
+
+            result.depth_range
+        } else {
+            None
         }
     }
 }
@@ -123,6 +136,12 @@ impl SplatBackbuffer {
 struct Uniforms {
     img_width: u32,
     img_height: u32,
+    /// 0 = packed RGBA image, 1 = float32 depth map.
+    mode: u32,
+    _pad: u32,
+    depth_min: f32,
+    depth_max: f32,
+    _pad2: [f32; 2],
 }
 
 pub struct SplatBackbufferResources {
@@ -220,10 +239,71 @@ impl SplatBackbufferResources {
     }
 }
 
+async fn render_rgba(splats: Splats, req: &RenderRequest) -> RenderResult {
+    let (image, _) = render_splats(
+        splats,
+        &req.state.camera,
+        req.state.img_size,
+        req.state.background,
+        req.state.splat_scale,
+        TextureMode::Packed,
+    )
+    .await;
+    RenderResult {
+        image,
+        depth_range: None,
+    }
+}
+
+async fn render_depth(splats: Splats, req: &RenderRequest) -> RenderResult {
+    let max_depth = 100.0;
+
+    let (image, _) = render_splats_depth(
+        splats,
+        &req.state.camera,
+        req.state.img_size,
+        req.state.background,
+        req.state.splat_scale,
+    )
+    .await;
+
+    let accumulated_depth = image.clone().slice(s![.., .., 4..5]);
+    let alpha = image.clone().slice(s![.., .., 3..4]);
+    let depth = accumulated_depth / alpha.clamp_min(1e-10);
+
+    let invalid = depth.clone().lower_equal_elem(0.0) | depth.clone().greater_elem(max_depth);
+    let depth_min = depth
+        .clone()
+        .mask_fill(invalid.clone(), f32::INFINITY)
+        .min()
+        .into_scalar_async::<f32>()
+        .await
+        .expect("Failed to read depth min");
+    let depth_max = depth
+        .clone()
+        .mask_fill(invalid, f32::NEG_INFINITY)
+        .max()
+        .into_scalar_async::<f32>()
+        .await
+        .expect("Failed to read depth max");
+
+    let depth_range = if depth_min.is_finite() && depth_max.is_finite() && depth_max > depth_min {
+        (depth_min, depth_max)
+    } else {
+        (0.0, max_depth)
+    };
+
+    RenderResult {
+        image: depth,
+        depth_range: Some(depth_range),
+    }
+}
+
 struct SplatBackbufferPainter {
     last_img: Tensor<3>,
     img_width: u32,
     img_height: u32,
+    depth_range: Option<(f32, f32)>,
 }
 
 impl CallbackTrait for SplatBackbufferPainter {
@@ -240,12 +320,21 @@ impl CallbackTrait for SplatBackbufferPainter {
         };
 
         // Update uniform buffer with image dimensions
+        let (mode, depth_min, depth_max) = match self.depth_range {
+            Some((min, max)) => (1, min, max),
+            None => (0, 0.0, 1.0),
+        };
         queue.write_buffer(
             &res.uniform_buffer,
             0,
             bytemuck::cast_slice(&[Uniforms {
                 img_width: self.img_width,
                 img_height: self.img_height,
+                mode,
+                _pad: 0,
+                depth_min,
+                depth_max,
+                _pad2: [0.0; 2],
             }]),
         );
 

--- a/apps/brush-app/src/wasm.rs
+++ b/apps/brush-app/src/wasm.rs
@@ -60,6 +60,7 @@ impl CameraSettings {
             },
             background: background.map(|v| v.to_glam()),
             grid_enabled,
+            depth_view: false,
         })
     }
 }

--- a/crates/brush-bench-test/src/benches.rs
+++ b/crates/brush-bench-test/src/benches.rs
@@ -136,6 +136,7 @@ fn generate_training_batch(resolution: (u32, u32), camera_pos: Vec3) -> SceneBat
         img_packed,
         has_alpha: false,
         alpha_mode: AlphaMode::Transparent,
+        depth: None,
         camera,
     }
 }

--- a/crates/brush-bench-test/tests/finite_diff.rs
+++ b/crates/brush-bench-test/tests/finite_diff.rs
@@ -11,7 +11,7 @@
 //! away from f16 quantization limits) so central differences are
 //! second-order accurate.
 
-use brush_render::gaussian_splats::RasterPass;
+use brush_render::gaussian_splats::{RasterPass, RasterizationMode};
 use brush_render::{
     camera::Camera,
     gaussian_splats::{SplatRenderMode, Splats},
@@ -105,7 +105,17 @@ async fn render_value(
         let splats = splats;
         let cam: &Camera = cam;
         let background = Vec3::ZERO;
-        async move { render_splats_with_pass(splats, cam, img_size, background, PASS).await }
+        async move {
+            render_splats_with_pass(
+                splats,
+                cam,
+                img_size,
+                background,
+                PASS,
+                RasterizationMode::Rgba,
+            )
+            .await
+        }
     }
     .await;
     diff.img
@@ -126,7 +136,17 @@ async fn analytical_grads(
         let splats = splats.clone();
         let cam: &Camera = cam;
         let background = Vec3::ZERO;
-        async move { render_splats_with_pass(splats, cam, img_size, background, PASS).await }
+        async move {
+            render_splats_with_pass(
+                splats,
+                cam,
+                img_size,
+                background,
+                PASS,
+                RasterizationMode::Rgba,
+            )
+            .await
+        }
     }
     .await;
     let grads = diff.img.mean().backward();
@@ -381,7 +401,15 @@ async fn finite_diff_broad_mip_mode() {
             SplatRenderMode::Mip,
             device,
         );
-        let diff = render_splats_with_pass(splats, cam, img_size, Vec3::ZERO, PASS).await;
+        let diff = render_splats_with_pass(
+            splats,
+            cam,
+            img_size,
+            Vec3::ZERO,
+            PASS,
+            RasterizationMode::Rgba,
+        )
+        .await;
         diff.img
             .mean()
             .into_scalar_async::<f32>()
@@ -404,7 +432,15 @@ async fn finite_diff_broad_mip_mode() {
             SplatRenderMode::Mip,
             device,
         );
-        let diff = render_splats_with_pass(splats.clone(), cam, img_size, Vec3::ZERO, PASS).await;
+        let diff = render_splats_with_pass(
+            splats.clone(),
+            cam,
+            img_size,
+            Vec3::ZERO,
+            PASS,
+            RasterizationMode::Rgba,
+        )
+        .await;
         let g = diff.img.mean().backward();
         (splats, g)
     }
@@ -486,7 +522,15 @@ async fn finite_diff_weighted_loss() {
         device: &burn::tensor::Device,
     ) -> f32 {
         let splats = build_splats(scene, device);
-        let diff = render_splats_with_pass(splats, cam, img_size, Vec3::ZERO, PASS).await;
+        let diff = render_splats_with_pass(
+            splats,
+            cam,
+            img_size,
+            Vec3::ZERO,
+            PASS,
+            RasterizationMode::Rgba,
+        )
+        .await;
         (diff.img * weights)
             .sum()
             .into_scalar_async::<f32>()
@@ -502,7 +546,15 @@ async fn finite_diff_weighted_loss() {
         device: &burn::tensor::Device,
     ) -> (Splats, Gradients) {
         let splats = build_splats(scene, device);
-        let diff = render_splats_with_pass(splats.clone(), cam, img_size, Vec3::ZERO, PASS).await;
+        let diff = render_splats_with_pass(
+            splats.clone(),
+            cam,
+            img_size,
+            Vec3::ZERO,
+            PASS,
+            RasterizationMode::Rgba,
+        )
+        .await;
         let loss = (diff.img * weights).sum();
         (splats, loss.backward())
     }

--- a/crates/brush-bench-test/tests/fuzz.rs
+++ b/crates/brush-bench-test/tests/fuzz.rs
@@ -185,6 +185,7 @@ async fn render_raw(
         cube_tensor(device, [n, 1, 3], dc),
         cube_tensor(device, [n], opac),
         mode,
+        brush_render::gaussian_splats::RasterizationMode::Rgba,
         glam::Vec3::ZERO,
         brush_render::gaussian_splats::RasterPass::Forward,
     )

--- a/crates/brush-bench-test/tests/integration.rs
+++ b/crates/brush-bench-test/tests/integration.rs
@@ -126,6 +126,7 @@ fn generate_test_batch(resolution: (u32, u32)) -> SceneBatch {
         img_packed,
         has_alpha: false,
         alpha_mode: AlphaMode::Transparent,
+        depth: None,
         camera,
     }
 }
@@ -252,6 +253,7 @@ async fn train_with_zero_visible_does_not_crash() {
         img_packed: TensorData::new(vec![pixel; 64 * 64], [64usize, 64]),
         has_alpha: false,
         alpha_mode: AlphaMode::Transparent,
+        depth: None,
         camera,
     };
 

--- a/crates/brush-dataset/Cargo.toml
+++ b/crates/brush-dataset/Cargo.toml
@@ -17,6 +17,7 @@ bytemuck.workspace = true
 thiserror = { workspace = true }
 image.workspace = true
 jpeg-decoder.workspace = true
+tiff = "0.11"
 serde.workspace = true
 serde_json.workspace = true
 glam.workspace = true

--- a/crates/brush-dataset/src/config.rs
+++ b/crates/brush-dataset/src/config.rs
@@ -36,4 +36,7 @@ pub struct LoadDataseConfig {
     /// Whether to interpret an alpha channel (or masks) as transparency or masking.
     #[arg(long, help_heading = "Dataset Options")]
     pub alpha_mode: Option<AlphaMode>,
+    /// Whether to rescale the dataset to suite the depth map scale
+    #[arg(long, help_heading = "Dataset Options", default_value = "false")]
+    pub estimate_metric_scale: bool,
 }

--- a/crates/brush-dataset/src/formats/colmap.rs
+++ b/crates/brush-dataset/src/formats/colmap.rs
@@ -8,8 +8,10 @@ use super::{DatasetLoadResult, FormatError};
 use crate::{
     Dataset,
     config::LoadDataseConfig,
-    formats::{find_image_by_name, find_mask_path, split_eval_every},
-    scene::{LoadImage, SceneView},
+    formats::{
+        find_depth_path, find_image_by_name, find_mask_path, find_points3d_path, split_eval_every,
+    },
+    scene::{LoadDepth, LoadImage, SceneView},
 };
 use brush_render::kernels::camera_model::CameraModel;
 use brush_render::kernels::camera_model::CameraModel::{
@@ -140,6 +142,7 @@ async fn load_dataset_inner(
         .parent()
         .expect("colmap cameras file must have a parent")
         .to_path_buf();
+    let points_dir_ = points_dir.clone();
 
     // One actor for both halves of the colmap load — the camera/image
     // parse and the points3d parse run concurrently on the same thread
@@ -153,11 +156,26 @@ async fn load_dataset_inner(
             .map(|cam| (cam.id, cam))
             .collect::<HashMap<_, _>>();
         let mut img_file = vfs.reader_at_path(&img_path).await?;
-        let img_infos = colmap_reader::read_images(&mut img_file, is_binary, false).await?;
+        let img_infos =
+            colmap_reader::read_images(&mut img_file, is_binary, load_args.estimate_metric_scale)
+                .await?;
         let mut img_info_list = img_infos.into_iter().collect::<Vec<_>>();
         img_info_list.sort_by(|img_a, img_b| img_a.name.cmp(&img_b.name));
 
         log::info!("Loading {} images for colmap dataset", img_info_list.len());
+
+        // COLMAP is reconstructed up to an unknown global scale.
+        // If metric depth maps are present, recover that scale so poses + points line
+        // up with the depth.
+        let metric_scale = if load_args.estimate_metric_scale {
+            let scale = estimate_metric_scale(&vfs, &img_info_list, &cam_model_data, &points_dir_)
+                .await
+                .expect("estimate metric scale failed");
+            log::info!("Rescaling colmap reconstruction to metric depth (scale = {scale})");
+            Some(scale)
+        } else {
+            None
+        };
 
         let mut views = Vec::new();
         let mut warnings = Vec::new();
@@ -192,10 +210,14 @@ async fn load_dataset_inner(
             };
 
             let mask_path = find_mask_path(&vfs, path);
+            let depth =
+                find_depth_path(&vfs, path).map(|p| LoadDepth::new(vfs.clone(), p.to_path_buf()));
 
             // Convert w2c to c2w.
-            let world_to_cam =
-                glam::Affine3A::from_rotation_translation(img_info.quat, img_info.tvec);
+            let world_to_cam = glam::Affine3A::from_rotation_translation(
+                img_info.quat,
+                img_info.tvec * metric_scale.unwrap_or(1.0),
+            );
             let cam_to_world = world_to_cam.inverse();
             let (_, quat, translation) = cam_to_world.to_scale_rotation_translation();
 
@@ -217,28 +239,29 @@ async fn load_dataset_inner(
                 load_args.alpha_mode,
             );
 
-            views.push(SceneView { camera, image });
+            views.push(SceneView {
+                camera,
+                image,
+                depth,
+            });
         }
 
         let (train_views, eval_views) = split_eval_every(views, load_args.eval_split_every);
 
-        Result::<_, FormatError>::Ok((Dataset::from_views(train_views, eval_views), warnings))
+        Result::<_, FormatError>::Ok((
+            Dataset::from_views(train_views, eval_views),
+            warnings,
+            metric_scale,
+        ))
     });
 
     let load_args = load_args.clone();
 
     let init = actor.run(move || async move {
-        let points_path = vfs_init
-            .files_ending_in("points3d.txt")
-            .chain(vfs_init.files_ending_in("points3d.bin"))
-            .find(|p| p.parent() == Some(points_dir.as_path()))?;
-        let is_binary = matches!(
-            points_path.extension().and_then(|p| p.to_str()),
-            Some("bin")
-        );
+        let (points_path, is_binary) = find_points3d_path(&vfs_init, &points_dir)?;
         // At this point the VFS has said this file exists so just unwrap.
         let mut points_file = vfs_init
-            .reader_at_path(points_path)
+            .reader_at_path(&points_path)
             .await
             .expect("unreachable");
 
@@ -292,7 +315,13 @@ async fn load_dataset_inner(
 
     // Wait for both halves.
     let (dataset, init) = tokio::join!(dataset, init);
-    let ((dataset, warnings), init_splat) = (dataset?, init);
+    let ((dataset, warnings, metric_scale), mut init_splat) = (dataset?, init);
+
+    if let (Some(scale), Some(splat)) = (metric_scale, init_splat.as_mut()) {
+        for m in &mut splat.data.means {
+            *m *= scale;
+        }
+    }
 
     Ok(DatasetLoadResult {
         init_splat,
@@ -380,4 +409,84 @@ fn build_camera_model(colmap_camera: &ColmapCamera) -> CameraModel {
             Pinhole
         }
     }
+}
+
+/// Estimate the global scale that maps the COLMAP reconstruction into
+/// the metric frame of the depth maps.
+async fn estimate_metric_scale(
+    vfs: &Arc<BrushVfs>,
+    images: &[colmap_reader::Image],
+    cameras: &HashMap<i32, ColmapCamera>,
+    points_dir: &Path,
+) -> Option<f32> {
+    let any_depth = images.iter().any(|img| {
+        find_image_by_name(vfs, &img.name)
+            .and_then(|p| super::find_depth_path(vfs, p))
+            .is_some()
+    });
+    if !any_depth {
+        return None;
+    }
+
+    let (points_path, is_binary) = find_points3d_path(vfs, points_dir)?;
+    let mut points_file = vfs.reader_at_path(&points_path).await.ok()?;
+    let points = colmap_reader::read_points3d(&mut points_file, is_binary, false)
+        .await
+        .ok()?;
+    let point_map: HashMap<i64, glam::Vec3> = points.iter().map(|p| (p.id, p.xyz)).collect();
+
+    let mut accumulated_colmap_depth = 0.0;
+    let mut accumulated_dataset_depth = 0.0;
+
+    for img in images {
+        let Some(point_data) = &img.points else {
+            continue;
+        };
+        let Some(image_path) = find_image_by_name(vfs, &img.name) else {
+            continue;
+        };
+        let Some(depth_path) = find_depth_path(vfs, image_path) else {
+            continue;
+        };
+        let Some(cam) = cameras.get(&img.camera_id) else {
+            continue;
+        };
+
+        let height = cam.height as usize;
+        let width = cam.width as usize;
+
+        let depth_loader = LoadDepth::new(vfs.clone(), depth_path.to_path_buf());
+        let Ok(depth) = depth_loader.load_vec(height, width).await else {
+            continue;
+        };
+
+        for (xy, &pid) in point_data.xys.iter().zip(point_data.point3d_ids.iter()) {
+            if pid < 0 {
+                continue;
+            }
+            let Some(&xyz) = point_map.get(&pid) else {
+                continue;
+            };
+            let colmap_depth = (img.quat * xyz + img.tvec).z;
+
+            let u = xy.x as i32;
+            let v = xy.y as i32;
+
+            if u < 0 || v < 0 || u as usize >= width || v as usize >= height {
+                continue;
+            }
+
+            let expected_depth = depth[v as usize * width + u as usize];
+            if expected_depth <= 0.0 || colmap_depth <= 0.0 {
+                continue;
+            }
+            accumulated_colmap_depth += colmap_depth;
+            accumulated_dataset_depth += expected_depth;
+        }
+    }
+
+    let scale = accumulated_dataset_depth / accumulated_colmap_depth;
+
+    log::info!("Estimated metric scale {scale}");
+    Some(scale)
 }

--- a/crates/brush-dataset/src/formats/colmap.rs
+++ b/crates/brush-dataset/src/formats/colmap.rs
@@ -261,7 +261,7 @@ async fn load_dataset_inner(
         let (points_path, is_binary) = find_points3d_path(&vfs_init, &points_dir)?;
         // At this point the VFS has said this file exists so just unwrap.
         let mut points_file = vfs_init
-            .reader_at_path(&points_path)
+            .reader_at_path(points_path)
             .await
             .expect("unreachable");
 
@@ -429,7 +429,7 @@ async fn estimate_metric_scale(
     }
 
     let (points_path, is_binary) = find_points3d_path(vfs, points_dir)?;
-    let mut points_file = vfs.reader_at_path(&points_path).await.ok()?;
+    let mut points_file = vfs.reader_at_path(points_path).await.ok()?;
     let points = colmap_reader::read_points3d(&mut points_file, is_binary, false)
         .await
         .ok()?;

--- a/crates/brush-dataset/src/formats/mod.rs
+++ b/crates/brush-dataset/src/formats/mod.rs
@@ -188,6 +188,40 @@ fn find_mask_path<'a>(vfs: &'a BrushVfs, path: &'a Path) -> Option<&'a Path> {
     })
 }
 
+/// Locate the `points3d.{txt,bin}` belonging to the chosen reconstruction.
+fn find_points3d_path<'a>(vfs: &'a BrushVfs, points_dir: &'a Path) -> Option<(&'a Path, bool)> {
+    let path = vfs
+        .files_ending_in("points3d.txt")
+        .chain(vfs.files_ending_in("points3d.bin"))
+        .find(|p| p.parent() == Some(points_dir))?;
+    let is_binary = matches!(path.extension().and_then(|e| e.to_str()), Some("bin"));
+    Some((path, is_binary))
+}
+
+/// Locate a per-image depth map.
+fn find_depth_path<'a>(vfs: &'a BrushVfs, path: &'a Path) -> Option<&'a Path> {
+    let search_name = path.file_name().expect("File must have a name");
+    let search_stem = path.file_stem().expect("File must have a name");
+
+    vfs.iter_files().find(|candidate| {
+        let Some(stem) = candidate.file_stem() else {
+            return false;
+        };
+        if !(stem.eq_ignore_ascii_case(search_name) || stem.eq_ignore_ascii_case(search_stem)) {
+            return false;
+        }
+        let depth_idx = candidate
+            .components()
+            .position(|c| c.as_os_str().eq_ignore_ascii_case("depth"));
+        depth_idx.is_some_and(|idx| {
+            let candidate_components: Vec<_> = candidate.components().collect();
+            let path_dir_components: Vec<_> = path.parent().unwrap().components().collect();
+            let depth_dir_subpath = &candidate_components[idx + 1..candidate_components.len() - 1];
+            path_dir_components.ends_with(depth_dir_subpath)
+        })
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/brush-dataset/src/formats/nerfstudio.rs
+++ b/crates/brush-dataset/src/formats/nerfstudio.rs
@@ -260,7 +260,11 @@ async fn read_transforms_file(
             continue;
         }
 
-        let view = SceneView { image, camera };
+        let view = SceneView {
+            image,
+            camera,
+            depth: None,
+        };
         results.push(view);
     }
     Ok(results)

--- a/crates/brush-dataset/src/formats/realitycapture.rs
+++ b/crates/brush-dataset/src/formats/realitycapture.rs
@@ -149,7 +149,11 @@ async fn read_dataset_inner(
             continue;
         }
 
-        views.push(SceneView { camera, image });
+        views.push(SceneView {
+            camera,
+            image,
+            depth: None,
+        });
     }
 
     let (train_views, eval_views) = split_eval_every(views, load_args.eval_split_every);

--- a/crates/brush-dataset/src/lib.rs
+++ b/crates/brush-dataset/src/lib.rs
@@ -1,6 +1,7 @@
 #![recursion_limit = "256"]
 
 pub mod config;
+pub mod load_depth;
 pub mod load_image;
 pub mod scene;
 pub mod scene_loader;

--- a/crates/brush-dataset/src/load_depth.rs
+++ b/crates/brush-dataset/src/load_depth.rs
@@ -1,0 +1,99 @@
+use brush_vfs::BrushVfs;
+use burn::tensor::TensorData;
+use std::{
+    io::Cursor,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+use thiserror::Error;
+use tokio::io::AsyncReadExt;
+
+/// Lazily-loaded per-view depth map, but for single-channel float32 depth stored as TIFF
+/// (depth in metres, 0 marks an invalid depth).
+#[derive(Clone, Debug)]
+pub struct LoadDepth {
+    vfs: Arc<BrushVfs>,
+    path: PathBuf,
+}
+
+impl PartialEq for LoadDepth {
+    fn eq(&self, other: &Self) -> bool {
+        self.path == other.path
+    }
+}
+
+impl LoadDepth {
+    pub fn new(vfs: Arc<BrushVfs>, path: PathBuf) -> Self {
+        Self { vfs, path }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub async fn load(
+        &self,
+        expected_h: usize,
+        expected_w: usize,
+    ) -> Result<TensorData, LoadDepthError> {
+        let depth = self.load_vec(expected_h, expected_w).await?;
+        Ok(TensorData::new(depth, [expected_h, expected_w]))
+    }
+
+    pub async fn load_vec(
+        &self,
+        expected_h: usize,
+        expected_w: usize,
+    ) -> Result<Vec<f32>, LoadDepthError> {
+        let mut bytes = vec![];
+        self.vfs
+            .reader_at_path(&self.path)
+            .await?
+            .read_to_end(&mut bytes)
+            .await?;
+
+        let (depth, w, h) = decode_f32_tiff(&bytes)?;
+
+        if w != expected_w || h != expected_h {
+            Err(LoadDepthError::ReadTiffError(format!(
+                "invalid depth size {w} x {h}, expected {expected_w} x {expected_h}"
+            )))
+        } else {
+            Ok(depth)
+        }
+    }
+}
+
+/// Decode a single-channel float32 TIFF into in row-major order.
+fn decode_f32_tiff(bytes: &[u8]) -> Result<(Vec<f32>, usize, usize), LoadDepthError> {
+    let mut decoder = tiff::decoder::Decoder::new(Cursor::new(bytes))?;
+
+    let tiff::decoder::DecodingResult::F32(depth) = decoder.read_image()? else {
+        return Err(LoadDepthError::ReadTiffError(
+            "unsupported TIFF sample format (expected float32 depth)".to_owned(),
+        ));
+    };
+
+    let (w, h) = decoder.dimensions()?;
+    let (w, h) = (w as usize, h as usize);
+
+    if w * h != depth.len() {
+        Err(LoadDepthError::ReadTiffError(
+            "expected only a single channel".to_owned(),
+        ))
+    } else {
+        Ok((depth, w, h))
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum LoadDepthError {
+    #[error("I/O error while loading depth map: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("Error while loading TIFF file: {0}")]
+    LoadTiffError(#[from] tiff::TiffError),
+
+    #[error("Error while reading TIFF file: {0}")]
+    ReadTiffError(String),
+}

--- a/crates/brush-dataset/src/scene.rs
+++ b/crates/brush-dataset/src/scene.rs
@@ -4,6 +4,7 @@ use glam::{Affine3A, Vec3, vec3};
 use image::DynamicImage;
 use std::sync::Arc;
 
+pub use crate::load_depth::LoadDepth;
 pub use crate::load_image::LoadImage;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -17,6 +18,7 @@ pub enum ViewType {
 pub struct SceneView {
     pub image: LoadImage,
     pub camera: Camera,
+    pub depth: Option<LoadDepth>,
 }
 
 // Encapsulates a multi-view scene including cameras and the splats.
@@ -64,6 +66,7 @@ impl Scene {
             .map(|v| SceneView {
                 image: v.image.with_scale(scale),
                 camera: v.camera,
+                depth: v.depth,
             })
             .collect();
         Self::new(views)
@@ -147,6 +150,8 @@ pub struct SceneBatch {
     /// should consume (mask weight, alpha-matching loss, bg compositing).
     pub has_alpha: bool,
     pub alpha_mode: AlphaMode,
+    /// Optional `[H, W]` f32 metric depth map, `0` marking invalid depth.
+    pub depth: Option<TensorData>,
     pub camera: Camera,
 }
 

--- a/crates/brush-dataset/src/scene_loader.rs
+++ b/crates/brush-dataset/src/scene_loader.rs
@@ -139,10 +139,24 @@ async fn run_loader(
                 .expect("Scene loader failed to load an image");
             let sample = view_to_sample_image(raw, view.image.alpha_mode());
             let (img_packed, has_alpha) = sample_to_packed_data(sample);
+
+            let depth = if let Some(load_depth) = &view.depth {
+                let [h, w] = [img_packed.shape[0], img_packed.shape[1]];
+                Some(
+                    load_depth
+                        .load(h, w)
+                        .await
+                        .expect("Scene loader failed to load an image"),
+                )
+            } else {
+                None
+            };
+
             let batch = Arc::new(SceneBatch {
                 img_packed,
                 has_alpha,
                 alpha_mode: view.image.alpha_mode(),
+                depth,
                 camera: view.camera,
             });
             cache.lock().await.insert(index, batch.clone());

--- a/crates/brush-loss/src/lib.rs
+++ b/crates/brush-loss/src/lib.rs
@@ -1118,6 +1118,21 @@ pub fn image_loss_eval(
     wrap_wgpu_float::<3>(map).permute([1, 2, 0])
 }
 
+/// L1 depth loss in disparity (inverse-depth) space
+pub fn depth_loss(pred_depth: Tensor<2>, gt_depth: Tensor<2>) -> Tensor<1> {
+    let pred_invalid = pred_depth.clone().lower_equal_elem(0.0);
+    let disp_pred = pred_depth.recip().mask_fill(pred_invalid, 0.0);
+
+    let gt_valid = gt_depth.clone().greater_elem(0.0);
+    let gt_invalid = gt_depth.clone().lower_equal_elem(0.0);
+    let disp_gt = gt_depth.recip().mask_fill(gt_invalid, 0.0);
+
+    let valid = gt_valid.float();
+    let abs_err = (disp_pred - disp_gt).abs() * valid.clone();
+
+    abs_err.sum() / valid.sum().clamp_min(1.0)
+}
+
 /// Decode `gt_packed` back to a `[H, W, 3]` f32 RGB tensor. `composite_bg =
 /// Some(bg)` folds in `gt + (1 - gt.a) * bg`; `None` skips that math.
 /// Materialising f32 GT defeats the whole point of the packed format, so

--- a/crates/brush-render-bwd/src/burn_glue.rs
+++ b/crates/brush-render-bwd/src/burn_glue.rs
@@ -66,6 +66,7 @@ pub trait SplatBwdOps: SplatOps {
         img_size: glam::UVec2,
         v_output: FloatTensor<Self>,
         smooth_cutoff: bool,
+        render_depth: bool,
     ) -> RasterizeGrads<Self>;
 
     /// Backward pass for projection.
@@ -102,6 +103,7 @@ struct GaussianBackwardState<B: Backend> {
 
     render_mode: SplatRenderMode,
     pass: brush_render::gaussian_splats::RasterPass,
+    rasterization_mode: brush_render::gaussian_splats::RasterizationMode,
     background: Vec3,
     img_size: glam::UVec2,
 }
@@ -144,6 +146,7 @@ impl<B: Backend + SplatBwdOps> Backward<B, NUM_BWD_ARGS> for RenderBackwards {
             state.img_size,
             v_output,
             state.pass.smooth_cutoff(),
+            state.rasterization_mode.render_depth(),
         );
 
         let splat_grads = B::project_bwd(
@@ -226,6 +229,7 @@ pub async fn render_splats(
         img_size,
         background,
         brush_render::gaussian_splats::RasterPass::Backward,
+        brush_render::gaussian_splats::RasterizationMode::Rgba,
     )
     .await
 }
@@ -240,6 +244,7 @@ pub async fn render_splats_with_pass(
     img_size: glam::UVec2,
     background: Vec3,
     pass: brush_render::gaussian_splats::RasterPass,
+    rasterization_mode: brush_render::gaussian_splats::RasterizationMode,
 ) -> SplatOutputDiff {
     splats.clone().validate_values().await;
 
@@ -299,6 +304,7 @@ pub async fn render_splats_with_pass(
         sh_inner.clone(),
         raw_opac_inner.clone(),
         render_mode,
+        rasterization_mode,
         background,
         pass,
     )
@@ -323,6 +329,7 @@ pub async fn render_splats_with_pass(
                 compact_gid_from_isect: output.compact_gid_from_isect,
                 render_mode,
                 pass,
+                rasterization_mode,
                 global_from_compact_gid: output.global_from_compact_gid,
                 background,
                 img_size,
@@ -355,6 +362,7 @@ impl SplatBwdOps for Fusion<MainBackendBase> {
         img_size: glam::UVec2,
         v_output: FloatTensor<Self>,
         smooth_cutoff: bool,
+        render_depth: bool,
     ) -> RasterizeGrads<Self> {
         #[derive(Debug)]
         struct CustomOp {
@@ -362,6 +370,7 @@ impl SplatBwdOps for Fusion<MainBackendBase> {
             background: Vec3,
             img_size: glam::UVec2,
             smooth_cutoff: bool,
+            render_depth: bool,
         }
 
         impl Operation<FusionCubeRuntime<WgpuRuntime>> for CustomOp {
@@ -390,6 +399,7 @@ impl SplatBwdOps for Fusion<MainBackendBase> {
                     self.img_size,
                     h.get_float_tensor::<MainBackendBase>(v_output),
                     self.smooth_cutoff,
+                    self.render_depth,
                 );
 
                 h.register_float_tensor::<MainBackendBase>(&v_combined.id, grads.v_combined);
@@ -413,7 +423,7 @@ impl SplatBwdOps for Fusion<MainBackendBase> {
         let outputs = {
             let v_combined_out = TensorIr::uninit(
                 client.create_empty_handle(),
-                Shape::new([num_visible, 10]),
+                Shape::new([num_visible, 11]),
                 DType::F32,
             );
             let stream = StreamId::current();
@@ -427,6 +437,7 @@ impl SplatBwdOps for Fusion<MainBackendBase> {
                 background,
                 img_size,
                 smooth_cutoff,
+                render_depth,
             };
             client
                 .register(stream, OperationIr::Custom(desc), op)

--- a/crates/brush-render-bwd/src/kernels/project_backwards.rs
+++ b/crates/brush-render-bwd/src/kernels/project_backwards.rs
@@ -124,7 +124,7 @@ pub fn project_backwards_kernel(
     // splats that contributed to a pixel; non-contributing splats leave
     // v_rasterize_grads at zero and (since the dense outputs are zero-
     // init) we can return without writing anything at all.
-    let rg_base = (compact_gid * 10u32) as usize;
+    let rg_base = (compact_gid * 11u32) as usize;
     let v_mean2d_x = v_rasterize_grads[rg_base];
     let v_mean2d_y = v_rasterize_grads[rg_base + 1];
     let v_conics_x = v_rasterize_grads[rg_base + 2];
@@ -135,6 +135,7 @@ pub fn project_backwards_kernel(
     let v_color_b = v_rasterize_grads[rg_base + 7];
     let v_alpha_in = v_rasterize_grads[rg_base + 8];
     let v_refine_in = v_rasterize_grads[rg_base + 9];
+    let v_depth_in = v_rasterize_grads[rg_base + 10];
 
     let any_grad = v_mean2d_x != 0.0f32
         || v_mean2d_y != 0.0f32
@@ -145,7 +146,8 @@ pub fn project_backwards_kernel(
         || v_color_g != 0.0f32
         || v_color_b != 0.0f32
         || v_alpha_in != 0.0f32
-        || v_refine_in != 0.0f32;
+        || v_refine_in != 0.0f32
+        || v_depth_in != 0.0f32;
     if !any_grad {
         terminate!();
     }
@@ -217,6 +219,8 @@ pub fn project_backwards_kernel(
         Vec2::new(v_mean2d_x, v_mean2d_y),
         camera_model,
     );
+
+    let v_mean_c = Vec3A::new(v_mean_c.x(), v_mean_c.y(), v_mean_c.z() + v_depth_in);
 
     // v_covar_c = J^T * v_cov2d * J (2x2 sym → 3x3 sym).
     let vcc = cam_jac.transpose_congruence_sym2(v_cov2d);

--- a/crates/brush-render-bwd/src/kernels/rasterize_backwards.rs
+++ b/crates/brush-render-bwd/src/kernels/rasterize_backwards.rs
@@ -39,6 +39,7 @@ pub struct SplatGrad {
     pub rgb_b: f32,
     pub alpha: f32,
     pub refine: f32,
+    pub depth: f32,
 }
 
 #[cube]
@@ -54,6 +55,7 @@ fn zero_grad() -> SplatGrad {
         rgb_b: 0.0f32,
         alpha: 0.0f32,
         refine: 0.0f32,
+        depth: 0.0f32,
     }
 }
 
@@ -107,6 +109,7 @@ pub fn rasterize_backwards_kernel<A: AtomicAddF32>(
     v_splats: &mut Tensor<Atomic<A::Storage>>,
     u: RasterizeUniforms,
     #[comptime] smooth_cutoff: bool,
+    #[comptime] render_depth: bool,
 ) {
     let (tile_id, tile_origin_x, tile_origin_y) = tile_origin(u.tile_bw);
     // Only `pix_state` lives in shared memory — it gets read-modify-
@@ -115,8 +118,16 @@ pub fn rasterize_backwards_kernel<A: AtomicAddF32>(
     // pre-roll) are read-only post-init and L1-cached, so we re-derive
     // them inline in the inner loop. Smaller shared footprint → more
     // workgroup occupancy on Apple.
-    let mut pix_state = Shared::new_slice((TILE_SIZE * 4u32) as usize);
-    load_pixel_state(output, u, tile_origin_x, tile_origin_y, &mut pix_state);
+    let pix_stride = comptime![if render_depth { 5u32 } else { 4u32 }];
+    let mut pix_state = Shared::new_slice((TILE_SIZE * pix_stride) as usize);
+    load_pixel_state(
+        output,
+        u,
+        tile_origin_x,
+        tile_origin_y,
+        &mut pix_state,
+        render_depth,
+    );
     let (range_lo, range_hi) = load_range(tile_offsets, tile_id);
     let num_splats_in_tile = range_hi - range_lo;
     let rounds = (num_splats_in_tile + SPLAT_BATCH - 1u32) / SPLAT_BATCH;
@@ -142,9 +153,10 @@ pub fn rasterize_backwards_kernel<A: AtomicAddF32>(
             v_output,
             u,
             smooth_cutoff,
+            render_depth,
         );
         if splat_active {
-            let base = (compact_gid * 10u32) as usize;
+            let base = (compact_gid * 11u32) as usize;
             A::add(&v_splats[base], grad.xy_x);
             A::add(&v_splats[base + 1], grad.xy_y);
             A::add(&v_splats[base + 2], grad.conic_x);
@@ -155,6 +167,9 @@ pub fn rasterize_backwards_kernel<A: AtomicAddF32>(
             A::add(&v_splats[base + 7], grad.rgb_b);
             A::add(&v_splats[base + 8], grad.alpha);
             A::add(&v_splats[base + 9], grad.refine);
+            if comptime![render_depth] {
+                A::add(&v_splats[base + 10], grad.depth);
+            }
         }
         batch_idx += 1u32;
     }
@@ -194,7 +209,11 @@ fn load_pixel_state(
     tile_origin_x: u32,
     tile_origin_y: u32,
     pix_state: &mut Shared<[f32]>,
+    #[comptime] render_depth: bool,
 ) {
+    // Channels in the rendered image / per-pixel state stride. The depth
+    // numerator (if present) sits at offset 4, after rgba.
+    let out_chans = comptime![if render_depth { 5u32 } else { 4u32 }];
     let pixels_per_load = (TILE_SIZE + SPLAT_BATCH - 1u32) / SPLAT_BATCH;
     let mut p = 0u32;
     while p < pixels_per_load {
@@ -203,10 +222,10 @@ fn load_pixel_state(
             let pix_x = tile_origin_x + pix_rank % TILE_WIDTH;
             let pix_y = tile_origin_y + pix_rank / TILE_WIDTH;
             let inside = pix_x < u.img_w && pix_y < u.img_h;
-            let s = (pix_rank * 4u32) as usize;
+            let s = (pix_rank * out_chans) as usize;
             if inside {
                 let pix_id = pix_x + pix_y * u.img_w;
-                let base = (pix_id * 4u32) as usize;
+                let base = (pix_id * out_chans) as usize;
                 let final_r = output[base];
                 let final_g = output[base + 1];
                 let final_b = output[base + 2];
@@ -216,11 +235,19 @@ fn load_pixel_state(
                 pix_state[s + 1] = final_g - t_final * u.bg_g;
                 pix_state[s + 2] = final_b - t_final * u.bg_b;
                 pix_state[s + 3] = 1.0f32;
+                if comptime![render_depth] {
+                    // Depth numerator has no background term, so the seed is
+                    // just the accumulated sum_i w_i z_i.
+                    pix_state[s + 4] = output[base + 4];
+                }
             } else {
                 pix_state[s] = 0.0f32;
                 pix_state[s + 1] = 0.0f32;
                 pix_state[s + 2] = 0.0f32;
                 pix_state[s + 3] = 0.0f32;
+                if comptime![render_depth] {
+                    pix_state[s + 4] = 0.0f32;
+                }
             }
         }
         p += 1u32;
@@ -261,7 +288,9 @@ fn accumulate_grads_for_batch(
     v_output: &Tensor<f32>,
     u: RasterizeUniforms,
     #[comptime] smooth_cutoff: bool,
+    #[comptime] render_depth: bool,
 ) -> SplatGrad {
+    let out_chans = comptime![if render_depth { 5u32 } else { 4u32 }];
     let conic = Sym2 {
         c00: splat.conic_x,
         c01: splat.conic_y,
@@ -282,7 +311,7 @@ fn accumulate_grads_for_batch(
 
         if active_iter {
             let pixel_rank = i - UNIT_POS;
-            let s = (pixel_rank * 4u32) as usize;
+            let s = (pixel_rank * out_chans) as usize;
             let state_x = pix_state[s];
             let state_y = pix_state[s + 1];
             let state_z = pix_state[s + 2];
@@ -320,7 +349,7 @@ fn accumulate_grads_for_batch(
                         // loads for ~5 KiB of shared memory back, which
                         // recovers an Apple-GPU occupancy slot.
                         let pix_id = pix_x + pix_y * u.img_w;
-                        let pix_base = (pix_id * 4u32) as usize;
+                        let pix_base = (pix_id * out_chans) as usize;
                         let v_o_x = v_output[pix_base];
                         let v_o_y = v_output[pix_base + 1];
                         let v_o_z = v_output[pix_base + 2];
@@ -337,13 +366,20 @@ fn accumulate_grads_for_batch(
                         grad.rgb_b += select(splat.color_b >= 0.0f32, vis * v_o_z, 0.0f32);
 
                         let ra = 1.0f32 / (1.0f32 - alpha_eff);
-                        let dot_rgb = ((state_w * clamped_r - state_x) * v_o_x
+                        let mut dot_rgb = ((state_w * clamped_r - state_x) * v_o_x
                             + (state_w * clamped_g - state_y) * v_o_y
                             + (state_w * clamped_b - state_z) * v_o_z)
                             * ra;
                         let new_remain_x = state_x - vis * clamped_r;
                         let new_remain_y = state_y - vis * clamped_g;
                         let new_remain_z = state_z - vis * clamped_b;
+                        if comptime![render_depth] {
+                            let v_o_d = v_output[pix_base + 4];
+                            let state_d = pix_state[s + 4];
+                            grad.depth += vis * v_o_d;
+                            dot_rgb += (state_w * splat.depth - state_d) * v_o_d * ra;
+                            pix_state[s + 4] = state_d - vis * splat.depth;
+                        }
                         // Chain through the cutoff. Hard step (production):
                         // w' = 0 and w == 1 in-branch, so the factor is 1.
                         let v_alpha_eff = dot_rgb + v_o_w * ra;

--- a/crates/brush-render-bwd/src/kernels/rasterize_backwards.rs
+++ b/crates/brush-render-bwd/src/kernels/rasterize_backwards.rs
@@ -366,7 +366,10 @@ fn accumulate_grads_for_batch(
                         grad.rgb_b += select(splat.color_b >= 0.0f32, vis * v_o_z, 0.0f32);
 
                         let ra = 1.0f32 / (1.0f32 - alpha_eff);
-                        let mut dot_rgb = ((state_w * clamped_r - state_x) * v_o_x
+                        // Depth no longer contributes to this dot accumulator
+                        // (see the render_depth block below), so it is written
+                        // once and never mutated.
+                        let dot_rgb = ((state_w * clamped_r - state_x) * v_o_x
                             + (state_w * clamped_g - state_y) * v_o_y
                             + (state_w * clamped_b - state_z) * v_o_z)
                             * ra;
@@ -376,8 +379,19 @@ fn accumulate_grads_for_batch(
                         if comptime![render_depth] {
                             let v_o_d = v_output[pix_base + 4];
                             let state_d = pix_state[s + 4];
+                            // Depth supervises gaussian positions only. Route the
+                            // depth-channel gradient to the per-splat depth value
+                            // (grad.depth), but do NOT fold it into the alpha VJP.
+                            // The term
+                            //   dot_rgb += (state_w * splat.depth - state_d) * v_o_d * ra
+                            // is dropped on purpose so depth loss cannot lower its
+                            // error by changing blending weights (opacity/shape)
+                            // instead of moving. This detaches the depth blending
+                            // weights, matching LFS detach_depth_weights and
+                            // DN-Splatter. The paired denominator detach lives in
+                            // brush-train train.rs. The state update below stays
+                            // for the front-to-back depth bookkeeping.
                             grad.depth += vis * v_o_d;
-                            dot_rgb += (state_w * splat.depth - state_d) * v_o_d * ra;
                             pix_state[s + 4] = state_d - vis * splat.depth;
                         }
                         // Chain through the cutoff. Hard step (production):

--- a/crates/brush-render-bwd/src/render_bwd.rs
+++ b/crates/brush-render-bwd/src/render_bwd.rs
@@ -28,6 +28,7 @@ impl SplatBwdOps for MainBackendBase {
         img_size: glam::UVec2,
         v_output: FloatTensor<Self>,
         smooth_cutoff: bool,
+        render_depth: bool,
     ) -> RasterizeGrads<Self> {
         let _span = tracing::trace_span!("rasterize_bwd").entered();
 
@@ -36,8 +37,9 @@ impl SplatBwdOps for MainBackendBase {
         let num_visible = projected_splats.shape()[0].max(1);
         let client = projected_splats.client.clone();
 
-        // Sparse [num_visible, 10] indexed by compact_gid.
-        let v_combined = Self::float_zeros([num_visible, 10].into(), &device, FloatDType::F32);
+        // Sparse [num_visible, 11] indexed by compact_gid. Lane 10 is the
+        // expected-depth gradient (zero in colour-only modes).
+        let v_combined = Self::float_zeros([num_visible, 11].into(), &device, FloatDType::F32);
 
         let tile_bounds = uvec2(
             img_size
@@ -81,6 +83,7 @@ impl SplatBwdOps for MainBackendBase {
                     v_combined.clone().into_tensor_arg(),
                     uniforms,
                     smooth_cutoff,
+                    render_depth,
                 );
             } else {
                 rasterize_backwards_kernel::launch::<CasAtomicAdd, WgpuRuntime>(
@@ -95,6 +98,7 @@ impl SplatBwdOps for MainBackendBase {
                     v_combined.clone().into_tensor_arg(),
                     uniforms,
                     smooth_cutoff,
+                    render_depth,
                 );
             }
         });

--- a/crates/brush-render/src/burn_glue.rs
+++ b/crates/brush-render/src/burn_glue.rs
@@ -17,6 +17,7 @@ use burn_ir::{CustomOpIr, HandleContainer, OperationIr, OperationOutput, TensorI
 use burn_wgpu::WgpuRuntime;
 use glam::Vec3;
 
+use crate::gaussian_splats::RasterizationMode;
 use crate::{
     RenderAuxInner, SplatOps, camera::Camera, gaussian_splats::SplatRenderMode,
     render_aux::RenderOutput, wgpu_kind,
@@ -219,6 +220,7 @@ impl SplatOps for Fusion<MainBackendBase> {
         sh_coeffs: FloatTensor<Self>,
         raw_opacities: FloatTensor<Self>,
         render_mode: SplatRenderMode,
+        raster_mode: RasterizationMode,
         background: Vec3,
         pass: crate::gaussian_splats::RasterPass,
     ) -> RenderOutput<Self> {
@@ -244,6 +246,7 @@ impl SplatOps for Fusion<MainBackendBase> {
             base_sh_coeffs,
             base_raw_opac,
             render_mode,
+            raster_mode,
             background,
             pass,
         )

--- a/crates/brush-render/src/gaussian_splats.rs
+++ b/crates/brush-render/src/gaussian_splats.rs
@@ -388,6 +388,46 @@ pub async fn render_splats(
     splat_scale: Option<f32>,
     texture_mode: TextureMode,
 ) -> (Tensor<3>, RenderAux) {
+    render_splats_inner(
+        splats,
+        camera,
+        img_size,
+        background,
+        splat_scale,
+        texture_mode,
+        RasterizationMode::Rgba,
+    )
+    .await
+}
+
+pub async fn render_splats_depth(
+    splats: Splats,
+    camera: &Camera,
+    img_size: glam::UVec2,
+    background: Vec3,
+    splat_scale: Option<f32>,
+) -> (Tensor<3>, RenderAux) {
+    render_splats_inner(
+        splats,
+        camera,
+        img_size,
+        background,
+        splat_scale,
+        TextureMode::Float,
+        RasterizationMode::RgbaAndDepth,
+    )
+    .await
+}
+
+async fn render_splats_inner(
+    splats: Splats,
+    camera: &Camera,
+    img_size: glam::UVec2,
+    background: Vec3,
+    splat_scale: Option<f32>,
+    texture_mode: TextureMode,
+    raster_mode: RasterizationMode,
+) -> (Tensor<3>, RenderAux) {
     splats.clone().validate_values().await;
 
     let sh_coeffs = splats.sh_coeffs.into_value();
@@ -436,7 +476,7 @@ pub async fn render_splats(
         sh_coeffs.into_dispatch(),
         raw_opacities.into_dispatch(),
         render_mode,
-        RasterizationMode::Rgba,
+        raster_mode,
         background,
         pass,
     )

--- a/crates/brush-render/src/gaussian_splats.rs
+++ b/crates/brush-render/src/gaussian_splats.rs
@@ -21,6 +21,24 @@ pub enum SplatRenderMode {
     Mip,
 }
 
+/// Output channels the rasterizer produces.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Default)]
+pub enum RasterizationMode {
+    #[default]
+    Rgba,
+    RgbaAndDepth,
+}
+
+impl RasterizationMode {
+    pub const fn render_depth(self) -> bool {
+        matches!(self, Self::RgbaAndDepth)
+    }
+
+    pub const fn bwd_out_channels(self) -> usize {
+        if self.render_depth() { 5 } else { 4 }
+    }
+}
+
 /// Forward/backward rasterizer mode. Replaces the old `bwd_info: bool` so the
 /// test-only smooth-cutoff variant rides along on the same enum that already
 /// switches in/out the backward bookkeeping.
@@ -418,6 +436,7 @@ pub async fn render_splats(
         sh_coeffs.into_dispatch(),
         raw_opacities.into_dispatch(),
         render_mode,
+        RasterizationMode::Rgba,
         background,
         pass,
     )

--- a/crates/brush-render/src/kernels/helpers.rs
+++ b/crates/brush-render/src/kernels/helpers.rs
@@ -47,8 +47,8 @@ pub fn alpha_cutoff_weight_deriv(alpha: f32) -> f32 {
 
 /// `f32` lanes per projected splat. Layout matches `Splat`:
 ///   0:xy_x, 1:xy_y, 2:conic_x, 3:conic_y, 4:conic_z, 5:color_a,
-///   6:color_r, 7:color_g, 8:color_b.
-pub const PROJECTED_LANES: u32 = 9;
+///   6:color_r, 7:color_g, 8:color_b, 9:depth.
+pub const PROJECTED_LANES: u32 = 10;
 pub const PROJECTED_LANES_USIZE: usize = PROJECTED_LANES as usize;
 
 #[cube]
@@ -291,6 +291,7 @@ pub fn read_projected_splat(projected: &Tensor<f32>, idx: u32) -> Splat {
         color_r: projected[b + 6],
         color_g: projected[b + 7],
         color_b: projected[b + 8],
+        depth: projected[b + 9],
     }
 }
 
@@ -306,6 +307,7 @@ pub fn write_projected_splat(projected: &mut Tensor<f32>, idx: u32, splat: Splat
     projected[b + 6] = splat.color_r;
     projected[b + 7] = splat.color_g;
     projected[b + 8] = splat.color_b;
+    projected[b + 9] = splat.depth;
 }
 
 /// View-space transform of a world-space mean using the project uniforms'

--- a/crates/brush-render/src/kernels/project_visible.rs
+++ b/crates/brush-render/src/kernels/project_visible.rs
@@ -83,6 +83,7 @@ pub fn project_visible_kernel(
             color_r: cr_c,
             color_g: cg_c,
             color_b: cb_c,
+            depth: mean_c.z(),
         },
     );
 }

--- a/crates/brush-render/src/kernels/rasterize.rs
+++ b/crates/brush-render/src/kernels/rasterize.rs
@@ -34,6 +34,7 @@ pub fn rasterize_kernel(
     u: RasterizeUniforms,
     #[comptime] bwd_info: bool,
     #[comptime] smooth_cutoff: bool,
+    #[comptime] render_depth: bool,
 ) {
     let global_id = ABSOLUTE_POS as u32;
     let (pix_x, pix_y) = map_1d_to_2d(global_id, u.tile_bw);
@@ -75,6 +76,7 @@ pub fn rasterize_kernel(
     let mut pix_r = 0.0f32;
     let mut pix_g = 0.0f32;
     let mut pix_b = 0.0f32;
+    let mut pix_d = 0.0f32;
     let mut done = !inside;
     let mut last_useful_isect = range_lo;
 
@@ -145,6 +147,9 @@ pub fn rasterize_kernel(
                     pix_r += max(local_batch[dst_base + 6], 0.0f32) * vis;
                     pix_g += max(local_batch[dst_base + 7], 0.0f32) * vis;
                     pix_b += max(local_batch[dst_base + 8], 0.0f32) * vis;
+                    if comptime![render_depth] {
+                        pix_d += local_batch[dst_base + 9] * vis;
+                    }
                     t_acc = next_t;
                     last_useful_isect = batch_start + t + 1u32;
                 }
@@ -163,11 +168,15 @@ pub fn rasterize_kernel(
         let final_b = pix_b + t_acc * u.bg_b;
         let final_a = 1.0f32 - t_acc;
         if comptime![bwd_info] {
-            let base = (pix_id * 4u32) as usize;
+            let out_chans = comptime![if render_depth { 5u32 } else { 4u32 }];
+            let base = (pix_id * out_chans) as usize;
             out_img_f32[base] = final_r;
             out_img_f32[base + 1] = final_g;
             out_img_f32[base + 2] = final_b;
             out_img_f32[base + 3] = final_a;
+            if comptime![render_depth] {
+                out_img_f32[base + 4] = pix_d;
+            }
         } else {
             let r = clamp(final_r * 255.0f32, 0.0f32, 255.0f32) as u32;
             let g = clamp(final_g * 255.0f32, 0.0f32, 255.0f32) as u32;

--- a/crates/brush-render/src/kernels/types.rs
+++ b/crates/brush-render/src/kernels/types.rs
@@ -11,9 +11,9 @@ use crate::kernels::camera_model::pinhole::PinholeParams;
 pub use brush_cube::{Mat2x3, Mat3, PixelRect, Quat, Sym2, TileBbox, Vec3A};
 
 /// One projected splat as the kernel sees it. The on-device storage is
-/// a flat `Tensor<f32>` of `9 * num_visible` lanes (see
+/// a flat `Tensor<f32>` of `PROJECTED_LANES * num_visible` lanes (see
 /// `helpers::PROJECTED_LANES`); the load helper packages the lanes into
-/// this struct so consumers don't carry nine independent locals.
+/// this struct so consumers don't carry ten independent locals.
 #[derive(CubeType, CubeTypeMut, Copy, Clone)]
 #[expand(derive(Clone, Copy))]
 pub struct Splat {
@@ -26,6 +26,7 @@ pub struct Splat {
     pub color_r: f32,
     pub color_g: f32,
     pub color_b: f32,
+    pub depth: f32,
 }
 
 #[cube]
@@ -41,6 +42,7 @@ impl Splat {
             color_r: 0.0f32,
             color_g: 0.0f32,
             color_b: 0.0f32,
+            depth: 0.0f32,
         }
     }
 }

--- a/crates/brush-render/src/lib.rs
+++ b/crates/brush-render/src/lib.rs
@@ -7,7 +7,7 @@ use camera::Camera;
 use clap::ValueEnum;
 use glam::Vec3;
 
-use crate::gaussian_splats::SplatRenderMode;
+use crate::gaussian_splats::{RasterPass, RasterizationMode, SplatRenderMode};
 pub use crate::gaussian_splats::{Splats, TextureMode, render_splats};
 pub use crate::render_aux::{RenderAux, RenderAuxInner, RenderOutput};
 
@@ -73,8 +73,9 @@ pub trait SplatOps: Backend {
         sh_coeffs: FloatTensor<Self>,
         raw_opacities: FloatTensor<Self>,
         render_mode: SplatRenderMode,
+        rasterization_mode: RasterizationMode,
         background: Vec3,
-        pass: gaussian_splats::RasterPass,
+        pass: RasterPass,
     ) -> impl Future<Output = RenderOutput<Self>>;
 }
 

--- a/crates/brush-render/src/lib.rs
+++ b/crates/brush-render/src/lib.rs
@@ -8,7 +8,7 @@ use clap::ValueEnum;
 use glam::Vec3;
 
 use crate::gaussian_splats::{RasterPass, RasterizationMode, SplatRenderMode};
-pub use crate::gaussian_splats::{Splats, TextureMode, render_splats};
+pub use crate::gaussian_splats::{Splats, TextureMode, render_splats, render_splats_depth};
 pub use crate::render_aux::{RenderAux, RenderAuxInner, RenderOutput};
 
 pub mod burn_glue;

--- a/crates/brush-render/src/render.rs
+++ b/crates/brush-render/src/render.rs
@@ -43,6 +43,7 @@ impl SplatOps for MainBackendBase {
         sh_coeffs: FloatTensor<Self>,
         raw_opacities: FloatTensor<Self>,
         render_mode: SplatRenderMode,
+        raster_mode: crate::gaussian_splats::RasterizationMode,
         background: Vec3,
         pass: RasterPass,
     ) -> RenderOutput<Self> {
@@ -52,6 +53,7 @@ impl SplatOps for MainBackendBase {
         );
         let bwd_info = pass.bwd_info();
         let smooth_cutoff = pass.smooth_cutoff();
+        let render_depth = raster_mode.render_depth() && bwd_info;
 
         let transforms = into_contiguous(transforms);
         let sh_coeffs = into_contiguous(sh_coeffs);
@@ -244,7 +246,11 @@ impl SplatOps for MainBackendBase {
                 tile_offsets.clone().into_tensor_arg(),
             );
         });
-        let out_dim = if bwd_info { 4 } else { 1 };
+        let out_dim = if bwd_info {
+            if render_depth { 5 } else { 4 }
+        } else {
+            1
+        };
         let out_img = create_tensor(
             [img_size.y as usize, img_size.x as usize, out_dim],
             &device,
@@ -290,6 +296,7 @@ impl SplatOps for MainBackendBase {
                 uniforms,
                 bwd_info,
                 smooth_cutoff,
+                render_depth,
             );
         });
         RenderOutput {

--- a/crates/brush-train/src/config.rs
+++ b/crates/brush-train/src/config.rs
@@ -92,6 +92,10 @@ pub struct TrainConfig {
     #[arg(long, help_heading = "Refine options", default_value = "0.0")]
     pub lpips_loss_weight: f32,
 
+    /// Weight of l1 loss on depth (disparity-space)
+    #[arg(long, help_heading = "Training options", default_value = "0.0")]
+    pub depth_loss_weight: f32,
+
     /// Base background color (R,G,B) used during training.
     #[arg(
         long,

--- a/crates/brush-train/src/train.rs
+++ b/crates/brush-train/src/train.rs
@@ -10,10 +10,10 @@ use crate::{
     stats::RefineRecord,
 };
 use brush_dataset::scene::SceneBatch;
-use brush_loss::{ImageLossConfig, image_loss};
-use brush_render::gaussian_splats::Splats;
+use brush_loss::{ImageLossConfig, depth_loss, image_loss};
+use brush_render::gaussian_splats::{RasterPass, RasterizationMode, Splats};
 use brush_render::{AlphaMode, bounding_box::BoundingBox, sh::sh_coeffs_for_degree};
-use brush_render_bwd::render_splats;
+use brush_render_bwd::render_splats_with_pass;
 use burn::{
     backend::wgpu::{AutoCompiler, WgpuDevice, WgpuRuntime},
     lr_scheduler::{
@@ -188,9 +188,22 @@ impl SplatTrainer {
             // The splats already carry their 3D-filter floor (set at refine);
             // the render path folds it in. Optimizer/refine work on raw params.
             let render_input = splats.clone();
-            let diff_out = render_splats(render_input, &camera, img_size, background)
-                .instrument(trace_span!("Forward"))
-                .await;
+            let use_depth = batch.depth.is_some() && self.config.depth_loss_weight > 0.0;
+            let raster_mode = if use_depth {
+                RasterizationMode::RgbaAndDepth
+            } else {
+                RasterizationMode::Rgba
+            };
+            let diff_out = render_splats_with_pass(
+                render_input,
+                &camera,
+                img_size,
+                background,
+                RasterPass::Backward,
+                raster_mode,
+            )
+            .instrument(trace_span!("Forward"))
+            .await;
 
             let pred_image = diff_out.img;
             let refine_weight_holder = diff_out.refine_weight_holder;
@@ -223,7 +236,7 @@ impl SplatTrainer {
                 mask: masked_alpha,
             };
             let pred_for_loss = if do_alpha_match {
-                pred_image.clone()
+                pred_image.clone().slice(s![.., .., 0..4])
             } else {
                 pred_image.clone().slice(s![.., .., 0..3])
             };
@@ -251,6 +264,16 @@ impl SplatTrainer {
                         pred_image.clone().slice(s![.., .., 0..3]).unsqueeze_dim(0),
                         gt_rgb_diff.unsqueeze_dim(0),
                     ) * self.config.lpips_loss_weight;
+            }
+
+            // Depth Disparity L1 loss on rendered expected depth
+            if use_depth && let Some(depth_data) = &batch.depth {
+                let gt_depth: Tensor<2> = Tensor::from_data(depth_data.clone(), &device);
+                let accumulated_depth = pred_image.clone().slice(s![.., .., 4..5]);
+                let alpha = pred_image.clone().slice(s![.., .., 3..4]);
+                let expected_depth =
+                    (accumulated_depth / alpha.clamp_min(1e-10)).reshape([img_h, img_w]);
+                loss = loss + depth_loss(expected_depth, gt_depth) * self.config.depth_loss_weight;
             }
 
             // Strip the autodiff graph off the loss so consumers can read the

--- a/crates/brush-train/src/train.rs
+++ b/crates/brush-train/src/train.rs
@@ -270,7 +270,16 @@ impl SplatTrainer {
             if use_depth && let Some(depth_data) = &batch.depth {
                 let gt_depth: Tensor<2> = Tensor::from_data(depth_data.clone(), &device);
                 let accumulated_depth = pred_image.clone().slice(s![.., .., 4..5]);
-                let alpha = pred_image.clone().slice(s![.., .., 3..4]);
+                // Detach the alpha denominator so depth loss cannot lower its
+                // error by changing transparency. A differentiable denominator
+                // lets depth error flow into opacity. This closes one of two
+                // coupling routes; the other lives in the rasterize backward,
+                // where the depth-channel gradient feeds the alpha term (see
+                // rasterize_backwards.rs, the dropped dot_rgb depth term).
+                // Together they detach the blending weights from depth, so depth
+                // supervision moves gaussian positions only, matching LFS
+                // detach_depth_weights and DN-Splatter.
+                let alpha = pred_image.clone().slice(s![.., .., 3..4]).detach();
                 let expected_depth =
                     (accumulated_depth / alpha.clamp_min(1e-10)).reshape([img_h, img_w]);
                 loss = loss + depth_loss(expected_depth, gt_depth) * self.config.depth_loss_weight;
@@ -936,4 +945,125 @@ fn sample_background_color(base: glam::Vec3, strength: f32) -> glam::Vec3 {
         rng.random_range(-strength..strength),
     );
     (base + noise).clamp(glam::Vec3::ZERO, glam::Vec3::ONE)
+}
+
+#[cfg(test)]
+mod depth_loss_grad_tests {
+    use super::*;
+    use brush_render::camera::Camera;
+    use brush_render::gaussian_splats::SplatRenderMode;
+    use brush_render::kernels::camera_model::CameraModel;
+
+    /// A depth-only loss must move gaussian positions and leave opacity untouched.
+    ///
+    /// The rendered depth is the alpha-normalized expected depth,
+    /// `accum(ch4) / alpha(ch3)`. Two routes let depth error reach opacity. The
+    /// alpha denominator is differentiable, and the depth-loss term detaches it.
+    /// The rasterize backward also folds the depth-channel gradient into the
+    /// alpha gradient, and `rasterize_backwards.rs` drops that term. With both
+    /// routes closed the depth blending weights are detached, so depth
+    /// supervision moves the per-splat depth values only. This matches the
+    /// `detach_depth_weights` behavior; see the kernel comment for the citation.
+    /// The test renders the differentiable depth path, applies a depth-only
+    /// loss, and asserts the raw opacities get no gradient while the positions do.
+    #[tokio::test]
+    async fn depth_loss_does_not_touch_opacity() {
+        let device =
+            burn::tensor::Device::from(brush_cube::test_helpers::test_device().await).autodiff();
+
+        // A handful of near-opaque gaussians spread in depth in front of a
+        // camera that looks down +z.
+        let means = vec![
+            0.0, 0.0, 0.0, //
+            0.3, 0.0, 0.5, //
+            -0.3, 0.2, 1.0, //
+            0.1, -0.2, 1.5, //
+        ];
+        let n = means.len() / 3;
+        let rotations: Vec<f32> = (0..n).flat_map(|_| [1.0, 0.0, 0.0, 0.0]).collect();
+        let log_scales: Vec<f32> = (0..n).flat_map(|_| [-1.0, -1.0, -1.0]).collect();
+        let sh: Vec<f32> = (0..n).flat_map(|_| [0.5, 0.5, 0.5]).collect();
+        // High raw opacity so the depth channel carries real weight.
+        let opac: Vec<f32> = vec![4.0; n];
+
+        let splats = Splats::from_raw(
+            means,
+            rotations,
+            log_scales,
+            sh,
+            opac,
+            SplatRenderMode::Default,
+            &device,
+        );
+
+        let camera = Camera::new(
+            glam::vec3(0.0, 0.0, -5.0),
+            glam::Quat::IDENTITY,
+            0.7,
+            0.7,
+            glam::vec2(0.5, 0.5),
+            CameraModel::Pinhole,
+        );
+        let img_size = glam::uvec2(48, 48);
+
+        let diff_out = render_splats_with_pass(
+            splats.clone(),
+            &camera,
+            img_size,
+            glam::Vec3::ZERO,
+            RasterPass::Backward,
+            RasterizationMode::RgbaAndDepth,
+        )
+        .await;
+
+        let [img_h, img_w, _] = diff_out.img.dims();
+        let accumulated_depth = diff_out.img.clone().slice(s![.., .., 4..5]);
+        // Same detached denominator as the training depth-loss term.
+        let alpha = diff_out.img.clone().slice(s![.., .., 3..4]).detach();
+        let expected_depth = (accumulated_depth / alpha.clamp_min(1e-10)).reshape([img_h, img_w]);
+
+        // A positive constant target, so the disparity error and its gradient are
+        // nonzero wherever a gaussian was rendered.
+        let gt_depth = Tensor::<2>::ones([img_h, img_w], &device) * 3.0;
+        let loss = depth_loss(expected_depth, gt_depth);
+
+        let grads = splats.bwd_validate(loss).await;
+
+        // Positions live in transforms columns 0..3 and must receive gradient.
+        let transforms_grad = splats
+            .transforms
+            .grad(&grads)
+            .expect("depth loss must reach gaussian positions");
+        let means_grad_absmax = transforms_grad
+            .slice(s![.., 0..3])
+            .abs()
+            .max()
+            .into_data_async()
+            .await
+            .expect("means grad readback")
+            .to_vec::<f32>()
+            .expect("f32 means grad")[0];
+        assert!(
+            means_grad_absmax > 1e-8,
+            "expected a nonzero position gradient, got {means_grad_absmax}"
+        );
+
+        // Opacity must receive no gradient. burn either prunes the leaf (None) or
+        // returns an all-zero gradient. A nonzero one means depth error can still
+        // push opacity, which is the regression this test guards.
+        if let Some(opac_grad) = splats.raw_opacities.grad(&grads) {
+            let opac_grad_absmax = opac_grad
+                .abs()
+                .max()
+                .into_data_async()
+                .await
+                .expect("opacity grad readback")
+                .to_vec::<f32>()
+                .expect("f32 opacity grad")[0];
+            assert!(
+                opac_grad_absmax < 1e-8,
+                "depth loss must not push opacity, got {opac_grad_absmax}"
+            );
+        }
+    }
 }


### PR DESCRIPTION
I added an L1 loss on the inverse depth, just like gsplat implements the depth loss. At the moment, the depth maps are loaded as TIFF float32 images from a folder named depth, only for COLMAP datasets. Since COLMAP is scale ambiguous, I added an argument that uses the depth maps and the projected landmarks to estimate the correct scale of the COLMAP dataset.

Here is a video with a comparison [https://www.youtube.com/watch?v=Si_vElXaDjo](https://www.youtube.com/watch?v=Si_vElXaDjo) between with and without depth loss.

I also added a depth map viewer with the turbo color map:
<img width="2476" height="1770" alt="image" src="https://github.com/user-attachments/assets/977bac80-9ba8-4225-9817-908baf6d2d03" />

Please tell me your opinion on my changes. 

Thanks,
Kilian Northoff