### PR TITLE
Fix splat export orientation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,9 +224,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"

--- a/apps/brush-app/src/ui/training_panel.rs
+++ b/apps/brush-app/src/ui/training_panel.rs
@@ -91,8 +91,8 @@ impl TrainingPanel {
     }
 }
 
-async fn export(splat: Splats) -> Result<(), Error> {
-    let data = brush_serde::splat_to_ply(splat).await?;
+async fn export(splat: Splats, up_axis: Option<glam::Vec3>) -> Result<(), Error> {
+    let data = brush_serde::splat_to_ply(splat, up_axis).await?;
     rrfd::save_file("export.ply", data).await?;
     Ok(())
 }
@@ -293,10 +293,11 @@ impl AppPane for TrainingPanel {
                         let Some(splats) = process.current_splats().latest() else {
                             return;
                         };
+                        let up_axis = process.up_axis();
 
                         self.export_actor
                             .run(move || async move {
-                                if let Err(e) = export(splats).await {
+                                if let Err(e) = export(splats, up_axis).await {
                                     let _ = sender.send(e);
                                     ctx.request_repaint();
                                 }

--- a/apps/brush-app/src/ui/ui_process.rs
+++ b/apps/brush-app/src/ui/ui_process.rs
@@ -178,11 +178,16 @@ impl UiProcess {
 
     pub fn set_model_up(&self, up_axis: Vec3) {
         let mut inner = self.write();
+        inner.up_axis = Some(up_axis);
         inner.controls.model_local_to_world = Affine3A::from_rotation_translation(
             Quat::from_rotation_arc(Vec3::NEG_Y, up_axis.normalize()),
             Vec3::ZERO,
         );
         inner.repaint();
+    }
+
+    pub fn up_axis(&self) -> Option<Vec3> {
+        self.read().up_axis
     }
 
     /// Connect to an existing running process.
@@ -345,6 +350,7 @@ struct UiProcessInner {
     ui_ctx: egui::Context,
     burn_device: WgpuDevice,
     actor: Actor,
+    up_axis: Option<Vec3>,
 }
 
 impl UiProcessInner {
@@ -378,6 +384,7 @@ impl UiProcessInner {
             burn_device,
             ui_ctx,
             actor,
+            up_axis: None,
         }
     }
 

--- a/crates/brush-bench-test/src/reference.rs
+++ b/crates/brush-bench-test/src/reference.rs
@@ -107,7 +107,7 @@ async fn test_reference() -> anyhow::Result<()> {
 
         let tensors = SafeTensors::deserialize(data)?;
         let splats: Splats = splats_from_safetensors(&tensors, &device)?;
-        let img_ref = safetensor_to_burn::<3>(&tensors.tensor("out_img")?, &device);
+        let img_ref = safetensor_to_burn::<3>(&tensors.tensor("out_img")?, &device)?;
         let [h, w, _] = img_ref.dims();
 
         let fov = std::f64::consts::PI * 0.5;

--- a/crates/brush-process/src/train_stream.rs
+++ b/crates/brush-process/src/train_stream.rs
@@ -235,10 +235,16 @@ pub(crate) async fn train_stream(
                         .replace(".ply", &format!("_lod{current_lod}.ply"));
                     (lod_name, lod_refine_steps, lod_refine_steps)
                 };
-                let res =
-                    export_checkpoint(splats.clone(), &export_path, &name, exp_iter, exp_total)
-                        .await
-                        .with_context(|| "Export at LOD boundary failed");
+                let res = export_checkpoint(
+                    splats.clone(),
+                    &export_path,
+                    &name,
+                    exp_iter,
+                    exp_total,
+                    up_axis,
+                )
+                .await
+                .with_context(|| "Export at LOD boundary failed");
 
                 if let Err(error) = res {
                     emitter.emit(ProcessMessage::Warning { error }).await;
@@ -384,10 +390,16 @@ pub(crate) async fn train_stream(
                         .replace(".ply", &format!("_lod{current_lod}.ply"));
                     (lod_name, lod_refine_steps, lod_refine_steps)
                 };
-                let res =
-                    export_checkpoint(splats.clone(), &export_path, &name, exp_iter, exp_total)
-                        .await
-                        .with_context(|| format!("Export at iteration {iter} failed"));
+                let res = export_checkpoint(
+                    splats.clone(),
+                    &export_path,
+                    &name,
+                    exp_iter,
+                    exp_total,
+                    up_axis,
+                )
+                .await
+                .with_context(|| format!("Export at iteration {iter} failed"));
 
                 if let Err(error) = res {
                     emitter.emit(ProcessMessage::Warning { error }).await;
@@ -565,13 +577,14 @@ async fn export_checkpoint(
     export_name: &str,
     iter: u32,
     total_steps: u32,
+    up_axis: Option<glam::Vec3>,
 ) -> Result<(), anyhow::Error> {
     tokio::fs::create_dir_all(&export_path)
         .await
         .with_context(|| format!("Creating export directory {}", export_path.display()))?;
     let digits = ((total_steps as f64).log10().floor() as usize) + 1;
     let export_name = export_name.replace("{iter}", &format!("{iter:0digits$}"));
-    let splat_data = brush_serde::splat_to_ply(splats)
+    let splat_data = brush_serde::splat_to_ply(splats, up_axis)
         .await
         .context("Serializing splat data")?;
     tokio::fs::write(export_path.join(&export_name), splat_data)

--- a/crates/brush-serde/src/export.rs
+++ b/crates/brush-serde/src/export.rs
@@ -3,6 +3,7 @@ use std::vec;
 use brush_render::gaussian_splats::Splats;
 use brush_render::sh::sh_coeffs_for_degree;
 use burn::tensor::Transaction;
+use glam::Vec3;
 use serde::ser::SerializeStruct;
 use serde::{Serialize, Serializer};
 use serde_ply::{SerializeError, SerializeOptions};
@@ -176,7 +177,7 @@ async fn read_splat_data(splats: Splats) -> Result<DynamicPly, ExportError> {
     Ok(DynamicPly { vertex: vertices })
 }
 
-pub async fn splat_to_ply(splats: Splats) -> Result<Vec<u8>, ExportError> {
+pub async fn splat_to_ply(splats: Splats, up_axis: Option<Vec3>) -> Result<Vec<u8>, ExportError> {
     // Fold any 3D-filter floor into the stored scales/opacity so the ply holds
     // ordinary derived values — the floor is never written as a separate field.
     let splats = splats.bake_min_scale();
@@ -185,12 +186,15 @@ pub async fn splat_to_ply(splats: Splats) -> Result<Vec<u8>, ExportError> {
 
     let render_mode_str = if splats.render_mip { "mip" } else { "default" };
 
-    let comments = vec![
-        "Exported from Brush".to_owned(),
-        "Vertical axis: y".to_owned(),
-        format!("SH degree: {}", sh_degree),
-        format!("SplatRenderMode: {}", render_mode_str),
-    ];
+    let mut comments = vec!["Exported from Brush".to_owned()];
+    if let Some(up) = up_axis {
+        comments.push(format!("Vertical axis: {} {} {}", up.x, up.y, up.z));
+    } else {
+        comments.push("Vertical axis: y".to_owned());
+    }
+    comments.push(format!("SH degree: {sh_degree}"));
+    comments.push(format!("SplatRenderMode: {render_mode_str}"));
+
     Ok(serde_ply::to_bytes(
         &ply,
         SerializeOptions::binary_le().with_comments(comments),
@@ -255,7 +259,7 @@ mod tests {
                 ply_data.vertex[0].rest_coeffs.len(),
                 expected_rest_coeffs as usize
             );
-            assert!(splat_to_ply(splats).await.is_ok());
+            assert!(splat_to_ply(splats, None).await.is_ok());
         }
     }
 
@@ -266,7 +270,7 @@ mod tests {
 
         for (degree, expected_rest_fields) in test_cases {
             let splats = create_test_splats(degree);
-            let ply_bytes = splat_to_ply(splats).await.unwrap();
+            let ply_bytes = splat_to_ply(splats, None).await.unwrap();
             let ply_string = String::from_utf8_lossy(&ply_bytes);
 
             let actual_rest_fields = ply_string.matches("property float f_rest_").count();
@@ -291,7 +295,7 @@ mod tests {
 
         for degree in [0, 1, 2] {
             let original_splats = create_test_splats(degree);
-            let ply_bytes = splat_to_ply(original_splats.clone())
+            let ply_bytes = splat_to_ply(original_splats.clone(), None)
                 .await
                 .expect("Failed to serialize splats");
 
@@ -319,7 +323,7 @@ mod tests {
             let original = create_test_splats_with_count(degree, num_splats);
             assert_eq!(original.num_splats(), num_splats as u32);
 
-            let ply_bytes = splat_to_ply(original.clone())
+            let ply_bytes = splat_to_ply(original.clone(), None)
                 .await
                 .expect("Failed to export splats");
 

--- a/crates/brush-serde/src/import.rs
+++ b/crates/brush-serde/src/import.rs
@@ -197,15 +197,26 @@ pub fn stream_splat_from_ply<T: AsyncRead + Unpin>(
             .comments
             .iter()
             .filter_map(|c| {
-                match c
-                    .to_lowercase()
-                    .strip_prefix("vertical axis: ")
-                    .map(|s| s.trim())
-                {
-                    Some("x") => Some(Vec3::X),
-                    Some("y") => Some(Vec3::NEG_Y),
-                    Some("z") => Some(Vec3::NEG_Z),
-                    _ => None,
+                let s = c.to_lowercase();
+                let suffix = s.strip_prefix("vertical axis: ")?.trim();
+                match suffix {
+                    "x" => Some(Vec3::X),
+                    "y" => Some(Vec3::NEG_Y),
+                    "z" => Some(Vec3::NEG_Z),
+                    _ => {
+                        let parts: Vec<f32> = suffix
+                            .split(|ch: char| {
+                                ch == ',' || ch.is_whitespace() || ch == '[' || ch == ']'
+                            })
+                            .filter(|s| !s.is_empty())
+                            .filter_map(|p| p.parse::<f32>().ok())
+                            .collect();
+                        if parts.len() == 3 {
+                            Some(Vec3::new(parts[0], parts[1], parts[2]))
+                        } else {
+                            None
+                        }
+                    }
                 }
             })
             .next_back();
@@ -602,7 +613,7 @@ mod tests {
     async fn test_import_basic_functionality() {
         let _device = brush_cube::test_helpers::test_device().await;
         let original_splats = create_test_splats(1);
-        let ply_bytes = splat_to_ply(original_splats.clone()).await.unwrap();
+        let ply_bytes = splat_to_ply(original_splats.clone(), None).await.unwrap();
 
         let cursor = Cursor::new(ply_bytes);
         let imported_message = load_splat_from_ply(cursor, None).await.unwrap();
@@ -621,7 +632,7 @@ mod tests {
         let _device = brush_cube::test_helpers::test_device().await;
         for degree in [0, 1, 2] {
             let original_splats = create_test_splats(degree);
-            let ply_bytes = splat_to_ply(original_splats).await.unwrap();
+            let ply_bytes = splat_to_ply(original_splats, None).await.unwrap();
 
             let cursor = Cursor::new(ply_bytes);
             let imported_message = load_splat_from_ply(cursor, None).await.unwrap();
@@ -640,7 +651,7 @@ mod tests {
         let original_splats = create_test_splats_with_count(0, 4);
         assert_eq!(original_splats.num_splats(), 4);
 
-        let ply_bytes = splat_to_ply(original_splats).await.unwrap();
+        let ply_bytes = splat_to_ply(original_splats, None).await.unwrap();
 
         // Test no subsampling
         let cursor = Cursor::new(ply_bytes.clone());
@@ -694,5 +705,24 @@ mod tests {
         assert_eq!(&sh[0..6], &[0., 0., 0., 0., 0., 0.]);
         assert_eq!(&sh[6..12], &[4., 4., 4., 4., 4., 4.]);
         assert_eq!(sub.raw_opacities.unwrap(), vec![0., 4., 8.]);
+    }
+
+    #[wasm_bindgen_test(unsupported = tokio::test)]
+    async fn test_import_custom_up_axis() {
+        let _device = brush_cube::test_helpers::test_device().await;
+        let original_splats = create_test_splats(1);
+        let custom_up = Vec3::new(0.123, 0.456, -0.789);
+        let ply_bytes = splat_to_ply(original_splats, Some(custom_up))
+            .await
+            .unwrap();
+
+        let cursor = Cursor::new(ply_bytes);
+        let imported_message = load_splat_from_ply(cursor, None).await.unwrap();
+
+        assert!(imported_message.meta.up_axis.is_some());
+        let imported_up = imported_message.meta.up_axis.unwrap();
+        assert!((imported_up.x - custom_up.x).abs() < 1e-5);
+        assert!((imported_up.y - custom_up.y).abs() < 1e-5);
+        assert!((imported_up.z - custom_up.z).abs() < 1e-5);
     }
 }

--- a/deny.toml
+++ b/deny.toml
@@ -30,6 +30,8 @@ ignore = [
     "RUSTSEC-2024-0436",
     # bincode is unmaintained, used by Cube and rerun, wait for them to upgrade.
     "RUSTSEC-2025-0141",
+    # ttf-parser is unmaintained, used transitively by winit.
+    "RUSTSEC-2026-0192",
 ]
 
 [bans]


### PR DESCRIPTION
Fixes exporting of splats so that their training up_axis is preserved in the PLY header, preventing them from loading upside-down in the viewer.

Note: This PR is based on the cargo-deny and anyhow upgrades in #508.