### PR TITLE
Stabilize min-scale folding and eval paths

### DIFF
--- a/crates/brush-process/src/train_stream.rs
+++ b/crates/brush-process/src/train_stream.rs
@@ -491,6 +491,46 @@ pub(crate) async fn train_stream(
     Ok(())
 }
 
+#[cfg(not(target_family = "wasm"))]
+fn eval_output_path(base: &Path, iter: u32, image_path: &Path) -> anyhow::Result<PathBuf> {
+    let mut relative = PathBuf::new();
+    for component in image_path.components() {
+        match component {
+            std::path::Component::Normal(part) => relative.push(part),
+            std::path::Component::CurDir => {}
+            _ => anyhow::bail!(
+                "Eval image path must be relative and cannot traverse directories: {}",
+                image_path.display()
+            ),
+        }
+    }
+    if relative.as_os_str().is_empty() {
+        anyhow::bail!("Eval image path is empty");
+    }
+    relative.set_extension("png");
+    Ok(base.join(format!("eval_{iter}")).join(relative))
+}
+
+#[cfg(all(test, not(target_family = "wasm")))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn eval_paths_are_safe_and_distinct() {
+        let base = Path::new("output");
+        let first = eval_output_path(base, 42, Path::new("images/a/frame.jpg")).unwrap();
+        let second = eval_output_path(base, 42, Path::new("images/b/frame.jpg")).unwrap();
+
+        assert_eq!(first, Path::new("output/eval_42/images/a/frame.png"));
+        assert_eq!(second, Path::new("output/eval_42/images/b/frame.png"));
+        assert_ne!(first, second);
+
+        for invalid in ["../frame.jpg", "/tmp/frame.jpg", "."] {
+            assert!(eval_output_path(base, 1, Path::new(invalid)).is_err());
+        }
+    }
+}
+
 async fn run_eval(
     device: &burn::tensor::Device,
     emitter: &Emitter,
@@ -530,10 +570,15 @@ async fn run_eval(
 
         #[cfg(not(target_family = "wasm"))]
         if let Some(path) = &save_path {
-            let img_name = view.image.img_name();
-            let path = path
-                .join(format!("eval_{iter}"))
-                .join(format!("{img_name}.png"));
+            let path = eval_output_path(path, iter, view.image.path())?;
+            if let Some(parent) = path.parent() {
+                tokio::fs::create_dir_all(parent).await.with_context(|| {
+                    format!(
+                        "Failed to create eval output directory {}",
+                        parent.display()
+                    )
+                })?;
+            }
             sample.save_to_disk(&path).await?;
         }
 

--- a/crates/brush-render/src/gaussian_splats.rs
+++ b/crates/brush-render/src/gaussian_splats.rs
@@ -93,17 +93,14 @@ pub fn fold_min_scale(
     let f = crate::burn_glue::match_backend(f, &transforms);
     let n = transforms.dims()[0] as i32;
     let log_scales = transforms.clone().slice(s![.., 7..10]); // [N,3]
-    let s2 = log_scales.mul_scalar(2.0).exp(); // s² = exp(2·log) [N,3]
+    let s2 = log_scales.clone().mul_scalar(2.0).exp(); // s² = exp(2·log) [N,3]
     let f2 = f.clone().mul(f).reshape([n, 1]); // [N,1]
-    let s2f = s2.clone().add(f2); // s² + f² [N,3]
+    let s2f = s2.add(f2); // s² + f² [N,3]
 
-    let new_log = s2f.clone().log().mul_scalar(0.5); // log(sqrt(s²+f²)) [N,3]
-    let transforms = transforms.slice_assign(s![.., 7..10], new_log);
+    let new_log = s2f.log().mul_scalar(0.5); // log(sqrt(s²+f²)) [N,3]
+    let transforms = transforms.slice_assign(s![.., 7..10], new_log.clone());
 
-    let det = |t: Tensor<2>| {
-        t.clone().slice(s![.., 0..1]) * t.clone().slice(s![.., 1..2]) * t.slice(s![.., 2..3])
-    };
-    let coef = (det(s2).div(det(s2f))).sqrt().reshape([n]); // sqrt(det1/det2) [N]
+    let coef = log_scales.sub(new_log).sum_dim(1).exp().reshape([n]);
     let opac = sigmoid(raw_opac).mul(coef).clamp(1e-6, 1.0 - 1e-6);
     let raw_opac = opac.clone().div(opac.neg().add_scalar(1.0)).log(); // logit
 
@@ -443,4 +440,48 @@ pub async fn render_splats(
     };
 
     (Tensor::from_dispatch(output.out_img), aux)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn min_scale_fold_is_stable_for_tiny_scales() {
+        let device = Device::from(brush_cube::test_helpers::test_device().await).autodiff();
+        let log_scale = -20.0_f32;
+        let mut data = vec![0.0; 10];
+        data[7..10].fill(log_scale);
+        let transforms = Tensor::from_data(TensorData::new(data, [1, 10]), &device).require_grad();
+        let source = transforms.clone();
+        let (_, raw_opacity) = fold_min_scale(
+            transforms,
+            Tensor::zeros([1], &device),
+            Tensor::from_floats([log_scale.exp()], &device),
+        );
+
+        let opacity = sigmoid(raw_opacity.clone())
+            .into_scalar_async::<f32>()
+            .await
+            .expect("opacity readback");
+        let grads = raw_opacity.sum().backward();
+        let gradient = source
+            .grad(&grads)
+            .expect("transform gradient")
+            .into_data_async()
+            .await
+            .expect("gradient readback")
+            .try_to_vec::<f32>()
+            .expect("f32 gradient");
+
+        let expected_opacity = 0.5 * 0.5_f32.sqrt().powi(3);
+        assert!((opacity - expected_opacity).abs() < 1e-6);
+        let expected_gradient = 0.5 / (1.0 - expected_opacity);
+        for actual in &gradient[7..10] {
+            assert!(
+                actual.is_finite() && (actual - expected_gradient).abs() < 2e-4,
+                "unexpected gradient {actual}"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- compute min-scale opacity compensation in log space to avoid determinant underflow
- preserve source directories when saving eval renders, avoiding duplicate-filename collisions
- reject absolute and traversing eval image paths

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --locked -p brush-render -p brush-process --all-targets --all-features -- -D warnings`
- `cargo test --locked -p brush-render -p brush-process -- --nocapture`
- `cargo check --locked -p brush-app -p brush-js --lib --target wasm32-unknown-unknown`

## Training smoke test

7k-iteration Mip runs on `mipnerf360/stump` at 512px, with seed 42, background noise disabled, and 109 train / 16 eval images:

| Metric | `main` | This PR |
| --- | ---: | ---: |
| PSNR | 12.012516 | 12.012574 |
| SSIM | 0.036367 | 0.036401 |
| Exported splats | 1,478,010 | 1,476,490 |
| Wall time | 113.02s | 120.40s |

Both exports contained zero non-finite scale or opacity values. Refinement still uses an entropy-seeded RNG, so the 0.1% splat-count difference and single-run timing variation are expected.
