### PR TITLE
Keep prefix sums within WebGPU limits

### DIFF
--- a/crates/brush-prefix-sum/src/kernels.rs
+++ b/crates/brush-prefix-sum/src/kernels.rs
@@ -4,7 +4,8 @@ use burn::cubecl::frontend::CompilationArg;
 use burn::cubecl::frontend::IndexMutExpand;
 use burn::cubecl::prelude::*;
 
-pub const THREADS_PER_GROUP: usize = 512;
+// WebGPU guarantees at least 256 invocations per workgroup.
+pub const THREADS_PER_GROUP: usize = 256;
 
 #[cube]
 fn linear_workgroup_id() -> usize {

--- a/crates/brush-prefix-sum/src/lib.rs
+++ b/crates/brush-prefix-sum/src/lib.rs
@@ -11,6 +11,10 @@ pub fn prefix_sum(input: CubeTensor) -> CubeTensor {
     assert!(input.is_contiguous(), "Please ensure input is contiguous");
 
     let num = input.shape()[0];
+    if num == 0 {
+        return input;
+    }
+
     let client = input.client.clone();
     let outputs = create_tensor(input.shape().dims::<1>(), &input.device, input.dtype);
 
@@ -85,6 +89,7 @@ pub fn prefix_sum(input: CubeTensor) -> CubeTensor {
 mod tests {
     use crate::prefix_sum;
     use brush_cube::{CubeDevice, MainBackendBase, create_tensor_from_slice};
+    use burn::backend::TensorMetadata;
     use burn::backend::ops::IntTensorOps;
     use burn::tensor::DType;
 
@@ -111,7 +116,7 @@ mod tests {
     }
 
     #[wasm_bindgen_test(unsupported = tokio::test)]
-    async fn test_512_multiple() {
+    async fn test_workgroup_multiple() {
         const ITERS: usize = 1024;
         let data: Vec<i32> = (0..ITERS).map(|i| 90 + i as i32).collect();
         let device = CubeDevice::Wgpu(brush_cube::test_helpers::test_device().await);
@@ -126,6 +131,33 @@ mod tests {
             .collect();
         for (summed, reff) in summed.iter().zip(prefix_sum_ref) {
             assert_eq!(*summed, reff);
+        }
+    }
+
+    #[wasm_bindgen_test(unsupported = tokio::test)]
+    async fn test_empty() {
+        let device = CubeDevice::Wgpu(brush_cube::test_helpers::test_device().await);
+        let keys = create_tensor_from_slice::<i32>(&[], &device, DType::I32);
+        let summed = prefix_sum(keys);
+        assert_eq!(summed.shape()[0], 0);
+    }
+
+    #[wasm_bindgen_test(unsupported = tokio::test)]
+    async fn test_workgroup_boundaries() {
+        let device = CubeDevice::Wgpu(brush_cube::test_helpers::test_device().await);
+
+        for len in [255usize, 256, 257] {
+            let data: Vec<i32> = (0..len).map(|i| (i % 7) as i32).collect();
+            let keys = create_tensor_from_slice(&data, &device, DType::I32);
+            let summed = read_i32(prefix_sum(keys)).await;
+            let expected: Vec<_> = data
+                .into_iter()
+                .scan(0, |sum, value| {
+                    *sum += value;
+                    Some(*sum)
+                })
+                .collect();
+            assert_eq!(summed, expected, "length {len}");
         }
     }
 


### PR DESCRIPTION
## Summary

- use WebGPU's guaranteed 256-invocation workgroup limit for prefix sums
- return empty inputs without launching a zero-sized dispatch
- cover empty input and the 255/256/257 workgroup boundaries