### PR TITLE
Quality: Missing dtype validation in safetensor loading causes silent data corruption or confusing panics

### DIFF
--- a/crates/brush-bench-test/src/safetensor_utils.rs
+++ b/crates/brush-bench-test/src/safetensor_utils.rs
@@ -11,18 +11,21 @@ fn float_from_u8(data: &[u8]) -> Vec<f32> {
 pub(crate) fn safetensor_to_burn<const D: usize>(
     t: &TensorView,
     device: &Device,
-) -> Tensor<D, Float> {
+) -> anyhow::Result<Tensor<D, Float>> {
+    if t.dtype() != safetensors::Dtype::F32 {
+        anyhow::bail!("Expected F32 tensor, got {:?}", t.dtype());
+    }
     let data = TensorData::new::<f32, _>(float_from_u8(t.data()), t.shape());
-    Tensor::from_data(data, device)
+    Ok(Tensor::from_data(data, device))
 }
 
 pub fn splats_from_safetensors(tensors: &SafeTensors, device: &Device) -> anyhow::Result<Splats> {
     Ok(Splats::from_tensor_data(
-        safetensor_to_burn::<2>(&tensors.tensor("means")?, device),
-        safetensor_to_burn::<2>(&tensors.tensor("quats")?, device),
-        safetensor_to_burn::<2>(&tensors.tensor("scales")?, device),
-        safetensor_to_burn::<3>(&tensors.tensor("coeffs")?, device),
-        safetensor_to_burn::<1>(&tensors.tensor("opacities")?, device),
+        safetensor_to_burn::<2>(&tensors.tensor("means")?, device)?,
+        safetensor_to_burn::<2>(&tensors.tensor("quats")?, device)?,
+        safetensor_to_burn::<2>(&tensors.tensor("scales")?, device)?,
+        safetensor_to_burn::<3>(&tensors.tensor("coeffs")?, device)?,
+        safetensor_to_burn::<1>(&tensors.tensor("opacities")?, device)?,
         SplatRenderMode::Default,
     ))
 }


### PR DESCRIPTION
## Problem

`float_from_u8` blindly interprets raw bytes as little-endian f32 without checking the tensor's actual dtype from `TensorView::dtype()`. If the safetensor file contains U32 or I32 tensors (both 4 bytes per element), the bytes are silently reinterpreted as garbage f32 values — `TensorData::new` won't catch this because element counts still match. For non-4-byte dtypes (F16, BF16, U8), you get a confusing size-mismatch panic instead of a clear "unsupported dtype" error. This affects `splats_from_safetensors` which loads critical scene data (means, quats, scales, opacities).


**Severity**: `high`
**File**: `crates/brush-bench-test/src/safetensor_utils.rs`

## Solution

Add a dtype check before converting. Example fix for `safetensor_to_burn`:


## Changes

- `crates/brush-bench-test/src/safetensor_utils.rs` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
