### PR TITLE
Add --invert-masks, and cut copies out of the image path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1082,7 +1082,6 @@ dependencies = [
  "brush-serde",
  "brush-vfs",
  "burn",
- "bytemuck",
  "clap",
  "colmap-reader",
  "getrandom 0.4.3",

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Brush takes in COLMAP data or datasets in the Nerfstudio format. Training is ful
 It also supports masking images:
 - Images with transparency. This will force the final splat to match the transparency of the input.
 - A folder of images called 'masks'. This ignores parts of the image that are masked out.
+  Black pixels in the mask are ignored, white pixels are kept. Pass `--invert-masks` if your masks are the other way around.
 
 ## Viewer
 Brush also works well as a splat viewer, including on the web. It can load .ply & .compressed.ply files. You can stream in data from a URL (for a web app, simply append `?url=`).

--- a/apps/brush-app/src/ui/settings_popup.rs
+++ b/apps/brush-app/src/ui/settings_popup.rs
@@ -362,6 +362,15 @@ pub(crate) fn draw_settings(ui: &mut Ui, args: &mut TrainStreamConfig, enabled: 
         );
     }
 
+    let mut invert_masks = args.load_config.invert_masks;
+    ui.add_enabled(
+        enabled,
+        egui::Checkbox::new(&mut invert_masks, "Invert masks"),
+    );
+    if enabled {
+        args.load_config.invert_masks = invert_masks;
+    }
+
     let mut alpha_mode_enabled = args.load_config.alpha_mode.is_some();
     ui.add_enabled(
         enabled,

--- a/crates/brush-dataset/Cargo.toml
+++ b/crates/brush-dataset/Cargo.toml
@@ -13,7 +13,6 @@ colmap-reader.path = "../colmap-reader"
 
 burn.workspace = true
 
-bytemuck.workspace = true
 thiserror = { workspace = true }
 image.workspace = true
 jpeg-decoder.workspace = true

--- a/crates/brush-dataset/src/config.rs
+++ b/crates/brush-dataset/src/config.rs
@@ -43,6 +43,9 @@ pub struct LoadDatasetConfig {
     /// Whether to interpret an alpha channel (or masks) as transparency or masking.
     #[arg(long, help_heading = "Dataset Options")]
     pub alpha_mode: Option<AlphaMode>,
+    /// Invert mask images, so white means "ignore this pixel" instead of "keep it".
+    #[arg(long, help_heading = "Dataset Options", default_value = "false")]
+    pub invert_masks: bool,
     /// Max size of the cache for frames of the dataset, larger values usually improve performance for large datasets at the cost of more memory usage, can be e.g. 6G, 6000M, 6000MiB, 6000MB
     #[arg(long, help_heading = "Dataset Options", default_value = DEFAULT_MAX_SCENE_BATCH_CACHE_SIZE, value_parser = parse_size)]
     pub max_scene_batch_cache_size: u64,

--- a/crates/brush-dataset/src/formats/colmap.rs
+++ b/crates/brush-dataset/src/formats/colmap.rs
@@ -215,6 +215,7 @@ async fn load_dataset_inner(
                 mask_path.map(|p| p.to_path_buf()),
                 load_args.max_resolution,
                 load_args.alpha_mode,
+                load_args.invert_masks,
             );
 
             views.push(SceneView { camera, image });
@@ -470,6 +471,7 @@ mod tests {
             subsample_frames: None,
             subsample_points: None,
             alpha_mode: None,
+            invert_masks: false,
             max_scene_batch_cache_size: 0,
         }
     }

--- a/crates/brush-dataset/src/formats/nerfstudio.rs
+++ b/crates/brush-dataset/src/formats/nerfstudio.rs
@@ -190,6 +190,7 @@ async fn read_transforms_file(
             mask_path,
             load_args.max_resolution,
             load_args.alpha_mode,
+            load_args.invert_masks,
         );
 
         let w = frame.w.or(scene.w);

--- a/crates/brush-dataset/src/formats/realitycapture.rs
+++ b/crates/brush-dataset/src/formats/realitycapture.rs
@@ -134,6 +134,7 @@ async fn read_dataset_inner(
             mask_path,
             load_args.max_resolution,
             load_args.alpha_mode,
+            load_args.invert_masks,
         );
 
         // The csv carries no image dimensions; intrinsics are resolution

--- a/crates/brush-dataset/src/load_image.rs
+++ b/crates/brush-dataset/src/load_image.rs
@@ -1,6 +1,6 @@
 use brush_render::AlphaMode;
 use brush_vfs::BrushVfs;
-use image::{DynamicImage, GenericImageView, ImageBuffer};
+use image::{DynamicImage, GrayImage, ImageBuffer};
 use std::{
     io::{self, Cursor},
     path::{Path, PathBuf},
@@ -15,6 +15,7 @@ pub struct LoadImage {
     mask_path: Option<PathBuf>,
     max_resolution: u32,
     alpha_mode: AlphaMode,
+    invert_mask: bool,
     scale: f32,
 }
 
@@ -22,6 +23,7 @@ impl PartialEq for LoadImage {
     fn eq(&self, other: &Self) -> bool {
         self.path == other.path
             && self.mask_path == other.mask_path
+            && self.invert_mask == other.invert_mask
             && self.max_resolution == other.max_resolution
             && self.scale == other.scale
     }
@@ -34,6 +36,7 @@ impl LoadImage {
         mask_path: Option<PathBuf>,
         max_resolution: u32,
         override_alpha_mode: Option<AlphaMode>,
+        invert_mask: bool,
     ) -> Self {
         let alpha_mode = override_alpha_mode.unwrap_or_else(|| {
             if mask_path.is_some() {
@@ -49,6 +52,7 @@ impl LoadImage {
             mask_path,
             max_resolution,
             alpha_mode,
+            invert_mask,
             scale: 1.0,
         }
     }
@@ -72,27 +76,37 @@ impl LoadImage {
                 .await?
                 .read_to_end(&mut mask_bytes)
                 .await?;
-            let mut mask_img = image::load_from_memory(&mask_bytes)?;
+            let mask_img = image::load_from_memory(&mask_bytes)?;
+
+            // Only one channel of the mask ever reaches the alpha channel, so
+            // reduce it to 8bpp before doing any work on it. A grayscale mask
+            // (the usual case) then costs no conversion at all, and the resize
+            // below runs over one channel instead of three or four.
+            let mut mask = if mask_img.color().has_alpha() {
+                let rgba = mask_img.into_rgba8();
+                let (w, h) = rgba.dimensions();
+                let alpha = rgba.pixels().map(|p| p[3]).collect();
+                GrayImage::from_raw(w, h, alpha).expect("one byte per pixel")
+            } else {
+                mask_img.into_luma8()
+            };
 
             // Resize mask image if needed. This is allowed to squash the mask.
-            if mask_img.dimensions() != masked_img.dimensions() {
-                mask_img = mask_img.resize_exact(
+            if mask.dimensions() != masked_img.dimensions() {
+                mask = image::imageops::resize(
+                    &mask,
                     masked_img.width(),
                     masked_img.height(),
                     image::imageops::FilterType::Triangle,
                 );
             }
 
-            if mask_img.color().has_alpha() {
-                let mask_img = mask_img.into_rgba8();
-                for (pixel, mask_pixel) in masked_img.pixels_mut().zip(mask_img.pixels()) {
-                    pixel[3] = mask_pixel[3];
-                }
-            } else {
-                let mask_img = mask_img.into_rgb8();
-                for (pixel, mask_pixel) in masked_img.pixels_mut().zip(mask_img.pixels()) {
-                    pixel[3] = mask_pixel[0];
-                }
+            for (pixel, mask_pixel) in masked_img.pixels_mut().zip(mask.pixels()) {
+                pixel[3] = if self.invert_mask {
+                    255 - mask_pixel[0]
+                } else {
+                    mask_pixel[0]
+                };
             }
 
             img = masked_img.into();
@@ -206,5 +220,52 @@ fn decode_jpeg_scaled(bytes: &[u8], max_resolution: u32) -> Option<DynamicImage>
         }
         // CMYK32 / L16 are rare in photogrammetry data; fall back to image crate.
         _ => None,
+    }
+}
+
+#[cfg(all(test, not(target_family = "wasm")))]
+mod tests {
+    use super::LoadImage;
+    use brush_vfs::BrushVfs;
+    use image::{DynamicImage, GrayImage, Rgb, RgbImage, RgbaImage};
+    use std::sync::Arc;
+
+    /// Write an image + mask pair to a temp dir and load them back.
+    async fn load_with_mask(mask: DynamicImage, invert: bool) -> RgbaImage {
+        let dir = tempfile::tempdir().expect("temp dir");
+        RgbImage::from_pixel(4, 2, Rgb([10, 20, 30]))
+            .save(dir.path().join("img.png"))
+            .expect("save image");
+        mask.save(dir.path().join("mask.png")).expect("save mask");
+
+        let vfs = Arc::new(BrushVfs::from_path(dir.path()).await.expect("vfs"));
+        LoadImage::new(
+            vfs,
+            "img.png".into(),
+            Some("mask.png".into()),
+            1920,
+            None,
+            invert,
+        )
+        .load()
+        .await
+        .expect("load image")
+        .into_rgba8()
+    }
+
+    #[tokio::test]
+    async fn mask_becomes_alpha() {
+        let mask = GrayImage::from_raw(4, 2, (0..8).map(|i| i * 30).collect()).expect("mask");
+        let img = load_with_mask(mask.into(), false).await;
+        let alpha: Vec<u8> = img.pixels().map(|p| p[3]).collect();
+        assert_eq!(alpha, (0..8).map(|i| i * 30).collect::<Vec<_>>());
+    }
+
+    #[tokio::test]
+    async fn inverted_mask_flips_alpha() {
+        let mask = GrayImage::from_raw(4, 2, (0..8).map(|i| i * 30).collect()).expect("mask");
+        let img = load_with_mask(mask.into(), true).await;
+        let alpha: Vec<u8> = img.pixels().map(|p| p[3]).collect();
+        assert_eq!(alpha, (0..8).map(|i| 255 - i * 30).collect::<Vec<_>>());
     }
 }

--- a/crates/brush-dataset/src/scene.rs
+++ b/crates/brush-dataset/src/scene.rs
@@ -84,48 +84,55 @@ impl Scene {
     }
 }
 
-// Converts an image to a train sample. The tensor will be a floating point image with a [0, 1] image.
-//
-// This assume the input image has un-premultiplied alpha, whereas the output has pre-multiplied alpha.
-pub fn view_to_sample_image(image: DynamicImage, alpha_mode: AlphaMode) -> DynamicImage {
-    if image.color().has_alpha() && alpha_mode == AlphaMode::Transparent {
-        let mut rgba_bytes = image.to_rgba8();
-        // Assume image has un-multiplied alpha and convert it to pre-multiplied.
-        // Perform multiplication in byte space before converting to float.
-        for pixel in rgba_bytes.chunks_exact_mut(4) {
-            let r = pixel[0];
-            let g = pixel[1];
-            let b = pixel[2];
-            let a = pixel[3];
+/// Convert a loaded view into the GPU-side packed representation: `[H, W]`
+/// u32, each entry packing `[r8 g8 b8 a8]`. Images without alpha get
+/// `a = 255` (fully opaque) so the kernel always sees a valid alpha byte.
+/// Returns `(packed, has_alpha)` so the trainer knows whether to apply
+/// alpha-dependent loss terms.
+///
+/// Transparent-alpha views arrive un-premultiplied and leave premultiplied.
+/// That happens here rather than in a pass of its own: premultiplying,
+/// widening to RGBA and packing all read the same pixel, so they cost one
+/// walk over the image and one allocation between them.
+pub fn view_to_packed_data(image: DynamicImage, alpha_mode: AlphaMode) -> (TensorData, bool) {
+    let _span = tracing::trace_span!("view_to_packed").entered();
+    let (w, h) = (image.width(), image.height());
+    let has_alpha = image.color().has_alpha();
+    // Premultiplication is what `Transparent` means; a mask multiplies the
+    // loss instead and must keep its colours intact.
+    let premultiply = has_alpha && alpha_mode == AlphaMode::Transparent;
 
-            pixel[0] = ((r as u16 * a as u16 + 127) / 255) as u8;
-            pixel[1] = ((g as u16 * a as u16 + 127) / 255) as u8;
-            pixel[2] = ((b as u16 * a as u16 + 127) / 255) as u8;
-            pixel[3] = a;
-        }
-        DynamicImage::ImageRgba8(rgba_bytes)
-    } else {
-        image
-    }
+    // Pack as `[i32]` little-endian (same bit pattern as u32; i32 because the
+    // burn dispatch backend's default int dtype is i32 and refuses to cast
+    // u32 values >= 2^31). The kernel reads the same way (`val & 0xff` is
+    // `r`, `>> 24` is `a`) — the signedness only affects the host-side
+    // TensorData metadata, not the GPU bytes.
+    let packed: Vec<i32> = match image {
+        DynamicImage::ImageRgb8(img) => img
+            .pixels()
+            .map(|p| i32::from_le_bytes([p[0], p[1], p[2], 255]))
+            .collect(),
+        DynamicImage::ImageRgba8(img) => pack_rgba(&img, premultiply),
+        // 16-bit, luma and cmyk sources are rare; normalise them first.
+        other => pack_rgba(&other.into_rgba8(), premultiply),
+    };
+
+    (TensorData::new(packed, [h as usize, w as usize]), has_alpha)
 }
 
-/// Convert a sample into the GPU-side packed representation: `[H, W]` u32,
-/// each entry packing `[r8 g8 b8 a8]`. Images without alpha get `a = 255`
-/// (fully opaque) so the kernel always sees a valid alpha byte. Returns
-/// `(packed, has_alpha)` so the trainer knows whether to apply
-/// alpha-dependent loss terms.
-pub fn sample_to_packed_data(sample: DynamicImage) -> (TensorData, bool) {
-    let _span = tracing::trace_span!("sample_to_packed").entered();
-    let (w, h) = (sample.width(), sample.height());
-    let has_alpha = sample.color().has_alpha();
-    let packed: Vec<i32> = bytemuck::pod_collect_to_vec(&sample.into_rgba8().into_vec());
-    // Reinterpret the `[r g b a r g b a ...]` byte stream as `[i32]` little-endian
-    // (i32 bit-pattern same as the underlying u32; we use i32 because the burn
-    // dispatch backend's default int dtype is i32 and refuses to cast u32
-    // values >= 2^31). The kernel reads the same way (`val & 0xff` is `r`,
-    // `>> 24` is `a`) — the signedness only affects the host-side TensorData
-    // metadata, not the GPU bytes.
-    (TensorData::new(packed, [h as usize, w as usize]), has_alpha)
+fn pack_rgba(img: &image::RgbaImage, premultiply: bool) -> Vec<i32> {
+    img.pixels()
+        .map(|p| {
+            let [r, g, b, a] = p.0;
+            if premultiply {
+                // Multiply in byte space, before anything converts to float.
+                let mul = |c: u8| ((c as u16 * a as u16 + 127) / 255) as u8;
+                i32::from_le_bytes([mul(r), mul(g), mul(b), a])
+            } else {
+                i32::from_le_bytes([r, g, b, a])
+            }
+        })
+        .collect()
 }
 
 #[derive(Clone, Debug)]
@@ -140,6 +147,15 @@ pub struct SceneBatch {
 }
 
 impl SceneBatch {
+    /// Host bytes the packed image occupies.
+    pub fn packed_bytes(&self) -> u64 {
+        self.img_packed
+            .as_bytes()
+            .len()
+            .try_into()
+            .expect("shouldn't exceed ~18 Exabytes...")
+    }
+
     pub fn img_size(&self) -> [usize; 2] {
         [self.img_packed.shape[0], self.img_packed.shape[1]]
     }
@@ -147,7 +163,8 @@ impl SceneBatch {
 
 #[cfg(test)]
 mod tests {
-    use super::sample_to_packed_data;
+    use super::view_to_packed_data;
+    use brush_render::AlphaMode;
     use image::{DynamicImage, ImageBuffer, RgbImage, RgbaImage};
 
     #[test]
@@ -155,7 +172,8 @@ mod tests {
         let image =
             RgbaImage::from_raw(2, 1, vec![1, 2, 3, 4, 5, 6, 7, 8]).expect("valid RGBA image");
 
-        let (packed, has_alpha) = sample_to_packed_data(DynamicImage::ImageRgba8(image));
+        let (packed, has_alpha) =
+            view_to_packed_data(DynamicImage::ImageRgba8(image), AlphaMode::Masked);
 
         assert!(has_alpha);
         assert_eq!(packed.shape.dims(), [1, 2]);
@@ -170,7 +188,8 @@ mod tests {
         let image: RgbImage =
             ImageBuffer::from_raw(2, 1, vec![9, 10, 11, 12, 13, 14]).expect("valid RGB image");
 
-        let (packed, has_alpha) = sample_to_packed_data(DynamicImage::ImageRgb8(image));
+        let (packed, has_alpha) =
+            view_to_packed_data(DynamicImage::ImageRgb8(image), AlphaMode::Transparent);
 
         assert!(!has_alpha);
         assert_eq!(packed.shape.dims(), [1, 2]);

--- a/crates/brush-dataset/src/scene_loader.rs
+++ b/crates/brush-dataset/src/scene_loader.rs
@@ -1,12 +1,13 @@
 use std::sync::Arc;
 
 use brush_async::Actor;
+use burn::tensor::TensorData;
 use rand::{SeedableRng, seq::SliceRandom};
 use tokio::sync::{Mutex, mpsc};
 
 use crate::{
     config::LoadDatasetConfig,
-    scene::{Scene, SceneBatch, sample_to_packed_data, view_to_sample_image},
+    scene::{Scene, SceneBatch, view_to_packed_data},
 };
 
 /// Shared cache of GPU-ready scene batches. Each slot holds at most one
@@ -14,8 +15,9 @@ use crate::{
 /// the cache and just get re-decoded + re-packed on every visit.
 ///
 /// Caching the packed batch (instead of the decoded `DynamicImage`) skips
-/// the per-hit decode → premultiply → repack work: a cache hit is now a
-/// single copy of the already-packed `[H, W]` u32 buffer.
+/// the per-hit decode → premultiply → repack work. Cached buffers are put
+/// behind a refcount first (see `share_packed`), so a hit doesn't copy the
+/// pixels either: it hands out a view of the same allocation.
 struct BatchCache {
     slots: Vec<Option<Arc<SceneBatch>>>,
     used_bytes: u64,
@@ -35,22 +37,22 @@ impl BatchCache {
         self.slots[index].clone()
     }
 
+    /// Whether `insert` would take this batch: nothing cached for the view
+    /// yet, and it still fits the budget. Checked before caching so the
+    /// packed bytes only get shared when they're actually going to be kept.
+    ///
+    /// Tracks exact bytes: rounding to whole MB let sub-MB images slip in
+    /// for free and bypass the budget entirely.
+    fn admits(&self, index: usize, batch: &SceneBatch) -> bool {
+        self.slots[index].is_none() && self.used_bytes + batch.packed_bytes() < self.budget_bytes
+    }
+
     fn insert(&mut self, index: usize, batch: Arc<SceneBatch>) {
-        if self.slots[index].is_some() {
+        if !self.admits(index, &batch) {
             return;
         }
-        // Track exact bytes: rounding to whole MB let sub-MB images slip in
-        // for free and bypass the budget entirely.
-        let size_bytes: u64 = batch
-            .img_packed
-            .as_bytes()
-            .len()
-            .try_into()
-            .expect("shouldn't exceed ~18 Exabytes...");
-        if self.used_bytes + size_bytes < self.budget_bytes {
-            self.slots[index] = Some(batch);
-            self.used_bytes += size_bytes;
-        }
+        self.used_bytes += batch.packed_bytes();
+        self.slots[index] = Some(batch);
     }
 }
 
@@ -133,31 +135,46 @@ async fn run_loader(
         let index = shuffled.pop().expect("Need at least one view in dataset");
         let view = &views[index];
 
-        let batch = if let Some(batch) = cache.lock().await.get(index) {
-            batch
+        let cached = cache.lock().await.get(index);
+
+        let batch = if let Some(batch) = cached {
+            // The cached buffer is refcounted, so this is a pointer bump
+            // rather than a copy of the whole image.
+            batch.as_ref().clone()
         } else {
             let raw = view
                 .image
                 .load()
                 .await
                 .expect("Scene loader failed to load an image");
-            let sample = view_to_sample_image(raw, view.image.alpha_mode());
-            let (img_packed, has_alpha) = sample_to_packed_data(sample);
-            let batch = Arc::new(SceneBatch {
+            let (img_packed, has_alpha) = view_to_packed_data(raw, view.image.alpha_mode());
+            let mut batch = SceneBatch {
                 img_packed,
                 has_alpha,
                 alpha_mode: view.image.alpha_mode(),
                 camera: view.camera,
-            });
-            cache.lock().await.insert(index, batch.clone());
+            };
+
+            let mut cache = cache.lock().await;
+            if cache.admits(index, &batch) {
+                // Share the pixels before caching: this hand-off and every
+                // later hit then costs a refcount instead of a full copy.
+                batch.img_packed = share_packed(batch.img_packed);
+                cache.insert(index, Arc::new(batch.clone()));
+            }
             batch
         };
 
-        // The channel takes an owned batch; clone the packed buffer out of
-        // the shared cache entry.
-        if tx.send(batch.as_ref().clone()).await.is_err() {
+        if tx.send(batch).await.is_err() {
             break;
         }
         brush_async::yield_now().await;
     }
+}
+
+/// Move the packed pixels behind a refcount, so cloning the batch out of the
+/// cache doesn't copy them. Uploading to the GPU is unaffected: that copies
+/// into a staging buffer either way.
+fn share_packed(data: TensorData) -> TensorData {
+    TensorData::from_bytes(data.bytes.shared(), data.shape, data.dtype)
 }

--- a/crates/brush-process/src/train_stream.rs
+++ b/crates/brush-process/src/train_stream.rs
@@ -272,12 +272,13 @@ pub(crate) async fn train_stream(
             client.memory_cleanup();
 
             let cumulative_scale = (lod_img_pct as f32 / 100.0).powi(current_lod as i32);
-            dataloader = if lod_img_pct < 100 {
+            // Only rebuild the loader when the images actually changed size.
+            // A rebuild throws away a warm batch cache and re-decodes the
+            // whole dataset, which at 100% scale buys nothing.
+            if lod_img_pct < 100 {
                 let lod_scene = dataset.train.clone().with_image_scale(cumulative_scale);
-                SceneLoader::new(&lod_scene, 42, &train_stream_config.load_config)
-            } else {
-                SceneLoader::new(&dataset.train, 42, &train_stream_config.load_config)
-            };
+                dataloader = SceneLoader::new(&lod_scene, 42, &train_stream_config.load_config);
+            }
 
             let bounds = get_splat_bounds(splats.clone(), BOUND_PERCENTILE).await;
             trainer = SplatTrainer::new(&train_stream_config.train_config, &device, bounds);

--- a/crates/brush-train/src/eval.rs
+++ b/crates/brush-train/src/eval.rs
@@ -2,7 +2,7 @@
 use std::path::Path;
 
 use anyhow::Result;
-use brush_dataset::scene::{sample_to_packed_data, view_to_sample_image};
+use brush_dataset::scene::view_to_packed_data;
 use brush_loss::{ImageLossConfig, image_loss_eval};
 use brush_render::camera::Camera;
 use brush_render::gaussian_splats::Splats;
@@ -28,8 +28,7 @@ pub async fn eval_stats(
 ) -> Result<EvalSample> {
     let res = glam::uvec2(gt_img.width(), gt_img.height());
 
-    let (gt_packed_data, _has_alpha) =
-        sample_to_packed_data(view_to_sample_image(gt_img.clone(), alpha_mode));
+    let (gt_packed_data, _has_alpha) = view_to_packed_data(gt_img.clone(), alpha_mode);
     let gt_packed: Tensor<2, Int> = Tensor::from_data(gt_packed_data, device);
 
     // Render on reference black background.

--- a/crates/brush-train/src/lod.rs
+++ b/crates/brush-train/src/lod.rs
@@ -1,4 +1,4 @@
-use brush_dataset::scene::{sample_to_packed_data, view_to_sample_image};
+use brush_dataset::scene::view_to_packed_data;
 use brush_loss::{ImageLossConfig, image_loss};
 use brush_render::bwd::render_splats;
 use brush_render::gaussian_splats::Splats;
@@ -91,9 +91,8 @@ pub async fn compute_pup_scores(
             .load()
             .await
             .expect("Failed to load image for PUP scoring");
-        let sample = view_to_sample_image(image, view.image.alpha_mode());
-        let img_size = glam::uvec2(sample.width(), sample.height());
-        let (gt_data, _has_alpha) = sample_to_packed_data(sample);
+        let img_size = glam::uvec2(image.width(), image.height());
+        let (gt_data, _has_alpha) = view_to_packed_data(image, view.image.alpha_mode());
 
         let mut splats: Splats = splats.clone().train();
         splats.transforms = splats.transforms.map(|t: Tensor<2>| t.require_grad());


### PR DESCRIPTION
Masks where white means "ignore" rather than "keep" had to be inverted by hand before training. `--invert-masks` does it at load time, with a matching checkbox in the settings popup.

The rest is some cleanup & optimizations:

- The mask is cut down to one channel right after decode. A grayscale mask (the usual case) then needs no conversion at all, and the resize runs over 8bpp rather than 32. Note a non-alpha mask now takes luma instead of the red channel: same result for grayscale or black/white masks.

- Cached batches share their packed pixels behind a refcount. Cloning a batch out of the cache used to memcpy the whole image on every single step (~8MB at 1080p) because `Bytes::clone` copies unless the allocation is shared.

- Premultiply, widen to RGBA and pack are one pass now, where they were three passes with two full-image allocations between them.

- An LOD boundary keeps the existing loader when the image scale didn't change. With `--lod-image-scale 100` every level was dropping a fully warm cache and re-decoding the whole dataset.