### PR TITLE
Implement animation panel + cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -841,12 +841,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "brush-anim"
+version = "0.3.0"
+dependencies = [
+ "anyhow",
+ "brush-render",
+ "burn",
+ "ffmpeg-sidecar",
+ "glam",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "brush-app"
 version = "0.3.0"
 dependencies = [
  "android_logger",
  "anyhow",
  "async-channel",
+ "brush-anim",
  "brush-async",
  "brush-cli",
  "brush-dataset",
@@ -943,8 +957,12 @@ name = "brush-cli"
 version = "0.3.0"
 dependencies = [
  "anyhow",
+ "brush-anim",
  "brush-async",
  "brush-process",
+ "brush-render",
+ "brush-serde",
+ "burn",
  "clap",
  "env_logger",
  "getrandom 0.4.2",
@@ -3767,6 +3785,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fb2907d1f08b2b316b9223ced5b0e89d87028ba8deae9764741dba8ff7f3903"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "ffmpeg-sidecar"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126522985748cb6a56a966037c3d86d94414be7a01d7749eccf71f7290f6eacd"
+dependencies = [
+ "anyhow",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,12 +945,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "brush-anim"
+version = "1.0.0"
+dependencies = [
+ "anyhow",
+ "brush-render",
+ "burn",
+ "ffmpeg-sidecar",
+ "glam",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "brush-app"
 version = "1.0.0"
 dependencies = [
  "android_logger",
  "anyhow",
  "async-channel",
+ "brush-anim",
  "brush-async",
  "brush-cli",
  "brush-dataset",
@@ -1046,8 +1060,12 @@ name = "brush-cli"
 version = "1.0.0"
 dependencies = [
  "anyhow",
+ "brush-anim",
  "brush-async",
  "brush-process",
+ "brush-render",
+ "brush-serde",
+ "burn",
  "clap",
  "env_logger",
  "getrandom 0.4.3",
@@ -3953,6 +3971,15 @@ name = "fearless_simd"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97b65636e5b9ef369943878ac74335ba1c55c1cb6adbf1e2c293c624248d693"
+
+[[package]]
+name = "ffmpeg-sidecar"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126522985748cb6a56a966037c3d86d94414be7a01d7749eccf71f7290f6eacd"
+dependencies = [
+ "anyhow",
+]
 
 [[package]]
 name = "filetime"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "apps/brush-c",
     "apps/brush-cli",
     "apps/brush-js",
+    "crates/brush-anim",
     "crates/brush-async",
     "crates/brush-bench-test",
     "crates/brush-cube",

--- a/apps/brush-app/Cargo.toml
+++ b/apps/brush-app/Cargo.toml
@@ -26,6 +26,7 @@ brush-process.path = "../../crates/brush-process"
 brush-dataset.path = "../../crates/brush-dataset"
 brush-render.path = "../../crates/brush-render"
 brush-serde.path = "../../crates/brush-serde"
+brush-anim.path = "../../crates/brush-anim"
 
 rrfd.path = "../../crates/rrfd"
 

--- a/apps/brush-app/Cargo.toml
+++ b/apps/brush-app/Cargo.toml
@@ -26,6 +26,7 @@ brush-process.path = "../../crates/brush-process"
 brush-dataset.path = "../../crates/brush-dataset"
 brush-render.path = "../../crates/brush-render"
 brush-serde.path = "../../crates/brush-serde"
+brush-anim.path = "../../crates/brush-anim"
 
 rrfd.path = "../../crates/rrfd"
 
@@ -68,14 +69,14 @@ brush-cli.path = "../brush-cli"
 winit = { version = "0.30", features = ["default"] }
 clap.workspace = true
 env_logger.workspace = true
-tokio = { workspace = true, features = ["io-util", "rt", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["io-util", "rt", "rt-multi-thread", "sync"] }
 
 [target.'cfg(target_family = "windows")'.dependencies]
 winapi.workspace = true
 
 [target.'cfg(target_os = "android")'.dependencies]
 winit = { version = "0.30", features = ["android-game-activity"] }
-tokio = { workspace = true, features = ["io-util", "rt", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["io-util", "rt", "rt-multi-thread", "sync"] }
 android_logger = "0.15.0"
 jni = "0.22"
 

--- a/apps/brush-app/src/bin.rs
+++ b/apps/brush-app/src/bin.rs
@@ -45,6 +45,11 @@ fn main() -> Result<(), anyhow::Error> {
         .build()
         .expect("Failed to initialize tokio runtime")
         .block_on(async move {
+            // Headless animation render path (no viewer).
+            if args.animation.render_anim.is_some() {
+                return brush_cli::run_render_animation(&args).await;
+            }
+
             let init_process = brush_cli::build_process(&args);
 
             if args.with_viewer {

--- a/apps/brush-app/src/ui/animation_export.rs
+++ b/apps/brush-app/src/ui/animation_export.rs
@@ -1,0 +1,219 @@
+//! Export popup + background driver for rendering the animation to an MP4.
+//! The actual render/encode lives in `brush_anim`; this owns the UI, the
+//! worker thread, and progress reporting. Native only.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use brush_async::Actor;
+use brush_render::{camera::Camera, gaussian_splats::Splats};
+use egui::Align2;
+use glam::Vec3;
+
+/// Resolution presets offered in the popup.
+const PRESETS: [(&str, u32, u32); 3] = [
+    ("HD", 1280, 720),
+    ("Full HD", 1920, 1080),
+    ("UHD", 3840, 2160),
+];
+
+/// Everything needed to render and encode the video, gathered on the UI thread.
+pub struct ExportJob {
+    pub splats: Splats,
+    pub cameras: Vec<Camera>,
+    pub fps: usize,
+    pub background: Vec3,
+    pub splat_scale: Option<f32>,
+    pub width: u32,
+    pub height: u32,
+    pub path: PathBuf,
+}
+
+#[derive(Default)]
+struct Progress {
+    rendered: AtomicUsize,
+    total: AtomicUsize,
+    running: AtomicBool,
+    error: std::sync::Mutex<Option<String>>,
+}
+
+pub struct Exporter {
+    open: bool,
+    width: u32,
+    height: u32,
+    path: Option<PathBuf>,
+    /// Output path chosen by the async save dialog, picked up on the next frame.
+    picked_path: Arc<Mutex<Option<PathBuf>>>,
+    actor: Actor,
+    progress: Arc<Progress>,
+}
+
+impl Default for Exporter {
+    fn default() -> Self {
+        Self {
+            open: false,
+            width: 1920,
+            height: 1080,
+            path: None,
+            picked_path: Arc::new(Mutex::new(None)),
+            actor: Actor::new("animation-export"),
+            progress: Arc::new(Progress::default()),
+        }
+    }
+}
+
+impl Exporter {
+    pub fn open(&mut self) {
+        self.open = true;
+    }
+
+    fn is_running(&self) -> bool {
+        self.progress.running.load(Ordering::Relaxed)
+    }
+
+    /// Draws the popup. Returns a [`PendingExport`] when the user starts an
+    /// export, so the caller can build the splats/cameras for it.
+    pub fn draw(&mut self, ui: &egui::Ui) -> Option<PendingExport> {
+        if !self.open {
+            return None;
+        }
+
+        // Pick up a path chosen by the (async) save dialog.
+        if let Some(path) = self.picked_path.lock().expect("poisoned").take() {
+            self.path = Some(path);
+        }
+
+        let mut request = None;
+        let mut open = self.open;
+        egui::Window::new("Export animation")
+            .collapsible(false)
+            .resizable(false)
+            .anchor(Align2::CENTER_CENTER, [0.0, 0.0])
+            .open(&mut open)
+            .show(ui.ctx(), |ui| {
+                let running = self.is_running();
+
+                ui.add_enabled_ui(!running, |ui| {
+                    ui.horizontal(|ui| {
+                        ui.label("Preset:");
+                        for (name, w, h) in PRESETS {
+                            let selected = self.width == w && self.height == h;
+                            if ui.selectable_label(selected, name).clicked() {
+                                self.width = w;
+                                self.height = h;
+                            }
+                        }
+                    });
+
+                    ui.horizontal(|ui| {
+                        ui.label("Resolution:");
+                        ui.add(egui::DragValue::new(&mut self.width).range(16..=7680));
+                        ui.label("×");
+                        ui.add(egui::DragValue::new(&mut self.height).range(16..=4320));
+                    });
+
+                    ui.horizontal(|ui| {
+                        if ui.button("Choose file…").clicked() {
+                            let slot = self.picked_path.clone();
+                            let ctx = ui.ctx().clone();
+                            self.actor
+                                .run(move || async move {
+                                    // A cancelled dialog just leaves the path unset.
+                                    if let Ok(path) =
+                                        rrfd::pick_save_path("animation.mp4", "MP4 video", &["mp4"])
+                                            .await
+                                    {
+                                        *slot.lock().expect("poisoned") = Some(path);
+                                        ctx.request_repaint();
+                                    }
+                                })
+                                .detach();
+                        }
+                        match &self.path {
+                            Some(p) => ui.label(p.display().to_string()),
+                            None => ui.label(egui::RichText::new("No file selected").italics()),
+                        };
+                    });
+                });
+
+                ui.separator();
+
+                if running {
+                    let done = self.progress.rendered.load(Ordering::Relaxed);
+                    let total = self.progress.total.load(Ordering::Relaxed).max(1);
+                    ui.add(
+                        egui::ProgressBar::new(done as f32 / total as f32)
+                            .text(format!("Rendering frame {done} / {total}")),
+                    );
+                } else {
+                    if let Some(err) = self.progress.error.lock().expect("poisoned").as_ref() {
+                        ui.colored_label(egui::Color32::LIGHT_RED, err);
+                    } else if self.progress.total.load(Ordering::Relaxed) > 0 {
+                        ui.colored_label(egui::Color32::LIGHT_GREEN, "Export complete.");
+                    }
+
+                    let can_export = self.path.is_some();
+                    if ui
+                        .add_enabled(can_export, egui::Button::new("Export"))
+                        .clicked()
+                        && let Some(path) = self.path.clone()
+                    {
+                        request = Some(PendingExport {
+                            width: self.width,
+                            height: self.height,
+                            path,
+                        });
+                    }
+                }
+            });
+        self.open = open;
+
+        request
+    }
+
+    /// Kicks off the background render + encode for `job`.
+    pub fn start(&self, ctx: egui::Context, job: ExportJob) {
+        self.progress.rendered.store(0, Ordering::Relaxed);
+        self.progress
+            .total
+            .store(job.cameras.len(), Ordering::Relaxed);
+        self.progress.running.store(true, Ordering::Relaxed);
+        *self.progress.error.lock().expect("poisoned") = None;
+
+        let progress = self.progress.clone();
+        self.actor
+            .run(move || async move {
+                let result = brush_anim::render_to_mp4(
+                    job.splats,
+                    job.cameras,
+                    job.fps,
+                    job.background,
+                    job.splat_scale,
+                    job.width,
+                    job.height,
+                    &job.path,
+                    |done, _total| {
+                        progress.rendered.store(done, Ordering::Relaxed);
+                        ctx.request_repaint();
+                    },
+                )
+                .await;
+
+                if let Err(e) = result {
+                    *progress.error.lock().expect("poisoned") = Some(format!("{e:#}"));
+                }
+                progress.running.store(false, Ordering::Relaxed);
+                ctx.request_repaint();
+            })
+            .detach();
+    }
+}
+
+/// What the popup hands back when the user clicks Export. The caller turns this
+/// into a full [`ExportJob`] by adding the splats and per-frame cameras.
+pub struct PendingExport {
+    pub width: u32,
+    pub height: u32,
+    pub path: PathBuf,
+}

--- a/apps/brush-app/src/ui/animation_export.rs
+++ b/apps/brush-app/src/ui/animation_export.rs
@@ -1,0 +1,222 @@
+//! Export popup + background driver for rendering the animation to an MP4.
+//! The actual render/encode lives in `brush_anim`; this owns the UI, the
+//! worker thread, and progress reporting. Native only.
+
+use std::path::PathBuf;
+
+use brush_anim::VideoSettings;
+use brush_async::Actor;
+use brush_render::{camera::Camera, gaussian_splats::Splats};
+use egui::Align2;
+use tokio::sync::{oneshot, watch};
+
+/// Resolution presets offered in the popup.
+const PRESETS: [(&str, u32, u32); 3] = [
+    ("HD", 1280, 720),
+    ("Full HD", 1920, 1080),
+    ("UHD", 3840, 2160),
+];
+
+/// Everything needed to render and encode the video, gathered on the UI thread.
+pub struct ExportJob {
+    pub splats: Splats,
+    pub cameras: Vec<Camera>,
+    pub settings: VideoSettings,
+    pub path: PathBuf,
+}
+
+/// What the background export is doing, published to the UI thread.
+#[derive(Clone)]
+enum ExportState {
+    /// Nothing has been exported yet this session.
+    Idle,
+    Rendering {
+        done: usize,
+        total: usize,
+    },
+    Done,
+    Failed(String),
+}
+
+pub struct Exporter {
+    open: bool,
+    width: u32,
+    height: u32,
+    path: Option<PathBuf>,
+    /// A save dialog in flight; resolves to the chosen path, or closes without
+    /// a value if the user cancelled.
+    picked_path: Option<oneshot::Receiver<PathBuf>>,
+    actor: Actor,
+    /// Progress published by the worker. Each export installs a fresh channel;
+    /// the initial one has no sender and just reads back `Idle`.
+    state: watch::Receiver<ExportState>,
+}
+
+impl Default for Exporter {
+    fn default() -> Self {
+        let (_, state) = watch::channel(ExportState::Idle);
+        Self {
+            open: false,
+            width: 1920,
+            height: 1080,
+            path: None,
+            picked_path: None,
+            actor: Actor::new("animation-export"),
+            state,
+        }
+    }
+}
+
+impl Exporter {
+    pub fn open(&mut self) {
+        self.open = true;
+    }
+
+    /// Draws the popup. Returns a [`PendingExport`] when the user starts an
+    /// export, so the caller can build the splats/cameras for it.
+    pub fn draw(&mut self, ui: &egui::Ui) -> Option<PendingExport> {
+        if !self.open {
+            return None;
+        }
+
+        // Pick up a path chosen by the (async) save dialog.
+        if let Some(rx) = &mut self.picked_path {
+            match rx.try_recv() {
+                Ok(path) => {
+                    self.path = Some(path);
+                    self.picked_path = None;
+                }
+                // Cancelled: the sender dropped without ever sending.
+                Err(oneshot::error::TryRecvError::Closed) => self.picked_path = None,
+                Err(oneshot::error::TryRecvError::Empty) => {}
+            }
+        }
+
+        let mut request = None;
+        let mut open = self.open;
+        egui::Window::new("Export animation")
+            .collapsible(false)
+            .resizable(false)
+            .anchor(Align2::CENTER_CENTER, [0.0, 0.0])
+            .open(&mut open)
+            .show(ui.ctx(), |ui| {
+                let state = self.state.borrow().clone();
+
+                ui.add_enabled_ui(!matches!(state, ExportState::Rendering { .. }), |ui| {
+                    ui.horizontal(|ui| {
+                        ui.label("Preset:");
+                        for (name, w, h) in PRESETS {
+                            let selected = self.width == w && self.height == h;
+                            if ui.selectable_label(selected, name).clicked() {
+                                self.width = w;
+                                self.height = h;
+                            }
+                        }
+                    });
+
+                    ui.horizontal(|ui| {
+                        ui.label("Resolution:");
+                        ui.add(egui::DragValue::new(&mut self.width).range(16..=7680));
+                        ui.label("×");
+                        ui.add(egui::DragValue::new(&mut self.height).range(16..=4320));
+                    });
+
+                    ui.horizontal(|ui| {
+                        if ui.button("Choose file…").clicked() {
+                            let (tx, rx) = oneshot::channel();
+                            self.picked_path = Some(rx);
+                            let ctx = ui.ctx().clone();
+                            self.actor
+                                .run(move || async move {
+                                    // A cancelled dialog just drops `tx`.
+                                    if let Ok(path) =
+                                        rrfd::pick_save_path("animation.mp4", "MP4 video", &["mp4"])
+                                            .await
+                                    {
+                                        let _ = tx.send(path);
+                                        ctx.request_repaint();
+                                    }
+                                })
+                                .detach();
+                        }
+                        match &self.path {
+                            Some(p) => ui.label(p.display().to_string()),
+                            None => ui.label(egui::RichText::new("No file selected").italics()),
+                        };
+                    });
+                });
+
+                ui.separator();
+
+                if let ExportState::Rendering { done, total } = state {
+                    ui.add(
+                        egui::ProgressBar::new(done as f32 / total.max(1) as f32)
+                            .text(format!("Rendering frame {done} / {total}")),
+                    );
+                } else {
+                    match state {
+                        ExportState::Failed(err) => {
+                            ui.colored_label(egui::Color32::LIGHT_RED, err);
+                        }
+                        ExportState::Done => {
+                            ui.colored_label(egui::Color32::LIGHT_GREEN, "Export complete.");
+                        }
+                        ExportState::Idle | ExportState::Rendering { .. } => {}
+                    }
+
+                    let can_export = self.path.is_some();
+                    if ui
+                        .add_enabled(can_export, egui::Button::new("Export"))
+                        .clicked()
+                        && let Some(path) = self.path.clone()
+                    {
+                        request = Some(PendingExport {
+                            width: self.width,
+                            height: self.height,
+                            path,
+                        });
+                    }
+                }
+            });
+        self.open = open;
+
+        request
+    }
+
+    /// Kicks off the background render + encode for `job`.
+    pub fn start(&mut self, ctx: egui::Context, job: ExportJob) {
+        let total = job.cameras.len();
+        let (state, rx) = watch::channel(ExportState::Rendering { done: 0, total });
+        self.state = rx;
+
+        self.actor
+            .run(move || async move {
+                let result = brush_anim::render_to_mp4(
+                    job.splats,
+                    &job.cameras,
+                    &job.settings,
+                    &job.path,
+                    |done, total| {
+                        let _ = state.send(ExportState::Rendering { done, total });
+                        ctx.request_repaint();
+                    },
+                )
+                .await;
+
+                let _ = state.send(match result {
+                    Ok(()) => ExportState::Done,
+                    Err(e) => ExportState::Failed(format!("{e:#}")),
+                });
+                ctx.request_repaint();
+            })
+            .detach();
+    }
+}
+
+/// What the popup hands back when the user clicks Export. The caller turns this
+/// into a full [`ExportJob`] by adding the splats and per-frame cameras.
+pub struct PendingExport {
+    pub width: u32,
+    pub height: u32,
+    pub path: PathBuf,
+}

--- a/apps/brush-app/src/ui/animation_panel.rs
+++ b/apps/brush-app/src/ui/animation_panel.rs
@@ -1,0 +1,499 @@
+use brush_anim::{AnimationConfig, Interpolation};
+use egui::{Ui, WidgetText};
+use web_time::Instant;
+
+#[cfg(not(target_family = "wasm"))]
+use crate::ui::animation_export::Exporter;
+use crate::ui::panels::AppPane;
+use crate::ui::ui_process::UiProcess;
+
+#[cfg(not(target_family = "wasm"))]
+use std::sync::{Arc, Mutex};
+
+const MARKER_RADIUS: f32 = 10.0;
+
+#[derive(Default)]
+pub struct AnimationPanel {
+    /// Serializable animation state (keyframes, timeline, camera).
+    config: AnimationConfig,
+    current_frame: usize,
+    /// When playing: (wall-clock start, frame playback started from).
+    playback: Option<(Instant, usize)>,
+    /// Last frame applied to the camera, so we only update on change.
+    applied_frame: Option<usize>,
+    #[cfg(not(target_family = "wasm"))]
+    exporter: Exporter,
+    #[cfg(not(target_family = "wasm"))]
+    config_io: ConfigIo,
+}
+
+impl AppPane for AnimationPanel {
+    fn title(&self) -> WidgetText {
+        "Animation".into()
+    }
+
+    fn is_visible(&self, process: &UiProcess) -> bool {
+        !process.current_splats().is_empty() && !process.is_training()
+    }
+
+    fn ui(&mut self, ui: &mut Ui, process: &UiProcess) {
+        #[cfg(not(target_family = "wasm"))]
+        if let Some(config) = self.config_io.take_loaded() {
+            self.config = config;
+            self.apply_config_to_viewer(process);
+            self.playback = None;
+            self.applied_frame = None;
+        }
+
+        let min_frames = self.config.min_frames();
+        self.config.num_frames = self.config.num_frames.max(min_frames);
+
+        let last_frame = self.config.num_frames.saturating_sub(1);
+        self.current_frame = self.current_frame.min(last_frame);
+        self.advance_playback(ui, last_frame);
+
+        self.frame_slider(ui, last_frame);
+        self.keyframe_timeline(ui, last_frame);
+
+        ui.add_space(8.0);
+        self.toolbar(ui, min_frames, process);
+
+        if self.applied_frame != Some(self.current_frame) {
+            self.apply_camera_for_frame(process, self.current_frame);
+            self.applied_frame = Some(self.current_frame);
+        }
+
+        #[cfg(not(target_family = "wasm"))]
+        self.export_popup(ui, process);
+    }
+}
+
+impl AnimationPanel {
+    /// Advances `current_frame` from wall-clock time so playback speed tracks
+    /// the FPS regardless of the display refresh rate, looping at the end.
+    fn advance_playback(&mut self, ui: &Ui, last_frame: usize) {
+        let Some((start, start_frame)) = self.playback else {
+            return;
+        };
+        let advanced = (start.elapsed().as_secs_f32() * self.config.fps as f32) as usize;
+        self.current_frame = (start_frame + advanced) % (last_frame + 1);
+        ui.ctx().request_repaint();
+    }
+
+    fn frame_slider(&mut self, ui: &mut Ui, last_frame: usize) {
+        ui.label("Current frame");
+        ui.spacing_mut().slider_width = ui.available_width();
+        ui.add(
+            egui::Slider::new(&mut self.current_frame, 0..=last_frame)
+                .integer()
+                .show_value(false),
+        );
+    }
+
+    fn toolbar(&mut self, ui: &mut Ui, min_frames: usize, process: &UiProcess) {
+        ui.horizontal(|ui| {
+            let playing = self.playback.is_some();
+            if ui
+                .add_enabled(!playing, egui::Button::new("▶"))
+                .on_hover_text("Play the animation")
+                .clicked()
+            {
+                self.playback = Some((Instant::now(), self.current_frame));
+            }
+            if ui
+                .add_enabled(playing, egui::Button::new("⏹"))
+                .on_hover_text("Stop the animation")
+                .clicked()
+            {
+                self.playback = None;
+            }
+
+            ui.separator();
+
+            if ui
+                .button("➕")
+                .on_hover_text("Add keyframe at the current frame")
+                .clicked()
+            {
+                let camera = process.current_camera();
+                self.config
+                    .set_keyframe(self.current_frame, camera.position, camera.rotation);
+            }
+            let has_here = self
+                .config
+                .keyframes
+                .iter()
+                .any(|k| k.frame == self.current_frame);
+            if ui
+                .add_enabled(has_here, egui::Button::new("➖"))
+                .on_hover_text("Remove the keyframe at the current frame")
+                .clicked()
+            {
+                self.config
+                    .keyframes
+                    .retain(|k| k.frame != self.current_frame);
+            }
+
+            ui.separator();
+
+            let prev_interp = self.config.interpolation;
+            egui::ComboBox::from_id_salt("interpolation")
+                .selected_text(self.config.interpolation.label())
+                .show_ui(ui, |ui| {
+                    for method in Interpolation::ALL {
+                        ui.selectable_value(&mut self.config.interpolation, method, method.label());
+                    }
+                });
+            // Re-apply the camera so the new method takes effect immediately.
+            if self.config.interpolation != prev_interp {
+                self.applied_frame = None;
+            }
+
+            #[cfg(not(target_family = "wasm"))]
+            {
+                ui.separator();
+                self.config_buttons(ui, process);
+            }
+
+            // FPS / frame-count editors, pushed to the right boundary. In a
+            // right-to-left layout the first widget sits furthest right.
+            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                ui.add(
+                    egui::DragValue::new(&mut self.config.num_frames)
+                        .range(min_frames..=100_000)
+                        .speed(1),
+                );
+                ui.label("Frames");
+                ui.add(
+                    egui::DragValue::new(&mut self.config.fps)
+                        .range(1..=60)
+                        .speed(1),
+                );
+                ui.label("FPS");
+            });
+        });
+    }
+
+    /// Save / load / export buttons (native only, since they touch the
+    /// filesystem and, for export, ffmpeg).
+    #[cfg(not(target_family = "wasm"))]
+    fn config_buttons(&mut self, ui: &mut Ui, process: &UiProcess) {
+        if ui
+            .button("Save…")
+            .on_hover_text("Save the animation to a config file")
+            .clicked()
+        {
+            self.sync_scene_into_config(process);
+            self.config_io.save(self.config.clone());
+        }
+        if ui
+            .button("Load…")
+            .on_hover_text("Load an animation config file")
+            .clicked()
+        {
+            self.config_io.load(ui.ctx().clone());
+        }
+        if ui
+            .add_enabled(
+                !self.config.keyframes.is_empty(),
+                egui::Button::new("Export…"),
+            )
+            .on_hover_text("Export the animation as an MP4 video")
+            .clicked()
+        {
+            self.exporter.open();
+        }
+    }
+
+    /// Captures the current viewer camera/scene state into the config so it can
+    /// be reproduced on export or load.
+    #[cfg(not(target_family = "wasm"))]
+    fn sync_scene_into_config(&mut self, process: &UiProcess) {
+        let camera = process.current_camera();
+        self.config.fov_x = camera.fov_x;
+        self.config.fov_y = camera.fov_y;
+        self.config.center_uv = camera.center_uv;
+        self.config.model_local_to_world = process.model_local_to_world();
+        let settings = process.get_cam_settings();
+        self.config.background = settings.background.unwrap_or(glam::Vec3::ZERO);
+        self.config.splat_scale = settings.splat_scale;
+    }
+
+    /// Pushes the loaded config's scene snapshot into the viewer, so live
+    /// playback matches what the config was authored with (and what export
+    /// produces). The inverse of [`Self::sync_scene_into_config`].
+    #[cfg(not(target_family = "wasm"))]
+    fn apply_config_to_viewer(&self, process: &UiProcess) {
+        process.set_model_local_to_world(self.config.model_local_to_world);
+        process.set_cam_fov(self.config.fov_y);
+        let mut settings = process.get_cam_settings();
+        settings.background = Some(self.config.background);
+        settings.splat_scale = self.config.splat_scale;
+        process.set_cam_settings(&settings);
+    }
+
+    /// Drives the live camera to the interpolated pose for `frame`.
+    fn apply_camera_for_frame(&self, process: &UiProcess, frame: usize) {
+        if let Some((position, rotation)) = self.config.pose_at_frame(frame) {
+            process.set_cam_transform(position, rotation);
+        }
+    }
+
+    /// Draws the export popup and starts an export when requested.
+    #[cfg(not(target_family = "wasm"))]
+    fn export_popup(&mut self, ui: &Ui, process: &UiProcess) {
+        let Some(pending) = self.exporter.draw(ui) else {
+            return;
+        };
+        let Some(splats) = process.current_splats().latest() else {
+            return;
+        };
+
+        self.sync_scene_into_config(process);
+        let cameras = self.config.render_cameras(pending.width, pending.height);
+        self.exporter.start(
+            ui.ctx().clone(),
+            crate::ui::animation_export::ExportJob {
+                splats,
+                cameras,
+                fps: self.config.fps,
+                background: self.config.background,
+                splat_scale: self.config.splat_scale,
+                width: pending.width,
+                height: pending.height,
+                path: pending.path,
+            },
+        );
+    }
+
+    fn keyframe_timeline(&mut self, ui: &mut Ui, last_frame: usize) {
+        let layout = TimelineLayout::allocate(ui, last_frame);
+        self.draw_track(ui, &layout);
+
+        let (to_move, to_remove) = self.draw_markers(ui, &layout);
+        if let Some((idx, new_frame)) = to_move {
+            self.config.keyframes[idx].frame = new_frame;
+        }
+        if let Some(idx) = to_remove {
+            self.config.keyframes.remove(idx);
+        }
+    }
+
+    /// Draws the baseline, the playhead, and the current frame number.
+    fn draw_track(&self, ui: &Ui, layout: &TimelineLayout) {
+        let painter = ui.painter_at(layout.rect);
+        let visuals = ui.visuals();
+
+        painter.line_segment(
+            [
+                egui::pos2(layout.track_left, layout.marker_y),
+                egui::pos2(layout.track_right(), layout.marker_y),
+            ],
+            egui::Stroke::new(2.0, visuals.widgets.inactive.bg_fill),
+        );
+
+        let playhead_x = layout.frame_to_x(self.current_frame);
+        painter.line_segment(
+            [
+                egui::pos2(playhead_x, layout.marker_y),
+                egui::pos2(playhead_x, layout.rect.bottom()),
+            ],
+            egui::Stroke::new(1.5, visuals.selection.bg_fill),
+        );
+        painter.text(
+            egui::pos2(playhead_x, layout.rect.top()),
+            egui::Align2::CENTER_TOP,
+            self.current_frame.to_string(),
+            egui::FontId::proportional(11.0),
+            visuals.selection.bg_fill,
+        );
+    }
+
+    /// Draws each keyframe marker and handles dragging/removal. Returns the
+    /// pending `(index, new_frame)` move and/or index to remove, applied by the
+    /// caller to avoid mutating while iterating.
+    fn draw_markers(
+        &self,
+        ui: &Ui,
+        layout: &TimelineLayout,
+    ) -> (Option<(usize, usize)>, Option<usize>) {
+        let painter = ui.painter_at(layout.rect);
+        let mut to_move = None;
+        let mut to_remove = None;
+
+        for (idx, kf) in self.config.keyframes.iter().enumerate() {
+            let frame = kf.frame;
+            let center = egui::pos2(layout.frame_to_x(frame), layout.marker_y);
+            let hit = egui::Rect::from_center_size(center, egui::Vec2::splat(MARKER_RADIUS * 2.5));
+            // Identity is keyed on the stable index, not the frame, so a drag
+            // survives the frame value changing underneath it.
+            let resp = ui.interact(
+                hit,
+                ui.id().with(("keyframe", idx)),
+                egui::Sense::click_and_drag(),
+            );
+
+            let color = if resp.hovered() || resp.dragged() {
+                ui.visuals().widgets.hovered.fg_stroke.color
+            } else {
+                ui.visuals().selection.bg_fill
+            };
+            painter.circle_filled(center, MARKER_RADIUS, color);
+            painter.circle_stroke(
+                center,
+                MARKER_RADIUS,
+                egui::Stroke::new(1.0, ui.visuals().extreme_bg_color),
+            );
+            painter.text(
+                egui::pos2(center.x, layout.marker_y + MARKER_RADIUS + 2.0),
+                egui::Align2::CENTER_TOP,
+                frame.to_string(),
+                egui::FontId::proportional(11.0),
+                ui.visuals().text_color(),
+            );
+
+            if resp.dragged()
+                && let Some(pointer) = resp.interact_pointer_pos()
+            {
+                let new_frame = layout.x_to_frame(pointer.x);
+                let occupied = self
+                    .config
+                    .keyframes
+                    .iter()
+                    .enumerate()
+                    .any(|(i, k)| i != idx && k.frame == new_frame);
+                if new_frame != frame && !occupied {
+                    to_move = Some((idx, new_frame));
+                }
+            }
+
+            resp.clone().context_menu(|ui| {
+                if ui.button("Remove keyframe").clicked() {
+                    to_remove = Some(idx);
+                    ui.close();
+                }
+            });
+
+            resp.on_hover_text(format!(
+                "Frame {frame} — drag to move, right-click to remove"
+            ));
+        }
+
+        (to_move, to_remove)
+    }
+}
+
+/// Geometry for mapping frames to/from x positions on the timeline.
+struct TimelineLayout {
+    rect: egui::Rect,
+    track_left: f32,
+    track_width: f32,
+    marker_y: f32,
+    span: f32,
+}
+
+impl TimelineLayout {
+    const PAD: f32 = 8.0;
+    const HEIGHT: f32 = 44.0;
+
+    fn allocate(ui: &mut Ui, last_frame: usize) -> Self {
+        let (rect, _) = ui.allocate_exact_size(
+            egui::vec2(ui.available_width(), Self::HEIGHT),
+            egui::Sense::hover(),
+        );
+        let track_left = rect.left() + Self::PAD;
+        Self {
+            track_left,
+            track_width: (rect.right() - Self::PAD - track_left).max(1.0),
+            // Leave room for the current frame above and keyframe numbers below.
+            marker_y: rect.top() + 20.0,
+            span: last_frame.max(1) as f32,
+            rect,
+        }
+    }
+
+    fn track_right(&self) -> f32 {
+        self.track_left + self.track_width
+    }
+
+    fn frame_to_x(&self, frame: usize) -> f32 {
+        self.track_left + (frame as f32 / self.span) * self.track_width
+    }
+
+    fn x_to_frame(&self, x: f32) -> usize {
+        (((x - self.track_left) / self.track_width) * self.span)
+            .round()
+            .clamp(0.0, self.span) as usize
+    }
+}
+
+/// Background file-dialog driver for saving/loading the animation config. The
+/// dialogs (via `rrfd`) are async, so they run on a worker thread and hand the
+/// loaded config back through a shared slot, picked up on the next frame.
+#[cfg(not(target_family = "wasm"))]
+struct ConfigIo {
+    actor: brush_async::Actor,
+    loaded: Arc<Mutex<Option<AnimationConfig>>>,
+}
+
+#[cfg(not(target_family = "wasm"))]
+impl Default for ConfigIo {
+    fn default() -> Self {
+        Self {
+            actor: brush_async::Actor::new("animation-config-io"),
+            loaded: Arc::new(Mutex::new(None)),
+        }
+    }
+}
+
+#[cfg(not(target_family = "wasm"))]
+impl ConfigIo {
+    /// Opens a save dialog and writes `config` as JSON to the chosen path.
+    fn save(&self, config: AnimationConfig) {
+        self.actor
+            .run(move || async move {
+                let json = match config.to_json() {
+                    Ok(json) => json,
+                    Err(e) => {
+                        log::error!("Failed to serialize animation config: {e}");
+                        return;
+                    }
+                };
+                if let Err(e) = rrfd::save_file("animation.json", json.into_bytes()).await {
+                    log::error!("Failed to save animation config: {e}");
+                }
+            })
+            .detach();
+    }
+
+    /// Opens a file picker and stashes the parsed config for the panel to pick up.
+    fn load(&self, ctx: egui::Context) {
+        let loaded = self.loaded.clone();
+        self.actor
+            .run(move || async move {
+                match load_config_file().await {
+                    Ok(config) => {
+                        *loaded.lock().expect("poisoned") = Some(config);
+                        ctx.request_repaint();
+                    }
+                    Err(e) => log::error!("Failed to load animation config: {e}"),
+                }
+            })
+            .detach();
+    }
+
+    fn take_loaded(&self) -> Option<AnimationConfig> {
+        self.loaded.lock().expect("poisoned").take()
+    }
+}
+
+#[cfg(not(target_family = "wasm"))]
+async fn load_config_file() -> anyhow::Result<AnimationConfig> {
+    use tokio::io::AsyncReadExt;
+
+    let picked = rrfd::pick_file().await?;
+    let mut contents = String::new();
+    let mut reader = picked.reader;
+    reader.read_to_string(&mut contents).await?;
+    Ok(AnimationConfig::from_json(&contents)?)
+}

--- a/apps/brush-app/src/ui/animation_panel.rs
+++ b/apps/brush-app/src/ui/animation_panel.rs
@@ -1,0 +1,509 @@
+use brush_anim::{AnimationConfig, Interpolation};
+use egui::{Ui, WidgetText};
+use web_time::Instant;
+
+#[cfg(not(target_family = "wasm"))]
+use crate::ui::animation_export::Exporter;
+use crate::ui::panels::AppPane;
+use crate::ui::ui_process::UiProcess;
+
+#[cfg(not(target_family = "wasm"))]
+use tokio::sync::oneshot;
+
+const MARKER_RADIUS: f32 = 10.0;
+
+#[derive(Default)]
+pub struct AnimationPanel {
+    /// Serializable animation state (keyframes, timeline, camera).
+    config: AnimationConfig,
+    current_frame: usize,
+    /// When playing: (wall-clock start, frame playback started from).
+    playback: Option<(Instant, usize)>,
+    /// Last frame applied to the camera, so we only update on change.
+    applied_frame: Option<usize>,
+    #[cfg(not(target_family = "wasm"))]
+    exporter: Exporter,
+    #[cfg(not(target_family = "wasm"))]
+    config_io: ConfigIo,
+}
+
+impl AppPane for AnimationPanel {
+    fn title(&self) -> WidgetText {
+        "Animation".into()
+    }
+
+    fn is_visible(&self, process: &UiProcess) -> bool {
+        !process.current_splats().is_empty() && !process.is_training()
+    }
+
+    fn ui(&mut self, ui: &mut Ui, process: &UiProcess) {
+        #[cfg(not(target_family = "wasm"))]
+        if let Some(config) = self.config_io.take_loaded() {
+            self.config = config;
+            self.apply_config_to_viewer(process);
+            self.playback = None;
+            self.applied_frame = None;
+        }
+
+        let min_frames = self.config.min_frames();
+        self.config.num_frames = self.config.num_frames.max(min_frames);
+
+        let last_frame = self.config.num_frames.saturating_sub(1);
+        self.current_frame = self.current_frame.min(last_frame);
+        self.advance_playback(ui, last_frame);
+
+        self.frame_slider(ui, last_frame);
+        self.keyframe_timeline(ui, last_frame);
+
+        ui.add_space(8.0);
+        self.toolbar(ui, min_frames, process);
+
+        if self.applied_frame != Some(self.current_frame) {
+            self.apply_camera_for_frame(process, self.current_frame);
+            self.applied_frame = Some(self.current_frame);
+        }
+
+        #[cfg(not(target_family = "wasm"))]
+        self.export_popup(ui, process);
+    }
+}
+
+impl AnimationPanel {
+    /// Advances `current_frame` from wall-clock time so playback speed tracks
+    /// the FPS regardless of the display refresh rate, looping at the end.
+    fn advance_playback(&mut self, ui: &Ui, last_frame: usize) {
+        let Some((start, start_frame)) = self.playback else {
+            return;
+        };
+        let advanced = (start.elapsed().as_secs_f32() * self.config.fps as f32) as usize;
+        self.current_frame = (start_frame + advanced) % (last_frame + 1);
+        ui.ctx().request_repaint();
+    }
+
+    fn frame_slider(&mut self, ui: &mut Ui, last_frame: usize) {
+        ui.label("Current frame");
+        ui.spacing_mut().slider_width = ui.available_width();
+        ui.add(
+            egui::Slider::new(&mut self.current_frame, 0..=last_frame)
+                .integer()
+                .show_value(false),
+        );
+    }
+
+    fn toolbar(&mut self, ui: &mut Ui, min_frames: usize, process: &UiProcess) {
+        ui.horizontal(|ui| {
+            let playing = self.playback.is_some();
+            if ui
+                .add_enabled(!playing, egui::Button::new("▶"))
+                .on_hover_text("Play the animation")
+                .clicked()
+            {
+                self.playback = Some((Instant::now(), self.current_frame));
+            }
+            if ui
+                .add_enabled(playing, egui::Button::new("⏹"))
+                .on_hover_text("Stop the animation")
+                .clicked()
+            {
+                self.playback = None;
+            }
+
+            ui.separator();
+
+            if ui
+                .button("➕")
+                .on_hover_text("Add keyframe at the current frame")
+                .clicked()
+            {
+                let camera = process.current_camera();
+                self.config
+                    .set_keyframe(self.current_frame, camera.position, camera.rotation);
+            }
+            let has_here = self
+                .config
+                .keyframes
+                .iter()
+                .any(|k| k.frame == self.current_frame);
+            if ui
+                .add_enabled(has_here, egui::Button::new("➖"))
+                .on_hover_text("Remove the keyframe at the current frame")
+                .clicked()
+            {
+                self.config
+                    .keyframes
+                    .retain(|k| k.frame != self.current_frame);
+            }
+
+            ui.separator();
+
+            let prev_interp = self.config.interpolation;
+            egui::ComboBox::from_id_salt("interpolation")
+                .selected_text(self.config.interpolation.label())
+                .show_ui(ui, |ui| {
+                    for method in Interpolation::ALL {
+                        ui.selectable_value(&mut self.config.interpolation, method, method.label());
+                    }
+                });
+            // Re-apply the camera so the new method takes effect immediately.
+            if self.config.interpolation != prev_interp {
+                self.applied_frame = None;
+            }
+
+            #[cfg(not(target_family = "wasm"))]
+            {
+                ui.separator();
+                self.config_buttons(ui, process);
+            }
+
+            // FPS / frame-count editors, pushed to the right boundary. In a
+            // right-to-left layout the first widget sits furthest right.
+            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                ui.add(
+                    egui::DragValue::new(&mut self.config.num_frames)
+                        .range(min_frames..=100_000)
+                        .speed(1),
+                );
+                ui.label("Frames");
+                ui.add(
+                    egui::DragValue::new(&mut self.config.fps)
+                        .range(1..=60)
+                        .speed(1),
+                );
+                ui.label("FPS");
+            });
+        });
+    }
+
+    /// Save / load / export buttons (native only, since they touch the
+    /// filesystem and, for export, ffmpeg).
+    #[cfg(not(target_family = "wasm"))]
+    fn config_buttons(&mut self, ui: &mut Ui, process: &UiProcess) {
+        if ui
+            .button("Save…")
+            .on_hover_text("Save the animation to a config file")
+            .clicked()
+        {
+            self.sync_scene_into_config(process);
+            self.config_io.save(self.config.clone());
+        }
+        if ui
+            .button("Load…")
+            .on_hover_text("Load an animation config file")
+            .clicked()
+        {
+            self.config_io.load(ui.ctx().clone());
+        }
+        if ui
+            .add_enabled(
+                !self.config.keyframes.is_empty(),
+                egui::Button::new("Export…"),
+            )
+            .on_hover_text("Export the animation as an MP4 video")
+            .clicked()
+        {
+            self.exporter.open();
+        }
+    }
+
+    /// Captures the current viewer camera/scene state into the config so it can
+    /// be reproduced on export or load.
+    #[cfg(not(target_family = "wasm"))]
+    fn sync_scene_into_config(&mut self, process: &UiProcess) {
+        let camera = process.current_camera();
+        self.config.fov_x = camera.fov_x;
+        self.config.fov_y = camera.fov_y;
+        self.config.center_uv = camera.center_uv;
+        self.config.model_local_to_world = process.model_local_to_world();
+        let settings = process.get_cam_settings();
+        self.config.background = settings.background.unwrap_or(glam::Vec3::ZERO);
+        self.config.splat_scale = settings.splat_scale;
+    }
+
+    /// Pushes the loaded config's scene snapshot into the viewer, so live
+    /// playback matches what the config was authored with (and what export
+    /// produces). The inverse of [`Self::sync_scene_into_config`].
+    #[cfg(not(target_family = "wasm"))]
+    fn apply_config_to_viewer(&self, process: &UiProcess) {
+        process.set_model_local_to_world(self.config.model_local_to_world);
+        process.set_cam_fov(self.config.fov_y);
+        let mut settings = process.get_cam_settings();
+        settings.background = Some(self.config.background);
+        settings.splat_scale = self.config.splat_scale;
+        process.set_cam_settings(&settings);
+    }
+
+    /// Drives the live camera to the interpolated pose for `frame`.
+    fn apply_camera_for_frame(&self, process: &UiProcess, frame: usize) {
+        if let Some((position, rotation)) = self.config.pose_at_frame(frame) {
+            process.set_cam_transform(position, rotation);
+        }
+    }
+
+    /// Draws the export popup and starts an export when requested.
+    #[cfg(not(target_family = "wasm"))]
+    fn export_popup(&mut self, ui: &Ui, process: &UiProcess) {
+        let Some(pending) = self.exporter.draw(ui) else {
+            return;
+        };
+        let Some(splats) = process.current_splats().latest() else {
+            return;
+        };
+
+        self.sync_scene_into_config(process);
+        self.exporter.start(
+            ui.ctx().clone(),
+            crate::ui::animation_export::ExportJob {
+                splats,
+                cameras: self.config.render_cameras(pending.width, pending.height),
+                settings: self.config.video_settings(pending.width, pending.height),
+                path: pending.path,
+            },
+        );
+    }
+
+    fn keyframe_timeline(&mut self, ui: &mut Ui, last_frame: usize) {
+        let layout = TimelineLayout::allocate(ui, last_frame);
+        self.draw_track(ui, &layout);
+
+        let (to_move, to_remove) = self.draw_markers(ui, &layout);
+        if let Some((idx, new_frame)) = to_move {
+            self.config.keyframes[idx].frame = new_frame;
+        }
+        if let Some(idx) = to_remove {
+            self.config.keyframes.remove(idx);
+        }
+    }
+
+    /// Draws the baseline, the playhead, and the current frame number.
+    fn draw_track(&self, ui: &Ui, layout: &TimelineLayout) {
+        let painter = ui.painter_at(layout.rect);
+        let visuals = ui.visuals();
+
+        painter.line_segment(
+            [
+                egui::pos2(layout.track_left, layout.marker_y),
+                egui::pos2(layout.track_right(), layout.marker_y),
+            ],
+            egui::Stroke::new(2.0, visuals.widgets.inactive.bg_fill),
+        );
+
+        let playhead_x = layout.frame_to_x(self.current_frame);
+        painter.line_segment(
+            [
+                egui::pos2(playhead_x, layout.marker_y),
+                egui::pos2(playhead_x, layout.rect.bottom()),
+            ],
+            egui::Stroke::new(1.5, visuals.selection.bg_fill),
+        );
+        painter.text(
+            egui::pos2(playhead_x, layout.rect.top()),
+            egui::Align2::CENTER_TOP,
+            self.current_frame.to_string(),
+            egui::FontId::proportional(11.0),
+            visuals.selection.bg_fill,
+        );
+    }
+
+    /// Draws each keyframe marker and handles dragging/removal. Returns the
+    /// pending `(index, new_frame)` move and/or index to remove, applied by the
+    /// caller to avoid mutating while iterating.
+    fn draw_markers(
+        &self,
+        ui: &Ui,
+        layout: &TimelineLayout,
+    ) -> (Option<(usize, usize)>, Option<usize>) {
+        let painter = ui.painter_at(layout.rect);
+        let mut to_move = None;
+        let mut to_remove = None;
+
+        for (idx, kf) in self.config.keyframes.iter().enumerate() {
+            let frame = kf.frame;
+            let center = egui::pos2(layout.frame_to_x(frame), layout.marker_y);
+            let hit = egui::Rect::from_center_size(center, egui::Vec2::splat(MARKER_RADIUS * 2.5));
+            // Identity is keyed on the stable index, not the frame, so a drag
+            // survives the frame value changing underneath it.
+            let resp = ui.interact(
+                hit,
+                ui.id().with(("keyframe", idx)),
+                egui::Sense::click_and_drag(),
+            );
+
+            let color = if resp.hovered() || resp.dragged() {
+                ui.visuals().widgets.hovered.fg_stroke.color
+            } else {
+                ui.visuals().selection.bg_fill
+            };
+            painter.circle_filled(center, MARKER_RADIUS, color);
+            painter.circle_stroke(
+                center,
+                MARKER_RADIUS,
+                egui::Stroke::new(1.0, ui.visuals().extreme_bg_color),
+            );
+            painter.text(
+                egui::pos2(center.x, layout.marker_y + MARKER_RADIUS + 2.0),
+                egui::Align2::CENTER_TOP,
+                frame.to_string(),
+                egui::FontId::proportional(11.0),
+                ui.visuals().text_color(),
+            );
+
+            if resp.dragged()
+                && let Some(pointer) = resp.interact_pointer_pos()
+            {
+                let new_frame = layout.x_to_frame(pointer.x);
+                let occupied = self
+                    .config
+                    .keyframes
+                    .iter()
+                    .enumerate()
+                    .any(|(i, k)| i != idx && k.frame == new_frame);
+                if new_frame != frame && !occupied {
+                    to_move = Some((idx, new_frame));
+                }
+            }
+
+            resp.clone().context_menu(|ui| {
+                if ui.button("Remove keyframe").clicked() {
+                    to_remove = Some(idx);
+                    ui.close();
+                }
+            });
+
+            resp.on_hover_text(format!(
+                "Frame {frame} — drag to move, right-click to remove"
+            ));
+        }
+
+        (to_move, to_remove)
+    }
+}
+
+/// Geometry for mapping frames to/from x positions on the timeline.
+struct TimelineLayout {
+    rect: egui::Rect,
+    track_left: f32,
+    track_width: f32,
+    marker_y: f32,
+    span: f32,
+}
+
+impl TimelineLayout {
+    const PAD: f32 = 8.0;
+    const HEIGHT: f32 = 44.0;
+
+    fn allocate(ui: &mut Ui, last_frame: usize) -> Self {
+        let (rect, _) = ui.allocate_exact_size(
+            egui::vec2(ui.available_width(), Self::HEIGHT),
+            egui::Sense::hover(),
+        );
+        let track_left = rect.left() + Self::PAD;
+        Self {
+            track_left,
+            track_width: (rect.right() - Self::PAD - track_left).max(1.0),
+            // Leave room for the current frame above and keyframe numbers below.
+            marker_y: rect.top() + 20.0,
+            span: last_frame.max(1) as f32,
+            rect,
+        }
+    }
+
+    fn track_right(&self) -> f32 {
+        self.track_left + self.track_width
+    }
+
+    fn frame_to_x(&self, frame: usize) -> f32 {
+        self.track_left + (frame as f32 / self.span) * self.track_width
+    }
+
+    fn x_to_frame(&self, x: f32) -> usize {
+        (((x - self.track_left) / self.track_width) * self.span)
+            .round()
+            .clamp(0.0, self.span) as usize
+    }
+}
+
+/// Background file-dialog driver for saving/loading the animation config. The
+/// dialogs (via `rrfd`) are async, so they run on a worker thread and hand the
+/// loaded config back over a channel, picked up on the next frame.
+#[cfg(not(target_family = "wasm"))]
+struct ConfigIo {
+    actor: brush_async::Actor,
+    /// A load in flight; resolves to the parsed config, or closes without a
+    /// value if the dialog was cancelled or the file didn't parse.
+    loading: Option<oneshot::Receiver<AnimationConfig>>,
+}
+
+#[cfg(not(target_family = "wasm"))]
+impl Default for ConfigIo {
+    fn default() -> Self {
+        Self {
+            actor: brush_async::Actor::new("animation-config-io"),
+            loading: None,
+        }
+    }
+}
+
+#[cfg(not(target_family = "wasm"))]
+impl ConfigIo {
+    /// Opens a save dialog and writes `config` as JSON to the chosen path.
+    fn save(&self, config: AnimationConfig) {
+        self.actor
+            .run(move || async move {
+                let json = match config.to_json() {
+                    Ok(json) => json,
+                    Err(e) => {
+                        log::error!("Failed to serialize animation config: {e}");
+                        return;
+                    }
+                };
+                if let Err(e) = rrfd::save_file("animation.json", json.into_bytes()).await {
+                    log::error!("Failed to save animation config: {e}");
+                }
+            })
+            .detach();
+    }
+
+    /// Opens a file picker and sends the parsed config for the panel to pick up.
+    fn load(&mut self, ctx: egui::Context) {
+        let (tx, rx) = oneshot::channel();
+        self.loading = Some(rx);
+        self.actor
+            .run(move || async move {
+                match load_config_file().await {
+                    Ok(config) => {
+                        let _ = tx.send(config);
+                        ctx.request_repaint();
+                    }
+                    Err(e) => log::error!("Failed to load animation config: {e}"),
+                }
+            })
+            .detach();
+    }
+
+    fn take_loaded(&mut self) -> Option<AnimationConfig> {
+        let rx = self.loading.as_mut()?;
+        match rx.try_recv() {
+            Ok(config) => {
+                self.loading = None;
+                Some(config)
+            }
+            // Cancelled or failed to parse: the sender dropped without sending.
+            Err(oneshot::error::TryRecvError::Closed) => {
+                self.loading = None;
+                None
+            }
+            Err(oneshot::error::TryRecvError::Empty) => None,
+        }
+    }
+}
+
+#[cfg(not(target_family = "wasm"))]
+async fn load_config_file() -> anyhow::Result<AnimationConfig> {
+    use tokio::io::AsyncReadExt;
+
+    let picked = rrfd::pick_file().await?;
+    let mut contents = String::new();
+    let mut reader = picked.reader;
+    reader.read_to_string(&mut contents).await?;
+    Ok(AnimationConfig::from_json(&contents)?)
+}

--- a/apps/brush-app/src/ui/app.rs
+++ b/apps/brush-app/src/ui/app.rs
@@ -10,9 +10,10 @@ use std::sync::Arc;
 use tracing::trace_span;
 
 use crate::ui::{
-    UiMode, camera_controls::CameraClamping, datasets::DatasetPanel, log_panel::LogPanel,
-    panels::AppPane, scene::ScenePanel, settings_panel::SettingsPanel, stats::StatsPanel,
-    training_panel::TrainingPanel, ui_process::UiProcess,
+    UiMode, animation_panel::AnimationPanel, camera_controls::CameraClamping,
+    datasets::DatasetPanel, log_panel::LogPanel, panels::AppPane, scene::ScenePanel,
+    settings_panel::SettingsPanel, stats::StatsPanel, training_panel::TrainingPanel,
+    ui_process::UiProcess,
 };
 
 /// Pane enum that wraps all panel types for serialization.
@@ -25,6 +26,7 @@ pub enum Pane {
     Training(#[serde(skip)] TrainingPanel),
     Settings(#[serde(skip)] SettingsPanel),
     Log(#[serde(skip)] LogPanel),
+    Animation(#[serde(skip)] AnimationPanel),
 }
 
 impl Pane {
@@ -36,6 +38,7 @@ impl Pane {
             Self::Training(p) => p,
             Self::Settings(p) => p,
             Self::Log(p) => p,
+            Self::Animation(p) => p,
         }
     }
 
@@ -47,6 +50,7 @@ impl Pane {
             Self::Training(p) => p,
             Self::Settings(p) => p,
             Self::Log(p) => p,
+            Self::Animation(p) => p,
         }
     }
 
@@ -75,6 +79,10 @@ impl Pane {
     fn log() -> RefCell<Self> {
         #[allow(clippy::default_constructed_unit_structs)] // Pane derives Default via serde.
         RefCell::new(Self::Log(LogPanel::default()))
+    }
+
+    fn animation() -> RefCell<Self> {
+        RefCell::new(Self::Animation(AnimationPanel::default()))
     }
 }
 
@@ -170,6 +178,7 @@ impl App {
             let training_pane = tiles.insert_pane(Pane::training());
             let settings_pane = tiles.insert_pane(Pane::settings());
             let log_pane = tiles.insert_pane(Pane::log());
+            let animation_pane = tiles.insert_pane(Pane::animation());
             Self::build_default_layout(
                 &mut tiles,
                 scene_pane,
@@ -178,6 +187,7 @@ impl App {
                 training_pane,
                 settings_pane,
                 log_pane,
+                animation_pane,
             )
         };
 
@@ -197,6 +207,7 @@ impl App {
             && has(tree, |p| matches!(p, Pane::Training(_)))
             && has(tree, |p| matches!(p, Pane::Settings(_)))
             && has(tree, |p| matches!(p, Pane::Log(_)))
+            && has(tree, |p| matches!(p, Pane::Animation(_)))
     }
 
     pub fn new(
@@ -257,6 +268,7 @@ impl App {
         training_pane: TileId,
         settings_pane: TileId,
         log_pane: TileId,
+        animation_pane: TileId,
     ) -> TileId {
         // Stats / Log / Settings share a tabbed area
         let bottom_tabs = tiles.insert_tab_tile(vec![stats_pane, log_pane, settings_pane]);
@@ -275,7 +287,15 @@ impl App {
             vec![scene_pane, sidebar_id],
         );
         content.shares.set_share(sidebar_id, 0.35);
-        tiles.insert_container(content)
+        let content_id = tiles.insert_container(content);
+
+        // Animation timeline spans the full width along the bottom.
+        let mut root = egui_tiles::Linear::new(
+            egui_tiles::LinearDir::Vertical,
+            vec![content_id, animation_pane],
+        );
+        root.shares.set_share(animation_pane, 0.2);
+        tiles.insert_container(root)
     }
 
     fn receive_messages(&mut self) {
@@ -333,6 +353,7 @@ impl eframe::App for App {
             let training_pane = find_pane(&tree.tiles, |p| matches!(p, Pane::Training(_)));
             let settings_pane = find_pane(&tree.tiles, |p| matches!(p, Pane::Settings(_)));
             let log_pane = find_pane(&tree.tiles, |p| matches!(p, Pane::Log(_)));
+            let animation_pane = find_pane(&tree.tiles, |p| matches!(p, Pane::Animation(_)));
 
             // Remove all container tiles
             let container_ids: Vec<TileId> = tree
@@ -353,6 +374,7 @@ impl eframe::App for App {
                 training_pane,
                 settings_pane,
                 log_pane,
+                animation_pane,
             ));
         }
 

--- a/apps/brush-app/src/ui/mod.rs
+++ b/apps/brush-app/src/ui/mod.rs
@@ -14,6 +14,9 @@ mod datasets;
 
 mod training_panel;
 
+#[cfg(not(target_family = "wasm"))]
+mod animation_export;
+mod animation_panel;
 mod settings_panel;
 mod settings_popup;
 

--- a/apps/brush-app/src/ui/scene.rs
+++ b/apps/brush-app/src/ui/scene.rs
@@ -1,6 +1,6 @@
 use brush_process::DataSource;
 use brush_process::{create_process, message::ProcessMessage};
-use brush_render::camera::{focal_to_fov, fov_to_focal};
+use brush_render::camera::fov_to_focal;
 use core::f32;
 use eframe::egui_wgpu::RenderState;
 use egui::{Align2, Button, Frame, RichText, containers::Popup};
@@ -1026,18 +1026,7 @@ impl AppPane for ScenePanel {
             let settings = process.get_cam_settings();
 
             // Adjust FOV so that the scene view shows at least what's visible in the dataset view.
-            // fov_to_focal(fov, 2, model) = 1 / projection(half_fov), so the ratio gives projected_x / projected_y.
-            let camera_aspect = fov_to_focal(camera.fov_y, 2, &camera.camera_model)
-                / fov_to_focal(camera.fov_x, 2, &camera.camera_model);
-            let viewport_aspect = size.x as f64 / size.y as f64;
-
-            if viewport_aspect > camera_aspect {
-                let focal_y = fov_to_focal(camera.fov_y, size.y, &camera.camera_model);
-                camera.fov_x = focal_to_fov(focal_y, size.x, &camera.camera_model);
-            } else {
-                let focal_x = fov_to_focal(camera.fov_x, size.x, &camera.camera_model);
-                camera.fov_y = focal_to_fov(focal_x, size.y, &camera.camera_model);
-            }
+            camera.fit_fov_to_size(size);
 
             // Render the splats and grid
             ui.scope(|ui| {

--- a/apps/brush-app/src/ui/ui_process.rs
+++ b/apps/brush-app/src/ui/ui_process.rs
@@ -185,6 +185,13 @@ impl UiProcess {
         inner.repaint();
     }
 
+    #[allow(dead_code)] // Only used on native (animation config load).
+    pub fn set_model_local_to_world(&self, transform: Affine3A) {
+        let mut inner = self.write();
+        inner.controls.model_local_to_world = transform;
+        inner.repaint();
+    }
+
     /// Connect to an existing running process.
     pub fn connect_to_process(&self, process: RunningProcess) {
         {

--- a/apps/brush-app/src/ui/ui_process.rs
+++ b/apps/brush-app/src/ui/ui_process.rs
@@ -190,6 +190,14 @@ impl UiProcess {
         self.read().up_axis
     }
 
+    /// Only the native animation panel drives this (on config load).
+    #[cfg(not(target_family = "wasm"))]
+    pub fn set_model_local_to_world(&self, transform: Affine3A) {
+        let mut inner = self.write();
+        inner.controls.model_local_to_world = transform;
+        inner.repaint();
+    }
+
     /// Connect to an existing running process.
     pub fn connect_to_process(&self, process: RunningProcess) {
         {

--- a/apps/brush-cli/Cargo.toml
+++ b/apps/brush-cli/Cargo.toml
@@ -13,6 +13,11 @@ path = "src/main.rs"
 [dependencies]
 brush-async.path = "../../crates/brush-async"
 brush-process.path = "../../crates/brush-process"
+brush-anim.path = "../../crates/brush-anim"
+brush-render.path = "../../crates/brush-render"
+brush-serde.path = "../../crates/brush-serde"
+
+burn.workspace = true
 
 indicatif.workspace = true
 indicatif-log-bridge = "0.2"

--- a/apps/brush-cli/src/lib.rs
+++ b/apps/brush-cli/src/lib.rs
@@ -12,6 +12,7 @@ use brush_process::message::TrainMessage;
 use clap::{Error, Parser, builder::ArgPredicate, error::ErrorKind};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use indicatif_log_bridge::LogWrapper;
+use std::path::PathBuf;
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio_stream::StreamExt;
@@ -22,6 +23,7 @@ use tracing::trace_span;
     author,
     version,
     arg_required_else_help = false,
+    next_line_help = true,
     about = "Brush - universal splats"
 )]
 pub struct Cli {
@@ -38,11 +40,50 @@ pub struct Cli {
     pub with_viewer: bool,
 
     #[clap(flatten)]
+    pub animation: AnimationArgs,
+
+    #[clap(flatten)]
     pub train_stream: TrainStreamConfig,
+}
+
+/// Options for rendering an animation (instead of training). The positional
+/// `PATH_OR_URL` is reused as the splat source: a single `.ply`, or a folder of
+/// `.ply` files (one video is rendered per file).
+#[derive(clap::Args, Clone)]
+#[command(next_help_heading = "Animation")]
+pub struct AnimationArgs {
+    /// Render an animation instead of training: path to an animation config
+    /// (JSON) saved from the viewer's "Save…" button.
+    #[arg(long, value_name = "ANIM_CONFIG")]
+    pub render_anim: Option<PathBuf>,
+
+    /// Output for the rendered animation. For a single ply, this is the MP4
+    /// path. For a folder source, set this to a directory to collect the videos
+    /// there (named after each ply); otherwise each video is written next to
+    /// its ply.
+    #[arg(long, value_name = "OUT", default_value = "animation.mp4")]
+    pub anim_out: PathBuf,
+
+    /// Output width for the rendered animation.
+    #[arg(long, default_value_t = 1920)]
+    pub anim_width: u32,
+
+    /// Output height for the rendered animation.
+    #[arg(long, default_value_t = 1080)]
+    pub anim_height: u32,
 }
 
 impl Cli {
     pub fn validate(self) -> Result<Self, Error> {
+        if self.animation.render_anim.is_some() {
+            if self.source.is_none() {
+                return Err(Error::raw(
+                    ErrorKind::MissingRequiredArgument,
+                    "--render-anim requires a PATH_OR_URL source (a .ply file or a folder of plys)",
+                ));
+            }
+            return Ok(self);
+        }
         if !self.with_viewer && self.source.is_none() {
             return Err(Error::raw(
                 ErrorKind::MissingRequiredArgument,
@@ -61,6 +102,138 @@ pub fn build_process(args: &Cli) -> Option<RunningProcess> {
     Some(create_process(source, async move |init| {
         Some(brush_process::args_file::merge_configs(&init, &cli_config))
     }))
+}
+
+/// Render an animation headlessly from the `--render-anim` config. The
+/// positional source is a single `.ply` (written to `--anim-out`) or a folder
+/// of plys (one video each, into `--anim-out` when it is a directory, otherwise
+/// next to each ply).
+pub async fn run_render_animation(args: &Cli) -> Result<(), anyhow::Error> {
+    use anyhow::Context;
+
+    let config_path = args
+        .animation
+        .render_anim
+        .as_ref()
+        .expect("render_anim must be set in render mode");
+
+    // The positional source is reused as the splat path; only local paths work.
+    let source = args.source.as_ref().expect("validate guarantees a source");
+    let DataSource::Path(source_path) = source else {
+        anyhow::bail!("--render-anim needs a local .ply file or folder, not {source}");
+    };
+    let source_path = std::path::PathBuf::from(source_path);
+
+    let config_str = tokio::fs::read_to_string(config_path)
+        .await
+        .with_context(|| format!("reading {}", config_path.display()))?;
+    let mut config =
+        brush_anim::AnimationConfig::from_json(&config_str).context("parsing animation config")?;
+    // The viewer keeps this invariant live; a hand-edited config might not, and
+    // a too-short timeline underflows the wrap math in `pose_at_frame`.
+    config.num_frames = config.num_frames.max(config.min_frames());
+
+    let device: burn::tensor::Device = brush_process::burn_init_setup().await.into();
+
+    let (width, height) = (args.animation.anim_width, args.animation.anim_height);
+    // Cameras only depend on the config + resolution, so build them once.
+    let cameras = config.render_cameras(width, height);
+
+    // Build the (ply, output) work list.
+    let jobs: Vec<(std::path::PathBuf, std::path::PathBuf)> = if source_path.is_dir() {
+        let mut plys: Vec<std::path::PathBuf> = std::fs::read_dir(&source_path)
+            .with_context(|| format!("reading directory {}", source_path.display()))?
+            .filter_map(Result::ok)
+            .map(|e| e.path())
+            .filter(|p| p.extension().is_some_and(|e| e.eq_ignore_ascii_case("ply")))
+            .collect();
+        plys.sort();
+        if plys.is_empty() {
+            anyhow::bail!("no .ply files found in {}", source_path.display());
+        }
+
+        // An `--anim-out` that is (or looks like) a directory collects the
+        // videos there; otherwise each video is written next to its ply.
+        let out = &args.animation.anim_out;
+        let out_dir = if out.is_dir() || out.extension().is_none() {
+            std::fs::create_dir_all(out)
+                .with_context(|| format!("creating output directory {}", out.display()))?;
+            Some(out.clone())
+        } else {
+            None
+        };
+
+        plys.into_iter()
+            .map(|ply| {
+                let mp4 = ply.with_extension("mp4");
+                let out = match &out_dir {
+                    Some(dir) => dir.join(mp4.file_name().expect("ply has a file name")),
+                    None => mp4,
+                };
+                (ply, out)
+            })
+            .collect()
+    } else {
+        vec![(source_path.clone(), args.animation.anim_out.clone())]
+    };
+
+    for (ply, out) in jobs {
+        render_one(&device, &config, &cameras, &ply, &out, width, height)
+            .await
+            .with_context(|| format!("rendering {}", ply.display()))?;
+    }
+    Ok(())
+}
+
+/// Renders a single ply to `out` using already-built `cameras`.
+async fn render_one(
+    device: &burn::tensor::Device,
+    config: &brush_anim::AnimationConfig,
+    cameras: &[brush_render::camera::Camera],
+    ply: &std::path::Path,
+    out: &std::path::Path,
+    width: u32,
+    height: u32,
+) -> Result<(), anyhow::Error> {
+    use anyhow::Context;
+    use brush_render::gaussian_splats::SplatRenderMode;
+
+    let ply_bytes = tokio::fs::read(ply)
+        .await
+        .with_context(|| format!("reading {}", ply.display()))?;
+    let message = brush_serde::load_splat_from_ply(std::io::Cursor::new(ply_bytes), None)
+        .await
+        .context("loading splat from ply")?;
+    let mode = message.meta.render_mode.unwrap_or(SplatRenderMode::Default);
+    let splats = message.data.into_splats(device, mode);
+
+    let bar = ProgressBar::new(cameras.len() as u64)
+        .with_style(
+            ProgressStyle::with_template("[{elapsed}] {bar:40.cyan/blue} {pos}/{len} {msg}")
+                .expect("Invalid indicatif config")
+                .progress_chars("◍○○"),
+        )
+        .with_message(format!(
+            "frames → {}",
+            out.file_name().unwrap_or_default().to_string_lossy()
+        ));
+
+    brush_anim::render_to_mp4(
+        splats,
+        cameras.to_vec(),
+        config.fps,
+        config.background,
+        config.splat_scale,
+        width,
+        height,
+        out,
+        |done, _total| bar.set_position(done as u64),
+    )
+    .await?;
+
+    bar.finish_and_clear();
+    log::info!("Wrote animation to {}", out.display());
+    Ok(())
 }
 
 /// Initialize the backend, then drive `process` to completion on the CLI UI.

--- a/apps/brush-cli/src/lib.rs
+++ b/apps/brush-cli/src/lib.rs
@@ -12,6 +12,7 @@ use brush_process::message::TrainMessage;
 use clap::{Error, Parser, builder::ArgPredicate, error::ErrorKind};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use indicatif_log_bridge::LogWrapper;
+use std::path::PathBuf;
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio_stream::StreamExt;
@@ -22,6 +23,7 @@ use tracing::trace_span;
     author,
     version,
     arg_required_else_help = false,
+    next_line_help = true,
     about = "Brush - universal splats"
 )]
 pub struct Cli {
@@ -38,11 +40,50 @@ pub struct Cli {
     pub with_viewer: bool,
 
     #[clap(flatten)]
+    pub animation: AnimationArgs,
+
+    #[clap(flatten)]
     pub train_stream: TrainStreamConfig,
+}
+
+/// Options for rendering an animation (instead of training). The positional
+/// `PATH_OR_URL` is reused as the splat source: a single `.ply`, or a folder of
+/// `.ply` files (one video is rendered per file).
+#[derive(clap::Args, Clone)]
+#[command(next_help_heading = "Animation")]
+pub struct AnimationArgs {
+    /// Render an animation instead of training: path to an animation config
+    /// (JSON) saved from the viewer's "Save…" button.
+    #[arg(long, value_name = "ANIM_CONFIG")]
+    pub render_anim: Option<PathBuf>,
+
+    /// Output for the rendered animation. For a single ply, this is the MP4
+    /// path. For a folder source, set this to a directory to collect the videos
+    /// there (named after each ply); otherwise each video is written next to
+    /// its ply.
+    #[arg(long, value_name = "OUT", default_value = "animation.mp4")]
+    pub anim_out: PathBuf,
+
+    /// Output width for the rendered animation.
+    #[arg(long, default_value_t = 1920)]
+    pub anim_width: u32,
+
+    /// Output height for the rendered animation.
+    #[arg(long, default_value_t = 1080)]
+    pub anim_height: u32,
 }
 
 impl Cli {
     pub fn validate(self) -> Result<Self, Error> {
+        if self.animation.render_anim.is_some() {
+            if self.source.is_none() {
+                return Err(Error::raw(
+                    ErrorKind::MissingRequiredArgument,
+                    "--render-anim requires a PATH_OR_URL source (a .ply file or a folder of plys)",
+                ));
+            }
+            return Ok(self);
+        }
         if !self.with_viewer && self.source.is_none() {
             return Err(Error::raw(
                 ErrorKind::MissingRequiredArgument,
@@ -61,6 +102,138 @@ pub fn build_process(args: &Cli) -> Option<RunningProcess> {
     Some(create_process(source, async move |init| {
         Some(brush_process::args_file::merge_configs(&init, &cli_config))
     }))
+}
+
+/// Render an animation headlessly from the `--render-anim` config. The
+/// positional source is a single `.ply` (written to `--anim-out`) or a folder
+/// of plys (one video each, into `--anim-out` when it is a directory, otherwise
+/// next to each ply).
+pub async fn run_render_animation(args: &Cli) -> Result<(), anyhow::Error> {
+    use anyhow::Context;
+
+    let config_path = args
+        .animation
+        .render_anim
+        .as_ref()
+        .expect("render_anim must be set in render mode");
+
+    // The positional source is reused as the splat path; only local paths work.
+    let source = args.source.as_ref().expect("validate guarantees a source");
+    let DataSource::Path(source_path) = source else {
+        anyhow::bail!("--render-anim needs a local .ply file or folder, not {source}");
+    };
+    let source_path = std::path::PathBuf::from(source_path);
+
+    let config_str = tokio::fs::read_to_string(config_path)
+        .await
+        .with_context(|| format!("reading {}", config_path.display()))?;
+    let mut config =
+        brush_anim::AnimationConfig::from_json(&config_str).context("parsing animation config")?;
+    // The viewer keeps this invariant live; a hand-edited config might not, and
+    // a too-short timeline underflows the wrap math in `pose_at_frame`.
+    config.num_frames = config.num_frames.max(config.min_frames());
+
+    let (width, height) = (args.animation.anim_width, args.animation.anim_height);
+    // Cameras and encoder settings only depend on the config + resolution, so
+    // build them once and reuse them for every ply.
+    let cameras = config.render_cameras(width, height);
+    let settings = config.video_settings(width, height);
+
+    // Build the (ply, output) work list.
+    let jobs: Vec<(std::path::PathBuf, std::path::PathBuf)> = if source_path.is_dir() {
+        let mut plys: Vec<std::path::PathBuf> = std::fs::read_dir(&source_path)
+            .with_context(|| format!("reading directory {}", source_path.display()))?
+            .filter_map(Result::ok)
+            .map(|e| e.path())
+            .filter(|p| p.extension().is_some_and(|e| e.eq_ignore_ascii_case("ply")))
+            .collect();
+        plys.sort();
+        if plys.is_empty() {
+            anyhow::bail!("no .ply files found in {}", source_path.display());
+        }
+
+        // An `--anim-out` that is (or looks like) a directory collects the
+        // videos there; otherwise each video is written next to its ply.
+        let out = &args.animation.anim_out;
+        let out_dir = if out.is_dir() || out.extension().is_none() {
+            std::fs::create_dir_all(out)
+                .with_context(|| format!("creating output directory {}", out.display()))?;
+            Some(out.clone())
+        } else {
+            None
+        };
+
+        plys.into_iter()
+            .map(|ply| {
+                let mp4 = ply.with_extension("mp4");
+                let out = match &out_dir {
+                    Some(dir) => dir.join(mp4.file_name().expect("ply has a file name")),
+                    None => mp4,
+                };
+                (ply, out)
+            })
+            .collect()
+    } else {
+        vec![(source_path.clone(), args.animation.anim_out.clone())]
+    };
+
+    let device: burn::tensor::Device = brush_process::burn_init_setup().await.into();
+
+    // Pin the render loop to a single thread. Brush's GPU layer keys ordering
+    // on `StreamId::current()` (thread-local), and each frame issues GPU work
+    // across several awaits — on the multi-thread runtime those would land on
+    // different threads. Same reason the trainer stream runs on an [`Actor`].
+    Actor::new("cli-anim-render")
+        .run(move || async move {
+            for (ply, out) in jobs {
+                render_one(&device, &cameras, &settings, &ply, &out)
+                    .await
+                    .with_context(|| format!("rendering {}", ply.display()))?;
+            }
+            Ok(())
+        })
+        .await
+}
+
+/// Renders a single ply to `out` using already-built `cameras`.
+async fn render_one(
+    device: &burn::tensor::Device,
+    cameras: &[brush_render::camera::Camera],
+    settings: &brush_anim::VideoSettings,
+    ply: &std::path::Path,
+    out: &std::path::Path,
+) -> Result<(), anyhow::Error> {
+    use anyhow::Context;
+    use brush_render::gaussian_splats::SplatRenderMode;
+
+    let ply_bytes = tokio::fs::read(ply)
+        .await
+        .with_context(|| format!("reading {}", ply.display()))?;
+    let message = brush_serde::load_splat_from_ply(std::io::Cursor::new(ply_bytes), None)
+        .await
+        .context("loading splat from ply")?;
+    let mode = message.meta.render_mode.unwrap_or(SplatRenderMode::Default);
+    let splats = message.data.into_splats(device, mode);
+
+    let bar = ProgressBar::new(cameras.len() as u64)
+        .with_style(
+            ProgressStyle::with_template("[{elapsed}] {bar:40.cyan/blue} {pos}/{len} {msg}")
+                .expect("Invalid indicatif config")
+                .progress_chars("◍○○"),
+        )
+        .with_message(format!(
+            "frames → {}",
+            out.file_name().unwrap_or_default().to_string_lossy()
+        ));
+
+    brush_anim::render_to_mp4(splats, cameras, settings, out, |done, _total| {
+        bar.set_position(done as u64);
+    })
+    .await?;
+
+    bar.finish_and_clear();
+    log::info!("Wrote animation to {}", out.display());
+    Ok(())
 }
 
 /// Initialize the backend, then drive `process` to completion on the CLI UI.
@@ -297,6 +470,7 @@ pub async fn run_cli_ui(
 mod tests {
     use super::*;
     use clap::Parser;
+    use std::path::Path;
 
     #[test]
     fn parses_source_and_overrides() {
@@ -374,5 +548,54 @@ mod tests {
     #[test]
     fn rejects_unknown_flag() {
         assert!(Cli::try_parse_from(["brush-cli", "--not-a-real-flag"]).is_err());
+    }
+
+    #[test]
+    fn parses_animation_args() {
+        let cli = Cli::try_parse_from([
+            "brush-cli",
+            "splats/",
+            "--render-anim",
+            "anim.json",
+            "--anim-out",
+            "out/",
+            "--anim-width",
+            "1280",
+            "--anim-height",
+            "720",
+        ])
+        .unwrap();
+
+        let anim = &cli.animation;
+        assert_eq!(anim.render_anim.as_deref(), Some(Path::new("anim.json")));
+        assert_eq!(anim.anim_out, Path::new("out/"));
+        assert_eq!((anim.anim_width, anim.anim_height), (1280, 720));
+        // Rendering is headless, and a source doubles as the splat path.
+        assert!(!cli.with_viewer);
+        assert!(cli.validate().is_ok());
+    }
+
+    #[test]
+    fn animation_defaults_to_full_hd_mp4() {
+        let cli = Cli::try_parse_from(["brush-cli", "splat.ply", "--render-anim", "anim.json"])
+            .unwrap()
+            .validate()
+            .unwrap();
+
+        let anim = &cli.animation;
+        assert_eq!(anim.anim_out, Path::new("animation.mp4"));
+        assert_eq!((anim.anim_width, anim.anim_height), (1920, 1080));
+    }
+
+    #[test]
+    fn validate_rejects_render_anim_without_source() {
+        // The positional source is the splat to render; there's nothing to
+        // render without it.
+        let cli = Cli::try_parse_from(["brush-cli", "--render-anim", "anim.json"]).unwrap();
+        assert!(cli.source.is_none());
+        let Err(err) = cli.validate() else {
+            panic!("expected validation error")
+        };
+        assert_eq!(err.kind(), ErrorKind::MissingRequiredArgument);
     }
 }

--- a/apps/brush-cli/src/main.rs
+++ b/apps/brush-cli/src/main.rs
@@ -4,10 +4,19 @@
 // this is a lean build of just the training path for quick CLI iteration.
 #[cfg(not(target_family = "wasm"))]
 fn main() -> anyhow::Result<()> {
-    use brush_cli::{Cli, build_process, run_headless};
+    use brush_cli::{Cli, build_process, run_headless, run_render_animation};
     use clap::Parser;
 
     let args = Cli::parse().validate()?;
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("Failed to initialize tokio runtime");
+
+    if args.animation.render_anim.is_some() {
+        return runtime.block_on(run_render_animation(&args));
+    }
 
     if args.with_viewer {
         anyhow::bail!(
@@ -19,11 +28,7 @@ fn main() -> anyhow::Result<()> {
     // `validate` guarantees a source is present when the viewer is off.
     let process = build_process(&args).expect("source must be present");
 
-    tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()
-        .expect("Failed to initialize tokio runtime")
-        .block_on(run_headless(process, args.train_stream))
+    runtime.block_on(run_headless(process, args.train_stream))
 }
 
 #[cfg(target_family = "wasm")]

--- a/crates/brush-anim/Cargo.toml
+++ b/crates/brush-anim/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "brush-anim"
+edition.workspace = true
+version.workspace = true
+readme.workspace = true
+license.workspace = true
+
+# Shared animation model: keyframe config + interpolation (all platforms) and
+# the native render/encode pipeline used by the viewer export and the CLI.
+
+[dependencies]
+brush-render.path = "../brush-render"
+
+glam = { workspace = true, features = ["serde"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+anyhow.workspace = true
+
+# Native-only: rendering frames + encoding to MP4 with ffmpeg.
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+burn.workspace = true
+# `download_ffmpeg` is off: it pulls xz2/lzma-sys which conflicts with
+# liblzma-sys already in the tree, so we use ffmpeg from PATH.
+ffmpeg-sidecar = { version = "2", default-features = false }
+
+[lints]
+workspace = true

--- a/crates/brush-anim/src/config.rs
+++ b/crates/brush-anim/src/config.rs
@@ -1,0 +1,245 @@
+use brush_render::camera::{Camera, focal_to_fov, fov_to_focal};
+use brush_render::kernels::camera_model::CameraModel;
+use glam::{Affine3A, Quat, Vec2, Vec3};
+use serde::{Deserialize, Serialize};
+
+/// How camera poses are interpolated between keyframes.
+#[derive(Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Interpolation {
+    Linear,
+    Smoothstep,
+    #[default]
+    CatmullRom,
+}
+
+impl Interpolation {
+    pub const ALL: [Self; 3] = [Self::Linear, Self::Smoothstep, Self::CatmullRom];
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Linear => "Linear",
+            Self::Smoothstep => "Smoothstep",
+            Self::CatmullRom => "Catmull-Rom",
+        }
+    }
+}
+
+/// A camera pose pinned to a frame on the timeline.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct Keyframe {
+    pub frame: usize,
+    pub position: Vec3,
+    pub rotation: Quat,
+}
+
+/// A complete, serializable animation: the timeline, the keyframe poses, and
+/// the viewer state (FOV, model transform, background) needed to reproduce the
+/// rendered view outside the app.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct AnimationConfig {
+    pub num_frames: usize,
+    pub fps: usize,
+    pub interpolation: Interpolation,
+    pub keyframes: Vec<Keyframe>,
+
+    /// Field of view captured from the viewer camera.
+    pub fov_x: f64,
+    pub fov_y: f64,
+    pub center_uv: Vec2,
+    /// Splat model-to-world transform from the viewer.
+    pub model_local_to_world: Affine3A,
+    /// Background color and splat scale from the viewer.
+    pub background: Vec3,
+    pub splat_scale: Option<f32>,
+}
+
+impl Default for AnimationConfig {
+    fn default() -> Self {
+        Self {
+            num_frames: 120,
+            fps: 30,
+            interpolation: Interpolation::default(),
+            keyframes: Vec::new(),
+            fov_x: 0.8,
+            fov_y: 0.8,
+            center_uv: Vec2::splat(0.5),
+            model_local_to_world: Affine3A::IDENTITY,
+            background: Vec3::ZERO,
+            splat_scale: None,
+        }
+    }
+}
+
+impl AnimationConfig {
+    pub fn to_json(&self) -> serde_json::Result<String> {
+        serde_json::to_string_pretty(self)
+    }
+
+    pub fn from_json(json: &str) -> serde_json::Result<Self> {
+        serde_json::from_str(json)
+    }
+
+    /// Smallest frame count that still fits every keyframe.
+    pub fn min_frames(&self) -> usize {
+        self.keyframes
+            .iter()
+            .map(|k| k.frame)
+            .max()
+            .map_or(1, |f| f + 1)
+    }
+
+    /// Insert a keyframe at `frame`, replacing any existing keyframe there.
+    pub fn set_keyframe(&mut self, frame: usize, position: Vec3, rotation: Quat) {
+        if let Some(existing) = self.keyframes.iter_mut().find(|k| k.frame == frame) {
+            existing.position = position;
+            existing.rotation = rotation;
+        } else {
+            self.keyframes.push(Keyframe {
+                frame,
+                position,
+                rotation,
+            });
+        }
+    }
+
+    /// The interpolated camera pose at `frame`, using the selected method. The
+    /// keyframes form a closed loop, so frames wrap smoothly from the last
+    /// keyframe back to the first. Returns `None` if there are no keyframes.
+    pub fn pose_at_frame(&self, frame: usize) -> Option<(Vec3, Quat)> {
+        let mut kfs: Vec<&Keyframe> = self.keyframes.iter().collect();
+        kfs.sort_by_key(|k| k.frame);
+        let n = kfs.len();
+        if n == 0 {
+            return None;
+        }
+        if n == 1 {
+            return Some((kfs[0].position, kfs[0].rotation));
+        }
+
+        // Segment `s` runs from kfs[s] to kfs[(s + 1) % n]; `t` is the position
+        // within it. Segment n-1 is the wrap from the last keyframe to the first.
+        let (s, t) = self.segment_at(&kfs, frame);
+        let p1 = kfs[s];
+        let p2 = kfs[(s + 1) % n];
+
+        let pose = match self.interpolation {
+            Interpolation::Linear => (
+                p1.position.lerp(p2.position, t),
+                p1.rotation.slerp(p2.rotation, t),
+            ),
+            Interpolation::Smoothstep => {
+                let t = t * t * (3.0 - 2.0 * t);
+                (
+                    p1.position.lerp(p2.position, t),
+                    p1.rotation.slerp(p2.rotation, t),
+                )
+            }
+            Interpolation::CatmullRom => {
+                let p0 = kfs[(s + n - 1) % n];
+                let p3 = kfs[(s + 2) % n];
+                (
+                    catmull_rom(p0.position, p1.position, p2.position, p3.position, t),
+                    catmull_rom_quat(p0.rotation, p1.rotation, p2.rotation, p3.rotation, t),
+                )
+            }
+        };
+        Some(pose)
+    }
+
+    /// Finds the loop segment containing `frame` and the `t` within it, given
+    /// keyframes sorted by frame.
+    fn segment_at(&self, kfs: &[&Keyframe], frame: usize) -> (usize, f32) {
+        let n = kfs.len();
+        let first = kfs[0].frame;
+        let last = kfs[n - 1].frame;
+
+        if (first..last).contains(&frame) {
+            let s = (0..n - 1)
+                .find(|&s| frame < kfs[s + 1].frame)
+                .expect("frame < last");
+            let t = (frame - kfs[s].frame) as f32 / (kfs[s + 1].frame - kfs[s].frame) as f32;
+            (s, t)
+        } else {
+            let wrap_len = self.num_frames - (last - first);
+            let steps = (frame + self.num_frames - last) % self.num_frames;
+            (n - 1, steps as f32 / wrap_len as f32)
+        }
+    }
+
+    /// Builds one render camera per frame: the stored viewer camera (FOV, model
+    /// transform) with the interpolated keyframe pose, fitting the FOV to the
+    /// target resolution exactly like the scene view does.
+    pub fn render_cameras(&self, width: u32, height: u32) -> Vec<Camera> {
+        let template = Camera::new(
+            Vec3::ZERO,
+            Quat::IDENTITY,
+            self.fov_x,
+            self.fov_y,
+            self.center_uv,
+            CameraModel::Pinhole,
+        );
+
+        (0..self.num_frames)
+            .map(|frame| {
+                let mut camera = template;
+                if let Some((position, rotation)) = self.pose_at_frame(frame) {
+                    camera.position = position;
+                    camera.rotation = rotation;
+                }
+
+                // Fold in the model transform, exactly like the scene view.
+                let view_eff = (camera.world_to_local() * self.model_local_to_world).inverse();
+                let (_, rotation, position) = view_eff.to_scale_rotation_translation();
+                camera.position = position;
+                camera.rotation = rotation;
+
+                // Fit the FOV to the target aspect ratio (same logic as the scene).
+                let camera_aspect = fov_to_focal(camera.fov_y, 2, &camera.camera_model)
+                    / fov_to_focal(camera.fov_x, 2, &camera.camera_model);
+                let viewport_aspect = width as f64 / height as f64;
+                if viewport_aspect > camera_aspect {
+                    let focal_y = fov_to_focal(camera.fov_y, height, &camera.camera_model);
+                    camera.fov_x = focal_to_fov(focal_y, width, &camera.camera_model);
+                } else {
+                    let focal_x = fov_to_focal(camera.fov_x, width, &camera.camera_model);
+                    camera.fov_y = focal_to_fov(focal_x, height, &camera.camera_model);
+                }
+                camera
+            })
+            .collect()
+    }
+}
+
+/// Catmull-Rom spline through `p1` and `p2`, using `p0`/`p3` to derive tangents.
+fn catmull_rom<V>(p0: V, p1: V, p2: V, p3: V, t: f32) -> V
+where
+    V: Copy
+        + std::ops::Add<Output = V>
+        + std::ops::Sub<Output = V>
+        + std::ops::Mul<f32, Output = V>,
+{
+    let t2 = t * t;
+    let t3 = t2 * t;
+    (p1 * 2.0
+        + (p2 - p0) * t
+        + (p0 * 2.0 - p1 * 5.0 + p2 * 4.0 - p3) * t2
+        + (p1 * 3.0 - p0 - p2 * 3.0 + p3) * t3)
+        * 0.5
+}
+
+/// Catmull-Rom for rotations: aligns the quaternions to one hemisphere (so the
+/// spline takes the short way), interpolates component-wise, then renormalizes.
+fn catmull_rom_quat(q0: Quat, q1: Quat, q2: Quat, q3: Quat, t: f32) -> Quat {
+    let q0 = if q1.dot(q0) < 0.0 { -q0 } else { q0 };
+    let q2 = if q1.dot(q2) < 0.0 { -q2 } else { q2 };
+    let q3 = if q2.dot(q3) < 0.0 { -q3 } else { q3 };
+    let blended = catmull_rom(
+        glam::Vec4::from(q0.to_array()),
+        glam::Vec4::from(q1.to_array()),
+        glam::Vec4::from(q2.to_array()),
+        glam::Vec4::from(q3.to_array()),
+        t,
+    );
+    Quat::from_vec4(blended).normalize()
+}

--- a/crates/brush-anim/src/config.rs
+++ b/crates/brush-anim/src/config.rs
@@ -1,0 +1,258 @@
+use brush_render::camera::Camera;
+use brush_render::kernels::camera_model::CameraModel;
+use glam::{Affine3A, Quat, Vec2, Vec3};
+use serde::{Deserialize, Serialize};
+
+/// How camera poses are interpolated between keyframes.
+#[derive(Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Interpolation {
+    Linear,
+    Smoothstep,
+    #[default]
+    CatmullRom,
+}
+
+impl Interpolation {
+    pub const ALL: [Self; 3] = [Self::Linear, Self::Smoothstep, Self::CatmullRom];
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Linear => "Linear",
+            Self::Smoothstep => "Smoothstep",
+            Self::CatmullRom => "Catmull-Rom",
+        }
+    }
+}
+
+/// A camera pose pinned to a frame on the timeline.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct Keyframe {
+    pub frame: usize,
+    pub position: Vec3,
+    pub rotation: Quat,
+}
+
+/// Everything the encoder needs beyond the splats and the per-frame cameras:
+/// output resolution plus the scene knobs each frame is rendered with.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct VideoSettings {
+    pub width: u32,
+    pub height: u32,
+    pub fps: usize,
+    pub background: Vec3,
+    pub splat_scale: Option<f32>,
+}
+
+/// A complete, serializable animation: the timeline, the keyframe poses, and
+/// the viewer state (FOV, model transform, background) needed to reproduce the
+/// rendered view outside the app.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct AnimationConfig {
+    pub num_frames: usize,
+    pub fps: usize,
+    pub interpolation: Interpolation,
+    pub keyframes: Vec<Keyframe>,
+
+    /// Field of view captured from the viewer camera.
+    pub fov_x: f64,
+    pub fov_y: f64,
+    pub center_uv: Vec2,
+    /// Splat model-to-world transform from the viewer.
+    pub model_local_to_world: Affine3A,
+    /// Background color and splat scale from the viewer.
+    pub background: Vec3,
+    pub splat_scale: Option<f32>,
+}
+
+impl Default for AnimationConfig {
+    fn default() -> Self {
+        Self {
+            num_frames: 120,
+            fps: 30,
+            interpolation: Interpolation::default(),
+            keyframes: Vec::new(),
+            fov_x: 0.8,
+            fov_y: 0.8,
+            center_uv: Vec2::splat(0.5),
+            model_local_to_world: Affine3A::IDENTITY,
+            background: Vec3::ZERO,
+            splat_scale: None,
+        }
+    }
+}
+
+impl AnimationConfig {
+    pub fn to_json(&self) -> serde_json::Result<String> {
+        serde_json::to_string_pretty(self)
+    }
+
+    pub fn from_json(json: &str) -> serde_json::Result<Self> {
+        serde_json::from_str(json)
+    }
+
+    /// The encoder settings for this animation at `width` x `height`.
+    pub fn video_settings(&self, width: u32, height: u32) -> VideoSettings {
+        VideoSettings {
+            width,
+            height,
+            fps: self.fps,
+            background: self.background,
+            splat_scale: self.splat_scale,
+        }
+    }
+
+    /// Smallest frame count that still fits every keyframe.
+    pub fn min_frames(&self) -> usize {
+        self.keyframes
+            .iter()
+            .map(|k| k.frame)
+            .max()
+            .map_or(1, |f| f + 1)
+    }
+
+    /// Insert a keyframe at `frame`, replacing any existing keyframe there.
+    pub fn set_keyframe(&mut self, frame: usize, position: Vec3, rotation: Quat) {
+        if let Some(existing) = self.keyframes.iter_mut().find(|k| k.frame == frame) {
+            existing.position = position;
+            existing.rotation = rotation;
+        } else {
+            self.keyframes.push(Keyframe {
+                frame,
+                position,
+                rotation,
+            });
+        }
+    }
+
+    /// The interpolated camera pose at `frame`, using the selected method. The
+    /// keyframes form a closed loop, so frames wrap smoothly from the last
+    /// keyframe back to the first. Returns `None` if there are no keyframes.
+    pub fn pose_at_frame(&self, frame: usize) -> Option<(Vec3, Quat)> {
+        let mut kfs: Vec<&Keyframe> = self.keyframes.iter().collect();
+        kfs.sort_by_key(|k| k.frame);
+        let n = kfs.len();
+        if n == 0 {
+            return None;
+        }
+        if n == 1 {
+            return Some((kfs[0].position, kfs[0].rotation));
+        }
+
+        // Segment `s` runs from kfs[s] to kfs[(s + 1) % n]; `t` is the position
+        // within it. Segment n-1 is the wrap from the last keyframe to the first.
+        let (s, t) = self.segment_at(&kfs, frame);
+        let p1 = kfs[s];
+        let p2 = kfs[(s + 1) % n];
+
+        let pose = match self.interpolation {
+            Interpolation::Linear => (
+                p1.position.lerp(p2.position, t),
+                p1.rotation.slerp(p2.rotation, t),
+            ),
+            Interpolation::Smoothstep => {
+                let t = t * t * (3.0 - 2.0 * t);
+                (
+                    p1.position.lerp(p2.position, t),
+                    p1.rotation.slerp(p2.rotation, t),
+                )
+            }
+            Interpolation::CatmullRom => {
+                let p0 = kfs[(s + n - 1) % n];
+                let p3 = kfs[(s + 2) % n];
+                (
+                    catmull_rom(p0.position, p1.position, p2.position, p3.position, t),
+                    catmull_rom_quat(p0.rotation, p1.rotation, p2.rotation, p3.rotation, t),
+                )
+            }
+        };
+        Some(pose)
+    }
+
+    /// Finds the loop segment containing `frame` and the `t` within it, given
+    /// keyframes sorted by frame.
+    fn segment_at(&self, kfs: &[&Keyframe], frame: usize) -> (usize, f32) {
+        let n = kfs.len();
+        let first = kfs[0].frame;
+        let last = kfs[n - 1].frame;
+
+        if (first..last).contains(&frame) {
+            let s = (0..n - 1)
+                .find(|&s| frame < kfs[s + 1].frame)
+                .expect("frame < last");
+            let t = (frame - kfs[s].frame) as f32 / (kfs[s + 1].frame - kfs[s].frame) as f32;
+            (s, t)
+        } else {
+            let wrap_len = self.num_frames - (last - first);
+            let steps = (frame + self.num_frames - last) % self.num_frames;
+            (n - 1, steps as f32 / wrap_len as f32)
+        }
+    }
+
+    /// Builds one render camera per frame: the stored viewer camera (FOV, model
+    /// transform) with the interpolated keyframe pose, fitting the FOV to the
+    /// target resolution exactly like the scene view does.
+    pub fn render_cameras(&self, width: u32, height: u32) -> Vec<Camera> {
+        let template = Camera::new(
+            Vec3::ZERO,
+            Quat::IDENTITY,
+            self.fov_x,
+            self.fov_y,
+            self.center_uv,
+            CameraModel::Pinhole,
+        );
+
+        (0..self.num_frames)
+            .map(|frame| {
+                let mut camera = template;
+                if let Some((position, rotation)) = self.pose_at_frame(frame) {
+                    camera.position = position;
+                    camera.rotation = rotation;
+                }
+
+                // Fold in the model transform, exactly like the scene view.
+                let view_eff = (camera.world_to_local() * self.model_local_to_world).inverse();
+                let (_, rotation, position) = view_eff.to_scale_rotation_translation();
+                camera.position = position;
+                camera.rotation = rotation;
+
+                // Fit the FOV to the target resolution, exactly like the scene view.
+                camera.fit_fov_to_size(glam::uvec2(width, height));
+                camera
+            })
+            .collect()
+    }
+}
+
+/// Catmull-Rom spline through `p1` and `p2`, using `p0`/`p3` to derive tangents.
+fn catmull_rom<V>(p0: V, p1: V, p2: V, p3: V, t: f32) -> V
+where
+    V: Copy
+        + std::ops::Add<Output = V>
+        + std::ops::Sub<Output = V>
+        + std::ops::Mul<f32, Output = V>,
+{
+    let t2 = t * t;
+    let t3 = t2 * t;
+    (p1 * 2.0
+        + (p2 - p0) * t
+        + (p0 * 2.0 - p1 * 5.0 + p2 * 4.0 - p3) * t2
+        + (p1 * 3.0 - p0 - p2 * 3.0 + p3) * t3)
+        * 0.5
+}
+
+/// Catmull-Rom for rotations: aligns the quaternions to one hemisphere (so the
+/// spline takes the short way), interpolates component-wise, then renormalizes.
+fn catmull_rom_quat(q0: Quat, q1: Quat, q2: Quat, q3: Quat, t: f32) -> Quat {
+    let q0 = if q1.dot(q0) < 0.0 { -q0 } else { q0 };
+    let q2 = if q1.dot(q2) < 0.0 { -q2 } else { q2 };
+    let q3 = if q2.dot(q3) < 0.0 { -q3 } else { q3 };
+    let blended = catmull_rom(
+        glam::Vec4::from(q0.to_array()),
+        glam::Vec4::from(q1.to_array()),
+        glam::Vec4::from(q2.to_array()),
+        glam::Vec4::from(q3.to_array()),
+        t,
+    );
+    Quat::from_vec4(blended).normalize()
+}

--- a/crates/brush-anim/src/lib.rs
+++ b/crates/brush-anim/src/lib.rs
@@ -1,0 +1,11 @@
+//! Shared animation model for Brush: a serializable keyframe [`AnimationConfig`]
+//! with camera interpolation (all platforms), plus the native render/encode
+//! pipeline used by both the viewer's export and the headless CLI.
+
+mod config;
+pub use config::{AnimationConfig, Interpolation, Keyframe};
+
+#[cfg(not(target_family = "wasm"))]
+mod render;
+#[cfg(not(target_family = "wasm"))]
+pub use render::render_to_mp4;

--- a/crates/brush-anim/src/lib.rs
+++ b/crates/brush-anim/src/lib.rs
@@ -1,0 +1,11 @@
+//! Shared animation model for Brush: a serializable keyframe [`AnimationConfig`]
+//! with camera interpolation (all platforms), plus the native render/encode
+//! pipeline used by both the viewer's export and the headless CLI.
+
+mod config;
+pub use config::{AnimationConfig, Interpolation, Keyframe, VideoSettings};
+
+#[cfg(not(target_family = "wasm"))]
+mod render;
+#[cfg(not(target_family = "wasm"))]
+pub use render::render_to_mp4;

--- a/crates/brush-anim/src/render.rs
+++ b/crates/brush-anim/src/render.rs
@@ -1,0 +1,76 @@
+use std::io::Write;
+use std::path::Path;
+
+use brush_render::{TextureMode, camera::Camera, gaussian_splats::Splats, render_splats};
+use ffmpeg_sidecar::command::FfmpegCommand;
+use glam::Vec3;
+
+/// Renders `cameras` against `splats` and encodes them to an H.264 MP4 at
+/// `path` with ffmpeg. `on_progress(done, total)` is called after each frame.
+#[allow(clippy::too_many_arguments)]
+pub async fn render_to_mp4(
+    splats: Splats,
+    cameras: Vec<Camera>,
+    fps: usize,
+    background: Vec3,
+    splat_scale: Option<f32>,
+    width: u32,
+    height: u32,
+    path: &Path,
+    mut on_progress: impl FnMut(usize, usize),
+) -> anyhow::Result<()> {
+    let mut child = FfmpegCommand::new()
+        .args(["-f", "rawvideo", "-pixel_format", "rgb24"])
+        .args(["-video_size", &format!("{width}x{height}")])
+        .args(["-framerate", &fps.to_string()])
+        .args(["-i", "-"])
+        .args([
+            "-c:v", "libx264", "-pix_fmt", "yuv420p", "-preset", "medium",
+        ])
+        // Quiet stderr so its pipe can't fill and stall the encoder.
+        .args(["-loglevel", "error", "-nostats", "-y"])
+        .arg(path)
+        .spawn()?;
+
+    let mut stdin = child
+        .take_stdin()
+        .ok_or_else(|| anyhow::anyhow!("ffmpeg stdin unavailable"))?;
+
+    let img_size = glam::uvec2(width, height);
+    let total = cameras.len();
+    for (i, camera) in cameras.iter().enumerate() {
+        let (image, _) = render_splats(
+            splats.clone(),
+            camera,
+            img_size,
+            background,
+            splat_scale,
+            TextureMode::Float,
+        )
+        .await;
+
+        // Float render is [h, w, 4] in 0..1; pack to rgb24, dropping alpha.
+        let data = image
+            .to_data_async()
+            .await
+            .map_err(|e| anyhow::anyhow!("frame readback failed: {e:?}"))?;
+        let floats = data
+            .as_slice::<f32>()
+            .map_err(|e| anyhow::anyhow!("unexpected frame format: {e:?}"))?;
+
+        let mut rgb = vec![0u8; (width * height * 3) as usize];
+        for px in 0..(width * height) as usize {
+            for c in 0..3 {
+                rgb[px * 3 + c] = (floats[px * 4 + c].clamp(0.0, 1.0) * 255.0) as u8;
+            }
+        }
+        stdin.write_all(&rgb)?;
+        on_progress(i + 1, total);
+    }
+
+    drop(stdin);
+    if !child.wait()?.success() {
+        anyhow::bail!("ffmpeg failed to encode the video");
+    }
+    Ok(())
+}

--- a/crates/brush-anim/src/render.rs
+++ b/crates/brush-anim/src/render.rs
@@ -1,0 +1,74 @@
+use std::io::Write;
+use std::path::Path;
+
+use brush_render::{TextureMode, camera::Camera, gaussian_splats::Splats, render_splats};
+use ffmpeg_sidecar::command::FfmpegCommand;
+
+use crate::config::VideoSettings;
+
+/// Renders `cameras` against `splats` and encodes them to an H.264 MP4 at
+/// `path` with ffmpeg. `on_progress(done, total)` is called after each frame.
+pub async fn render_to_mp4(
+    splats: Splats,
+    cameras: &[Camera],
+    settings: &VideoSettings,
+    path: &Path,
+    mut on_progress: impl FnMut(usize, usize),
+) -> anyhow::Result<()> {
+    let VideoSettings {
+        width,
+        height,
+        fps,
+        background,
+        splat_scale,
+    } = *settings;
+
+    let mut child = FfmpegCommand::new()
+        // Packed renders are RGBA8, one u32 per pixel; feed those bytes
+        // straight through and let ffmpeg drop alpha on the yuv420p convert.
+        .args(["-f", "rawvideo", "-pixel_format", "rgba"])
+        .args(["-video_size", &format!("{width}x{height}")])
+        .args(["-framerate", &fps.to_string()])
+        .args(["-i", "-"])
+        .args([
+            "-c:v", "libx264", "-pix_fmt", "yuv420p", "-preset", "medium",
+        ])
+        // Quiet stderr so its pipe can't fill and stall the encoder.
+        .args(["-loglevel", "error", "-nostats", "-y"])
+        .arg(path)
+        .spawn()?;
+
+    let mut stdin = child
+        .take_stdin()
+        .ok_or_else(|| anyhow::anyhow!("ffmpeg stdin unavailable"))?;
+
+    let img_size = glam::uvec2(width, height);
+    let total = cameras.len();
+    for (i, camera) in cameras.iter().enumerate() {
+        // `Packed` keeps this on the forward-only raster pass and hands back
+        // an [h, w, 1] u32 image already quantized to RGBA8 on the GPU — no
+        // backward bookkeeping and no CPU conversion, unlike `Float`.
+        let (image, _) = render_splats(
+            splats.clone(),
+            camera,
+            img_size,
+            background,
+            splat_scale,
+            TextureMode::Packed,
+        )
+        .await;
+
+        let data = image
+            .to_data_async()
+            .await
+            .map_err(|e| anyhow::anyhow!("frame readback failed: {e:?}"))?;
+        stdin.write_all(data.as_bytes())?;
+        on_progress(i + 1, total);
+    }
+
+    drop(stdin);
+    if !child.wait()?.success() {
+        anyhow::bail!("ffmpeg failed to encode the video");
+    }
+    Ok(())
+}

--- a/crates/brush-render/src/camera.rs
+++ b/crates/brush-render/src/camera.rs
@@ -72,6 +72,25 @@ impl Camera {
         }
     }
 
+    /// Widen the FOV on whichever axis `img_size` is relatively longer, so an
+    /// image rendered at that size shows at least what the camera's own aspect
+    /// ratio covers (rather than cropping it).
+    pub fn fit_fov_to_size(&mut self, img_size: glam::UVec2) {
+        // fov_to_focal(fov, 2, model) = 1 / projection(half_fov), so the ratio
+        // gives projected_x / projected_y.
+        let camera_aspect = fov_to_focal(self.fov_y, 2, &self.camera_model)
+            / fov_to_focal(self.fov_x, 2, &self.camera_model);
+        let viewport_aspect = img_size.x as f64 / img_size.y as f64;
+
+        if viewport_aspect > camera_aspect {
+            let focal_y = fov_to_focal(self.fov_y, img_size.y, &self.camera_model);
+            self.fov_x = focal_to_fov(focal_y, img_size.x, &self.camera_model);
+        } else {
+            let focal_x = fov_to_focal(self.fov_x, img_size.x, &self.camera_model);
+            self.fov_y = focal_to_fov(focal_x, img_size.y, &self.camera_model);
+        }
+    }
+
     pub fn local_to_world(&self) -> Affine3A {
         Affine3A::from_rotation_translation(self.rotation, self.position)
     }

--- a/crates/brush-render/src/tests/mod.rs
+++ b/crates/brush-render/src/tests/mod.rs
@@ -618,6 +618,62 @@ async fn render_panics_loudly_on_nan_positions() {
     let _ = render_splats(splats, &cam, img_size, Vec3::ZERO, None, TextureMode::Float).await;
 }
 
+// A `Packed` render reads back as one RGBA8 pixel per u32, in memory order.
+// The video export streams these bytes straight into ffmpeg as `rgba`, so the
+// layout is load-bearing, not an implementation detail.
+#[wasm_bindgen_test(unsupported = tokio::test)]
+async fn packed_readback_is_rgba8() {
+    // Splats at the camera origin are near-plane culled, so every pixel is
+    // pure background — a known value to check the byte layout against.
+    let cam = Camera::new(
+        glam::vec3(0.0, 0.0, 0.0),
+        glam::Quat::IDENTITY,
+        0.5,
+        0.5,
+        glam::vec2(0.5, 0.5),
+        CameraModel::Pinhole,
+    );
+    let img_size = glam::uvec2(16, 8);
+    let device: burn::tensor::Device = brush_cube::test_helpers::test_device().await.into();
+    let num_points = 4;
+
+    let splats = Splats::from_tensor_data(
+        Tensor::<2>::zeros([num_points, 3], &device),
+        Tensor::<1>::from_floats(glam::Quat::IDENTITY.to_array(), &device)
+            .unsqueeze_dim(0)
+            .repeat_dim(0, num_points),
+        Tensor::<2>::ones([num_points, 3], &device) * 2.0,
+        Tensor::<3>::ones([num_points, 1, 3], &device),
+        Tensor::<1>::zeros([num_points], &device),
+        SplatRenderMode::Default,
+    );
+
+    let bg = glam::vec3(0.7, 0.3, 0.1);
+    let (output, _aux) = render_splats(splats, &cam, img_size, bg, None, TextureMode::Packed).await;
+
+    // One u32 per pixel, not the four floats `Float` mode hands back.
+    assert_eq!(
+        output.shape().dims(),
+        [img_size.y as usize, img_size.x as usize, 1]
+    );
+
+    let data = output.to_data_async().await.expect("readback");
+    let bytes = data.as_bytes();
+    let n_pixels = (img_size.x * img_size.y) as usize;
+    assert_eq!(bytes.len(), n_pixels * 4);
+
+    // The kernel truncates rather than rounds, so allow the odd 1-LSB slip.
+    let expect = [bg.x, bg.y, bg.z, 0.0].map(|c| (c * 255.0) as u8);
+    for (i, px) in bytes.chunks_exact(4).enumerate() {
+        assert!(
+            px.iter()
+                .zip(expect)
+                .all(|(&got, want)| got.abs_diff(want) <= 1),
+            "pixel {i} = {px:?}, expected background {expect:?}"
+        );
+    }
+}
+
 // Zero-splat Splats must not crash and must render every pixel as the
 // background color. Reading pixels back forces fusion to flush, which is
 // what catches bugs in the empty-tensor code paths.

--- a/crates/rrfd/src/lib.rs
+++ b/crates/rrfd/src/lib.rs
@@ -73,6 +73,36 @@ pub async fn pick_directory() -> Result<PathBuf, PickFileError> {
     }
 }
 
+/// Pick a location to save a file and return the chosen path, without writing
+/// anything. Use this when the bytes are produced out-of-band (e.g. an external
+/// encoder writes to the path directly). For data you already have, use
+/// [`save_file`] instead.
+///
+/// Nb: Does not work on Android currently.
+#[cfg(not(target_family = "wasm"))]
+pub async fn pick_save_path(
+    default_name: &str,
+    filter_name: &str,
+    extensions: &[&str],
+) -> Result<PathBuf, PickFileError> {
+    #[cfg(not(target_os = "android"))]
+    {
+        let file = rfd::AsyncFileDialog::new()
+            .set_file_name(default_name)
+            .add_filter(filter_name, extensions)
+            .save_file()
+            .await
+            .ok_or(PickFileError::NoFileSelected)?;
+        Ok(file.path().to_path_buf())
+    }
+
+    #[cfg(target_os = "android")]
+    {
+        let _ = (default_name, filter_name, extensions);
+        panic!("No saving on Android yet.")
+    }
+}
+
 /// Saves data to a file and returns the filename the data was saved too.
 ///
 /// Nb: Does not work on Android currently.


### PR DESCRIPTION
I implemented an animation functionality similar to supersplat. I also added a CLI interface. That allows you to create the exact same animation for different PLYs that share the same coordinate frame. I needed this for comparing multiple splats. This is very convenient. I used claude for most parts.

This is how it looks like:
<img width="1634" height="363" alt="image" src="https://github.com/user-attachments/assets/5eb9574f-0cd9-455b-b10c-d13638bdb9a7" />
