### PR TITLE
Fix cargo-deny checks: ignore ttf-parser advisory and upgrade anyhow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,9 +224,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"

--- a/crates/brush-bench-test/src/reference.rs
+++ b/crates/brush-bench-test/src/reference.rs
@@ -107,7 +107,7 @@ async fn test_reference() -> anyhow::Result<()> {
 
         let tensors = SafeTensors::deserialize(data)?;
         let splats: Splats = splats_from_safetensors(&tensors, &device)?;
-        let img_ref = safetensor_to_burn::<3>(&tensors.tensor("out_img")?, &device);
+        let img_ref = safetensor_to_burn::<3>(&tensors.tensor("out_img")?, &device)?;
         let [h, w, _] = img_ref.dims();
 
         let fov = std::f64::consts::PI * 0.5;

--- a/deny.toml
+++ b/deny.toml
@@ -30,6 +30,8 @@ ignore = [
     "RUSTSEC-2024-0436",
     # bincode is unmaintained, used by Cube and rerun, wait for them to upgrade.
     "RUSTSEC-2025-0141",
+    # ttf-parser is unmaintained, used transitively by winit.
+    "RUSTSEC-2026-0192",
 ]
 
 [bans]


### PR DESCRIPTION
Ignores the RUSTSEC-2026-0192 unmaintained advisory for ttf-parser and upgrades anyhow to v1.0.103 to fix RUSTSEC-2026-0190.