### PR TITLE
Honor the training seed across random sampling

### DIFF
--- a/crates/brush-process/src/train_stream.rs
+++ b/crates/brush-process/src/train_stream.rs
@@ -50,7 +50,7 @@ pub(crate) async fn train_stream(
     log::info!("Using seed {}", process_config.seed);
 
     device.seed(process_config.seed);
-    let mut rng = rand::rngs::StdRng::from_seed([process_config.seed as u8; 32]);
+    let mut rng = rand::rngs::StdRng::seed_from_u64(process_config.seed);
 
     log::info!("Loading dataset");
     let load_result = load_dataset(vfs.clone(), &train_stream_config.load_config)
@@ -163,7 +163,11 @@ pub(crate) async fn train_stream(
     let mut eval_scene = dataset.eval;
 
     let mut train_duration = Duration::from_secs(0);
-    let mut dataloader = SceneLoader::new(&dataset.train, 42, &train_stream_config.load_config);
+    let mut dataloader = SceneLoader::new(
+        &dataset.train,
+        process_config.seed,
+        &train_stream_config.load_config,
+    );
     let bounds = get_splat_bounds(init_splats.clone(), BOUND_PERCENTILE).await;
 
     // Per-train-view (world center, focal-px at native res) for the
@@ -175,7 +179,12 @@ pub(crate) async fn train_stream(
         view_cams.push((view.camera.position, focal));
     }
 
-    let mut trainer = SplatTrainer::new(&train_stream_config.train_config, device, bounds);
+    let mut trainer = SplatTrainer::new_seeded(
+        &train_stream_config.train_config,
+        device,
+        bounds,
+        process_config.seed,
+    );
     trainer.set_view_cams(view_cams.clone());
 
     // Get the dataset name from the base path (if available) for interpolation.
@@ -268,11 +277,20 @@ pub(crate) async fn train_stream(
             // whole dataset, which at 100% scale buys nothing.
             if lod_img_pct < 100 {
                 let lod_scene = dataset.train.clone().with_image_scale(cumulative_scale);
-                dataloader = SceneLoader::new(&lod_scene, 42, &train_stream_config.load_config);
+                dataloader = SceneLoader::new(
+                    &lod_scene,
+                    process_config.seed,
+                    &train_stream_config.load_config,
+                );
             }
 
             let bounds = get_splat_bounds(splats.clone(), BOUND_PERCENTILE).await;
-            trainer = SplatTrainer::new(&train_stream_config.train_config, device, bounds);
+            trainer = SplatTrainer::new_seeded(
+                &train_stream_config.train_config,
+                device,
+                bounds,
+                process_config.seed,
+            );
             trainer.set_view_cams(view_cams.clone());
 
             log::info!(

--- a/crates/brush-train/src/multinomial.rs
+++ b/crates/brush-train/src/multinomial.rs
@@ -85,13 +85,4 @@ mod tests {
         // Function returns empty vector when it cannot sample any valid indices
         assert_eq!(result.len(), 0);
     }
-
-    #[wasm_bindgen_test(unsupported = test)]
-    fn sampling_is_reproducible() {
-        let weights = [0.1, 0.3, 0.4, 0.2];
-        assert_eq!(
-            multinomial_sample(&mut test_rng(), &weights, 3),
-            multinomial_sample(&mut test_rng(), &weights, 3)
-        );
-    }
 }

--- a/crates/brush-train/src/multinomial.rs
+++ b/crates/brush-train/src/multinomial.rs
@@ -1,7 +1,10 @@
-pub(crate) fn multinomial_sample(weights: &[f32], n: u32) -> Vec<i32> {
-    let mut rng = rand::rng();
+pub(crate) fn multinomial_sample<R: rand::Rng + ?Sized>(
+    rng: &mut R,
+    weights: &[f32],
+    n: u32,
+) -> Vec<i32> {
     rand::seq::index::sample_weighted(
-        &mut rng,
+        rng,
         weights.len(),
         |i| {
             if weights[i].is_finite() && weights[i] >= 0.0 {
@@ -28,13 +31,18 @@ pub(crate) fn multinomial_sample(weights: &[f32], n: u32) -> Vec<i32> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rand::SeedableRng;
     use wasm_bindgen_test::wasm_bindgen_test;
+
+    fn test_rng() -> rand::rngs::StdRng {
+        rand::rngs::StdRng::seed_from_u64(42)
+    }
 
     #[wasm_bindgen_test(unsupported = test)]
     fn test_multinomial_sampling() {
         // Test the complete multinomial sampling workflow (samples indices without replacement)
         let weights = vec![0.1, 0.3, 0.4, 0.2];
-        let samples = multinomial_sample(&weights, 3);
+        let samples = multinomial_sample(&mut test_rng(), &weights, 3);
 
         assert_eq!(samples.len(), 3);
         for &sample in &samples {
@@ -48,7 +56,7 @@ mod tests {
 
         // Test edge case: sampling all indices
         let single_weight = vec![1.0];
-        let single_samples = multinomial_sample(&single_weight, 1);
+        let single_samples = multinomial_sample(&mut test_rng(), &single_weight, 1);
         assert_eq!(single_samples.len(), 1);
         assert_eq!(single_samples[0], 0);
     }
@@ -57,7 +65,7 @@ mod tests {
     fn test_nan_weight_handling() {
         // Test that NaN weights are handled (converted to 0.0)
         let weights_with_nan = vec![0.5, f32::NAN, 0.3, 0.2];
-        let samples = multinomial_sample(&weights_with_nan, 2);
+        let samples = multinomial_sample(&mut test_rng(), &weights_with_nan, 2);
 
         assert_eq!(samples.len(), 2);
         // Should never sample index 1 (NaN weight becomes 0.0)
@@ -72,9 +80,18 @@ mod tests {
     fn test_all_zero_weights() {
         // Discovered behavior: returns empty vec when all weights are zero
         let zero_weights = vec![0.0, 0.0, 0.0];
-        let result = multinomial_sample(&zero_weights, 1);
+        let result = multinomial_sample(&mut test_rng(), &zero_weights, 1);
 
         // Function returns empty vector when it cannot sample any valid indices
         assert_eq!(result.len(), 0);
+    }
+
+    #[wasm_bindgen_test(unsupported = test)]
+    fn sampling_is_reproducible() {
+        let weights = [0.1, 0.3, 0.4, 0.2];
+        assert_eq!(
+            multinomial_sample(&mut test_rng(), &weights, 3),
+            multinomial_sample(&mut test_rng(), &weights, 3)
+        );
     }
 }

--- a/crates/brush-train/src/train.rs
+++ b/crates/brush-train/src/train.rs
@@ -23,6 +23,7 @@ use burn::{
 };
 
 use hashbrown::HashSet;
+use rand::SeedableRng;
 use tracing::{Instrument, trace_span};
 
 pub const BOUND_PERCENTILE: f32 = 0.8;
@@ -81,6 +82,7 @@ pub struct SplatTrainer {
     bounds: BoundingBox,
     step_count: u32,
     max_sh_degree: u32,
+    rng: rand::rngs::StdRng,
     /// Per-train-view (world center, focal in px at native res) for the
     /// Mip-Splatting 3D filter. Empty disables it. The floor itself lives on
     /// the splats (recomputed at each refine), not here.
@@ -136,6 +138,16 @@ pub async fn get_splat_bounds(splats: Splats, percentile: f32) -> BoundingBox {
 impl SplatTrainer {
     #[allow(unused_variables)]
     pub fn new(config: &TrainConfig, device: &Device, bounds: BoundingBox) -> Self {
+        Self::new_seeded(config, device, bounds, 42)
+    }
+
+    #[allow(unused_variables)]
+    pub fn new_seeded(
+        config: &TrainConfig,
+        device: &Device,
+        bounds: BoundingBox,
+        seed: u64,
+    ) -> Self {
         let decay =
             (config.lr_mean_end / config.lr_mean).powf(1.0 / config.total_train_iters as f64);
 
@@ -159,6 +171,7 @@ impl SplatTrainer {
             bounds,
             step_count: 0,
             max_sh_degree: 0,
+            rng: rand::rngs::StdRng::seed_from_u64(seed),
             view_cams: Vec::new(),
             #[cfg(not(target_family = "wasm"))]
             lpips,
@@ -197,7 +210,11 @@ impl SplatTrainer {
         let img_size = glam::uvec2(img_w as u32, img_h as u32);
         let base = &self.config.background_color;
         let base_bg = glam::Vec3::new(base[0], base[1], base[2]);
-        let background = sample_background_color(base_bg, self.config.background_noise_strength);
+        let background = sample_background_color(
+            base_bg,
+            self.config.background_noise_strength,
+            &mut self.rng,
+        );
 
         let median_scale = self.bounds.median_size();
 
@@ -542,7 +559,8 @@ impl SplatTrainer {
                 .expect("Failed to get weights")
                 .try_into_vec::<f32>()
                 .expect("Failed to read weights");
-            let resampled_inds = multinomial_sample(&resampled_weights, pruned_count);
+            let resampled_inds =
+                multinomial_sample(&mut self.rng, &resampled_weights, pruned_count);
             split_inds.extend(resampled_inds);
         }
 
@@ -611,7 +629,7 @@ impl SplatTrainer {
                     .expect("Failed to get weights")
                     .try_into_vec::<f32>()
                     .expect("Failed to read weights");
-                let growth_inds = multinomial_sample(&weights, grow_count);
+                let growth_inds = multinomial_sample(&mut self.rng, &weights, grow_count);
                 split_inds.extend(growth_inds);
             }
         }
@@ -885,12 +903,15 @@ async fn prune_points(
 }
 
 /// Sample a background color: base + uniform noise in [-strength, +strength], clamped to [0, 1].
-fn sample_background_color(base: glam::Vec3, strength: f32) -> glam::Vec3 {
+fn sample_background_color<R: rand::Rng + ?Sized>(
+    base: glam::Vec3,
+    strength: f32,
+    rng: &mut R,
+) -> glam::Vec3 {
     if strength <= 0.0 {
         return base.clamp(glam::Vec3::ZERO, glam::Vec3::ONE);
     }
     use rand::RngExt as _;
-    let mut rng = rand::rng();
     let noise = glam::Vec3::new(
         rng.random_range(-strength..strength),
         rng.random_range(-strength..strength),


### PR DESCRIPTION
## Summary

- seed random initialization with the full configured `u64`
- pass the configured seed to scene loading instead of hardcoding 42
- use a trainer-owned seeded RNG for background noise and refinement sampling

## Testing

- `cargo fmt --all -- --check`
- `cargo test --locked -p brush-train --lib`
- `cargo test --locked -p brush-process --lib`
- `cargo clippy --locked -p brush-train -p brush-process --all-targets --all-features -- -D warnings`
- `cargo check --locked -p brush-app -p brush-js --lib --target wasm32-unknown-unknown`
