### PR TITLE
Avoid reading every image of dataset for dimensions before training

### DIFF
--- a/crates/brush-dataset/src/formats/colmap.rs
+++ b/crates/brush-dataset/src/formats/colmap.rs
@@ -216,8 +216,13 @@ async fn load_dataset_inner(
                 load_args.max_resolution,
                 load_args.alpha_mode,
             );
+            let image_size = glam::uvec2(colmap_camera.width as u32, colmap_camera.height as u32);
 
-            views.push(SceneView { camera, image });
+            views.push(SceneView {
+                camera,
+                image,
+                image_size,
+            });
         }
 
         let (train_views, eval_views) = split_eval_every(views, load_args.eval_split_every);

--- a/crates/brush-dataset/src/formats/nerfstudio.rs
+++ b/crates/brush-dataset/src/formats/nerfstudio.rs
@@ -200,6 +200,7 @@ async fn read_transforms_file(
             (Some(w), Some(h)) => (w as u32, h as u32),
             _ => image.dimensions().await?,
         };
+        let image_size = glam::uvec2(w, h);
 
         let camera_model = resolve_camera_model(
             frame
@@ -260,7 +261,11 @@ async fn read_transforms_file(
             continue;
         }
 
-        let view = SceneView { image, camera };
+        let view = SceneView {
+            image,
+            camera,
+            image_size,
+        };
         results.push(view);
     }
     Ok(results)

--- a/crates/brush-dataset/src/formats/realitycapture.rs
+++ b/crates/brush-dataset/src/formats/realitycapture.rs
@@ -140,6 +140,7 @@ async fn read_dataset_inner(
         // independent once expressed as fov + normalized center, so a
         // header-only dimension read (no full decode) is enough.
         let (w, h) = image.dimensions().await?;
+        let image_size = glam::uvec2(w, h);
 
         let camera = row_to_camera(&fields, &header, w, h);
         if !camera.is_valid() {
@@ -149,7 +150,11 @@ async fn read_dataset_inner(
             continue;
         }
 
-        views.push(SceneView { camera, image });
+        views.push(SceneView {
+            camera,
+            image,
+            image_size,
+        });
     }
 
     let (train_views, eval_views) = split_eval_every(views, load_args.eval_split_every);

--- a/crates/brush-dataset/src/scene.rs
+++ b/crates/brush-dataset/src/scene.rs
@@ -17,6 +17,7 @@ pub enum ViewType {
 pub struct SceneView {
     pub image: LoadImage,
     pub camera: Camera,
+    pub image_size: glam::UVec2,
 }
 
 // Encapsulates a multi-view scene including cameras and the splats.
@@ -64,6 +65,7 @@ impl Scene {
             .map(|v| SceneView {
                 image: v.image.with_scale(scale),
                 camera: v.camera,
+                image_size: v.image_size,
             })
             .collect();
         Self::new(views)

--- a/crates/brush-process/src/train_stream.rs
+++ b/crates/brush-process/src/train_stream.rs
@@ -178,8 +178,7 @@ pub(crate) async fn train_stream(
     // Mip-Splatting 3D filter (always on).
     let mut view_cams: Vec<(glam::Vec3, f32)> = Vec::with_capacity(dataset.train.views.len());
     for view in dataset.train.views.iter() {
-        let (w, h) = view.image.dimensions().await.unwrap_or((1, 1));
-        let focal = view.camera.focal(glam::uvec2(w, h)).x;
+        let focal = view.camera.focal(view.image_size).x;
         view_cams.push((view.camera.position, focal));
     }
 


### PR DESCRIPTION
I've noticed that it stays a long time in "Completed Loading" before actually starting with the training.
The reason for that seems to be reading every image from the disk for the dimensions.
This can take a long time, e.g. I have a 26k images dataset on a hard disk that takes 26 minutes just to pass this.

We can avoid this, as every supported format actually already has this info, so we can just store it directly in the `SceneView` (or `LoadImage`, not sure about it...). This in the above case reduced this to just a few seconds.